### PR TITLE
perf(dpa): add session-aware routing and post-prefill decode protection

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -339,6 +339,35 @@ _metrics_refresh_task: asyncio.Task | None = None
 _METRICS_REFRESH_INTERVAL_SECONDS = 5.0
 
 
+def _get_dp_session_affinity_ids(
+    raw_request: Request | None,
+) -> tuple[str | None, str | None]:
+    """Extract AIPerf session lineage for CoreManager's DPA router.
+
+    AIPerf keeps ``X-Correlation-ID`` stable across the turns of one session.
+    When its Dynamo-affinity header option is enabled it also sends the parent
+    session ID for forked agent trees. CoreManager retains that lineage for
+    observability but deliberately assigns each child correlation ID its own
+    strict cache owner, matching SGLang's agentic routing. Clients without a
+    session header retain normal DP load balancing.
+    """
+    if os.environ.get("ATOM_DP_SESSION_AFFINITY", "0").lower() not in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return None, None
+    if raw_request is None:
+        return None, None
+
+    session_id = raw_request.headers.get(
+        "x-dynamo-session-id"
+    ) or raw_request.headers.get("x-correlation-id")
+    parent_id = raw_request.headers.get("x-dynamo-parent-session-id")
+    return session_id, parent_id
+
+
 # ============================================================================
 # Request/Response Logging
 # ============================================================================
@@ -774,6 +803,8 @@ async def generate_async(
     request_id: str,
     kv_transfer_params: dict[str, Any] | None = None,
     data_parallel_rank: int | None = None,
+    dp_session_id: str | None = None,
+    dp_parent_session_id: str | None = None,
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Generate text asynchronously for non-streaming requests."""
     token_queue: asyncio.Queue = asyncio.Queue()
@@ -820,6 +851,8 @@ async def generate_async(
             stream_callback=completion_callback,
             kv_transfer_params=kv_transfer_params,
             data_parallel_rank=data_parallel_rank,
+            dp_session_id=dp_session_id,
+            dp_parent_session_id=dp_parent_session_id,
         )
 
     seq = await loop.run_in_executor(None, do_preprocess)
@@ -899,6 +932,8 @@ async def generate_async_multimodal(
     sampling_params: SamplingParams,
     request_id: str,
     data_parallel_rank: int | None = None,
+    dp_session_id: str | None = None,
+    dp_parent_session_id: str | None = None,
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Generate text asynchronously for one multimodal request."""
     token_queue: asyncio.Queue = asyncio.Queue()
@@ -930,6 +965,8 @@ async def generate_async_multimodal(
             stream_callback=completion_callback,
             multimodal_data=multimodal_data,
             data_parallel_rank=data_parallel_rank,
+            dp_session_id=dp_session_id,
+            dp_parent_session_id=dp_parent_session_id,
         )
 
     seq = await loop.run_in_executor(None, do_preprocess)
@@ -997,6 +1034,8 @@ async def generate_async_fanout(
     kv_transfer_params: dict[str, Any] | None = None,
     multimodal_data: dict[str, Any] | None = None,
     data_parallel_rank: int | None = None,
+    dp_session_id: str | None = None,
+    dp_parent_session_id: str | None = None,
 ) -> list[dict[str, Any]]:
     """Non-streaming n>1 path: fan out N siblings and await all of them.
 
@@ -1048,6 +1087,8 @@ async def generate_async_fanout(
             multimodal_data=multimodal_data,
             parent_request_id=request_id,
             data_parallel_rank=data_parallel_rank,
+            dp_session_id=dp_session_id,
+            dp_parent_session_id=dp_parent_session_id,
         )
 
     seqs = await loop.run_in_executor(None, do_preprocess)
@@ -1139,6 +1180,8 @@ async def setup_streaming_request(
     kv_transfer_params: dict[str, Any] | None = None,
     multimodal_data: dict[str, Any] | None = None,
     data_parallel_rank: int | None = None,
+    dp_session_id: str | None = None,
+    dp_parent_session_id: str | None = None,
 ) -> tuple[int, StreamOutputCollector, int]:
     """Set up a streaming request with the engine.
 
@@ -1172,6 +1215,8 @@ async def setup_streaming_request(
             kv_transfer_params=kv_transfer_params,
             multimodal_data=multimodal_data,
             data_parallel_rank=data_parallel_rank,
+            dp_session_id=dp_session_id,
+            dp_parent_session_id=dp_parent_session_id,
         )
         _seq_id_to_request_id[seq.id] = request_id
         return seq
@@ -1339,6 +1384,8 @@ async def setup_streaming_request_fanout(
     kv_transfer_params: dict[str, Any] | None = None,
     multimodal_data: dict[str, Any] | None = None,
     data_parallel_rank: int | None = None,
+    dp_session_id: str | None = None,
+    dp_parent_session_id: str | None = None,
 ) -> tuple[list[int], StreamOutputCollector, int]:
     """Fan-out variant of :func:`setup_streaming_request`.
 
@@ -1389,6 +1436,8 @@ async def setup_streaming_request_fanout(
             multimodal_data=multimodal_data,
             parent_request_id=request_id,
             data_parallel_rank=data_parallel_rank,
+            dp_session_id=dp_session_id,
+            dp_parent_session_id=dp_parent_session_id,
         )
         for seq in seqs:
             _seq_id_to_request_id[seq.id] = request_id
@@ -1559,7 +1608,12 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
         )
 
         request_id = f"chatcmpl-{uuid.uuid4().hex}"
-        dp_rank = request.data_parallel_rank
+        dp_session_id, dp_parent_session_id = _get_dp_session_affinity_ids(raw_request)
+        dp_routing = {
+            "data_parallel_rank": request.data_parallel_rank,
+            "dp_session_id": dp_session_id,
+            "dp_parent_session_id": dp_parent_session_id,
+        }
 
         _log_request_model("request", request_id, request)
 
@@ -1611,7 +1665,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                         request_id,
                         multimodal_data=stream_multimodal_data,
                         kv_transfer_params=request.kv_transfer_params,
-                        data_parallel_rank=dp_rank,
+                        **dp_routing,
                     )
                 )
                 gen = stream_chat_response_fanout(
@@ -1635,7 +1689,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                         request_id,
                         multimodal_data=stream_multimodal_data,
                         kv_transfer_params=request.kv_transfer_params,
-                        data_parallel_rank=dp_rank,
+                        **dp_routing,
                     )
                 )
                 gen = stream_chat_response(
@@ -1665,7 +1719,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     request_id,
                     multimodal_data=multimodal_data,
                     kv_transfer_params=request.kv_transfer_params,
-                    data_parallel_rank=dp_rank,
+                    **dp_routing,
                 ),
                 raw_request,
                 request_id,
@@ -1688,7 +1742,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     multimodal_data,
                     sampling_params,
                     request_id,
-                    data_parallel_rank=dp_rank,
+                    **dp_routing,
                 ),
                 raw_request,
                 request_id,
@@ -1712,7 +1766,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     sampling_params,
                     request_id,
                     kv_transfer_params=request.kv_transfer_params,
-                    data_parallel_rank=dp_rank,
+                    **dp_routing,
                 ),
                 raw_request,
                 request_id,
@@ -1735,7 +1789,7 @@ async def chat_completions(request: ChatCompletionRequest, raw_request: Request)
                     sampling_params,
                     request_id,
                     kv_transfer_params=request.kv_transfer_params,
-                    data_parallel_rank=dp_rank,
+                    **dp_routing,
                 ),
                 raw_request,
                 request_id,
@@ -1786,7 +1840,12 @@ async def completions(request: CompletionRequest, raw_request: Request):
         )
 
         request_id = f"cmpl-{uuid.uuid4().hex}"
-        dp_rank = request.data_parallel_rank
+        dp_session_id, dp_parent_session_id = _get_dp_session_affinity_ids(raw_request)
+        dp_routing = {
+            "data_parallel_rank": request.data_parallel_rank,
+            "dp_session_id": dp_session_id,
+            "dp_parent_session_id": dp_parent_session_id,
+        }
 
         _log_request_model("request", request_id, request)
 
@@ -1799,7 +1858,7 @@ async def completions(request: CompletionRequest, raw_request: Request):
                         sampling_params,
                         request_id,
                         kv_transfer_params=request.kv_transfer_params,
-                        data_parallel_rank=dp_rank,
+                        **dp_routing,
                     )
                 )
                 gen = stream_completion_response_fanout(
@@ -1818,7 +1877,7 @@ async def completions(request: CompletionRequest, raw_request: Request):
                         sampling_params,
                         request_id,
                         kv_transfer_params=request.kv_transfer_params,
-                        data_parallel_rank=dp_rank,
+                        **dp_routing,
                     )
                 )
                 gen = stream_completion_response(
@@ -1843,7 +1902,7 @@ async def completions(request: CompletionRequest, raw_request: Request):
                     sampling_params,
                     request_id,
                     kv_transfer_params=request.kv_transfer_params,
-                    data_parallel_rank=request.data_parallel_rank,
+                    **dp_routing,
                 ),
                 raw_request,
                 request_id,
@@ -1858,7 +1917,7 @@ async def completions(request: CompletionRequest, raw_request: Request):
                     sampling_params,
                     request_id,
                     kv_transfer_params=request.kv_transfer_params,
-                    data_parallel_rank=request.data_parallel_rank,
+                    **dp_routing,
                 ),
                 raw_request,
                 request_id,

--- a/atom/entrypoints/openai/metrics.py
+++ b/atom/entrypoints/openai/metrics.py
@@ -135,6 +135,80 @@ class _AtomMetricsCollector:
             metric.add_metric([], float(value))
             yield metric
 
+        dp_router = snapshot.get("dp_router", {})
+        for name, documentation, value in (
+            (
+                "atom:dp_affinity_new",
+                "Number of new sticky DP sessions assigned to a load-aware "
+                "cache owner.",
+                dp_router.get("affinity_new_total", 0),
+            ),
+            (
+                "atom:dp_affinity_owner_hit",
+                "Number of requests routed to an existing session cache owner.",
+                dp_router.get("affinity_owner_hit_total", 0),
+            ),
+            (
+                "atom:dp_affinity_spill",
+                "Number of existing sessions moved off their cache owner; "
+                "strict affinity keeps this zero.",
+                dp_router.get("affinity_spill_total", 0),
+            ),
+            (
+                "atom:dp_affinity_parent_ignored",
+                "Number of new child sessions independently placed instead of "
+                "inheriting a parent owner.",
+                dp_router.get("affinity_parent_ignored_total", 0),
+            ),
+            (
+                "atom:dp_route_explicit",
+                "Number of requests routed by an explicit data-parallel rank.",
+                dp_router.get("explicit_total", 0),
+            ),
+            (
+                "atom:dp_route_load_balanced",
+                "Number of sessionless requests routed by the configured load "
+                "balancer.",
+                dp_router.get("load_balanced_total", 0),
+            ),
+        ):
+            metric = CounterMetricFamily(name, documentation)
+            metric.add_metric([], float(value))
+            yield metric
+
+        metric = CounterMetricFamily(
+            "atom:dp_requests_routed",
+            "Cumulative requests routed to each data-parallel rank.",
+            labels=["rank"],
+        )
+        for rank, value in enumerate(dp_router.get("requests_per_rank", [])):
+            metric.add_metric([str(rank)], float(value))
+        yield metric
+
+        for name, documentation, values in (
+            (
+                "atom:dp_inflight_requests",
+                "Current in-flight requests charged to each data-parallel rank.",
+                dp_router.get("inflight_requests_per_rank", []),
+            ),
+            (
+                "atom:dp_queued_prefill_tokens",
+                "Current estimated uncached prefill-token debt per "
+                "data-parallel rank; later sticky turns charge only positive "
+                "prompt growth.",
+                dp_router.get("queued_prefill_tokens_per_rank", []),
+            ),
+            (
+                "atom:dp_sessions",
+                "Sticky sessions currently owned by each data-parallel rank.",
+                dp_router.get("session_count_per_rank", []),
+            ),
+        ):
+            metric = GaugeMetricFamily(name, documentation, labels=["rank"])
+            for rank, value in enumerate(values):
+                metric.add_metric([str(rank)], float(value))
+            yield metric
+
         cache = snapshot.get("cache", {})
         cache_counters = (
             (

--- a/atom/entrypoints/openai/metrics.py
+++ b/atom/entrypoints/openai/metrics.py
@@ -139,8 +139,10 @@ class _AtomMetricsCollector:
         for name, documentation, value in (
             (
                 "atom:dp_affinity_new",
-                "Number of new sticky DP sessions assigned to a load-aware "
-                "cache owner.",
+                (
+                    "Number of new sticky DP sessions assigned to a load-aware "
+                    "cache owner."
+                ),
                 dp_router.get("affinity_new_total", 0),
             ),
             (
@@ -150,14 +152,18 @@ class _AtomMetricsCollector:
             ),
             (
                 "atom:dp_affinity_spill",
-                "Number of existing sessions moved off their cache owner; "
-                "strict affinity keeps this zero.",
+                (
+                    "Number of existing sessions moved off their cache owner; "
+                    "strict affinity keeps this zero."
+                ),
                 dp_router.get("affinity_spill_total", 0),
             ),
             (
                 "atom:dp_affinity_parent_ignored",
-                "Number of new child sessions independently placed instead of "
-                "inheriting a parent owner.",
+                (
+                    "Number of new child sessions independently placed instead of "
+                    "inheriting a parent owner."
+                ),
                 dp_router.get("affinity_parent_ignored_total", 0),
             ),
             (
@@ -167,8 +173,10 @@ class _AtomMetricsCollector:
             ),
             (
                 "atom:dp_route_load_balanced",
-                "Number of sessionless requests routed by the configured load "
-                "balancer.",
+                (
+                    "Number of sessionless requests routed by the configured load "
+                    "balancer."
+                ),
                 dp_router.get("load_balanced_total", 0),
             ),
         ):
@@ -193,9 +201,11 @@ class _AtomMetricsCollector:
             ),
             (
                 "atom:dp_queued_prefill_tokens",
-                "Current estimated uncached prefill-token debt per "
-                "data-parallel rank; later sticky turns charge only positive "
-                "prompt growth.",
+                (
+                    "Current estimated uncached prefill-token debt per "
+                    "data-parallel rank; later sticky turns charge only positive "
+                    "prompt growth."
+                ),
                 dp_router.get("queued_prefill_tokens_per_rank", []),
             ),
             (

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -373,6 +373,14 @@ class EngineCore:
             fwd_out = self.runner_mgr.call_func(
                 "forward", scheduled_batch, wait_out=True
             )
+            if (
+                self.scheduler.prefill_delayer is not None
+                and scheduled_batch.total_seqs_num_prefill > 0
+            ):
+                # Arm post-prefill decode protection only after the prefill
+                # forward really completed. A delayer FIRE merely grants
+                # admission and can still result in a decode/empty batch.
+                self.scheduler.prefill_delayer.notify_prefill_executed()
 
         # Aggregate KV transfer status from all workers (only when PD disaggregation is active)
         self._poll_kv_transfer_progress()
@@ -636,6 +644,7 @@ class DPEngineCoreProc(EngineCore):
                     kv_high_watermark=envs.ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK,
                     token_usage_low_watermark=envs.ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK,
                     max_queue_ms=envs.ATOM_PREFILL_DELAYER_MAX_QUEUE_MS,
+                    prefill_decode_interval=envs.ATOM_PREFILL_DECODE_INTERVAL,
                 )
             )
 

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import asyncio
+import hashlib
 import logging
 import multiprocessing
 import multiprocessing.shared_memory
@@ -211,10 +212,34 @@ class CoreManager:
         # Read once here: this is a construction-time config value (CoreManager
         # is built after env/args are finalized), not a runtime-tunable knob.
         self._dp_lb_req_equiv = envs.ATOM_DP_LB_REQ_EQUIV
-        # Authoritative in-flight load per rank, maintained locally: incremented
-        # on dispatch, decremented on finish/abort. Guarded by _lb_lock because
-        # dispatch runs on the request thread while release runs on the per-rank
-        # output threads.
+        self._dp_session_affinity_enabled = envs.ATOM_DP_SESSION_AFFINITY
+        # Session id -> rank whose local prefix cache owns the session. Owners
+        # are immutable for the lifetime of the process: moving one turn to a
+        # light rank discards the dominant optimization in agentic workloads,
+        # namely reuse of the accumulated conversation prefix.
+        self._dp_session_owners: dict[str, int] = {}
+        # Last prompt length observed for each sticky session.  A later turn on
+        # the same owner normally reuses the old prompt, so only its positive
+        # growth is new prefill debt.  Keeping this small scalar per session
+        # avoids charging the complete cached conversation on every turn.
+        self._dp_session_prompt_tokens: dict[str, int] = {}
+        self._dp_route_counters = {
+            "affinity_new_total": 0,
+            "affinity_owner_hit_total": 0,
+            # Kept as an explicit invariant/metric: strict affinity must leave
+            # this at zero. It makes an accidental reintroduction of spill
+            # visible in benchmark artifacts.
+            "affinity_spill_total": 0,
+            "affinity_parent_ignored_total": 0,
+            "explicit_total": 0,
+            "load_balanced_total": 0,
+        }
+        self._rank_routed_total = [0] * self.global_engine_count
+        # Authoritative local load per rank. Request count is in-flight until
+        # finish/abort; token count is queued/in-flight PREFILL work and is
+        # released as soon as the first model output proves prefill completed.
+        # Guarded by _lb_lock because dispatch runs on the request thread while
+        # completion/release runs on the per-rank output threads.
         self._rank_reqs = [0] * self.global_engine_count
         self._rank_tokens = [0] * self.global_engine_count
         # seq_id -> (dp_rank, req_cost, tok_cost) so release subtracts exactly
@@ -563,6 +588,11 @@ class CoreManager:
                         # once per step rather than twice per chunk.
                         dbg = logger.isEnabledFor(logging.DEBUG)
                         for seq_id, request_output in stream_outputs:
+                            # The first emitted model output means this
+                            # sequence's prompt prefill has completed. Keep the
+                            # request count charged for decode pressure, but
+                            # stop advertising its prompt as queued prefill.
+                            self._mark_seq_prefill_complete(seq_id)
                             callback = self._seq_id_to_callback.get(seq_id)
                             if dbg:
                                 logger.debug(
@@ -839,15 +869,17 @@ class CoreManager:
         # getattr/int pass per seq.
         hints = self._resolve_and_validate_hints(seqs)
 
-        # round_robin is load-agnostic and skips the charge/release bookkeeping;
-        # the load-aware strategies track per-rank load.
-        track_load = self._dp_lb_strategy != "round_robin"
+        # round_robin normally skips load bookkeeping. Session affinity still
+        # needs queued-prefill counters even if the fallback strategy is RR.
+        track_load = (
+            self._dp_lb_strategy != "round_robin" or self._dp_session_affinity_enabled
+        )
         engine_count = self._routable_engine_count
         dp_seqs = [[] for _ in range(engine_count)]
         reqs_snapshot = tokens_snapshot = None
         with self._lb_lock:
             for seq, hint in zip(seqs, hints):
-                dp_rank = hint if hint is not None else self._select_dp_rank_locked()
+                dp_rank = self._select_dp_rank_for_seq_locked(seq, hint)
                 if track_load:
                     self._charge_seq_load_locked(seq, dp_rank)
                 dp_seqs[dp_rank].append(seq)
@@ -897,7 +929,7 @@ class CoreManager:
         # ranks, so a single grep shows both what changed and how balanced it is.
         if reqs_snapshot is not None:
             logger.info(
-                "%s: add %s | in-flight reqs=%s prefill_tokens=%s",
+                "%s: add %s | in-flight reqs=%s queued_prefill_tokens=%s",
                 self.label,
                 ", ".join(added),
                 reqs_snapshot,
@@ -949,10 +981,151 @@ class CoreManager:
         self._rank_rotation_cursor += 1
         return best_rank
 
+    def _stable_session_rank(self, session_id: str) -> int:
+        """Map a session to a stable rank with rendezvous hashing.
+
+        Python's built-in ``hash`` is process-randomized, so it cannot define
+        cache ownership. Rendezvous hashing is deterministic and, unlike a
+        simple modulo, remaps only sessions owned by a rank that is added or
+        removed. The DP width is tiny, and this runs only once per new session.
+        """
+        session_key = str(session_id).encode("utf-8")
+        best_rank = 0
+        best_score = -1
+        for rank in range(self._routable_engine_count):
+            digest = hashlib.blake2b(
+                session_key + rank.to_bytes(4, "little"), digest_size=8
+            ).digest()
+            score = int.from_bytes(digest, "little")
+            if score > best_score:
+                best_rank = rank
+                best_score = score
+        return best_rank
+
+    def _select_new_session_rank_locked(self, session_id: str) -> int:
+        """Place a new sticky session on the lightest DP rank.
+
+        Existing sessions never call this function: locality wins once an
+        owner has cache state.  Before that first placement there is no cache
+        to preserve, so use estimated outstanding prefill debt plus the
+        configured token-equivalent decode pressure.  Rendezvous hashing is
+        only the deterministic tie-breaker; it must not override real load.
+        """
+        session_key = str(session_id).encode("utf-8")
+        best_rank = 0
+        best_load = None
+        best_hash = -1
+        for rank in range(self._routable_engine_count):
+            load = (
+                self._rank_tokens[rank] + self._dp_lb_req_equiv * self._rank_reqs[rank]
+            )
+            tie_hash = int.from_bytes(
+                hashlib.blake2b(
+                    session_key + rank.to_bytes(4, "little"), digest_size=8
+                ).digest(),
+                "little",
+            )
+            if (
+                best_load is None
+                or load < best_load
+                or (load == best_load and tie_hash > best_hash)
+            ):
+                best_rank = rank
+                best_load = load
+                best_hash = tie_hash
+        return best_rank
+
+    def _record_dp_route_locked(self, decision: str, rank: int) -> int:
+        """Account for one routing decision and return its target rank."""
+        self._dp_route_counters[decision] += 1
+        self._rank_routed_total[rank] += 1
+        return rank
+
+    def _select_dp_rank_for_seq_locked(
+        self, seq: Sequence, explicit_rank: int | None
+    ) -> int:
+        """Route one sequence using explicit hint, strict owner, then load.
+
+        This intentionally matches SGLang Model Gateway's agentic routing
+        semantics: a stable correlation/session id selects one DP rank, and
+        every later turn stays there. Load cannot move an existing session;
+        doing so turns a cheap cache hit into a potentially huge prefill.
+
+        Parent lineage does not affect placement. Each child correlation id is
+        its own sticky session, preventing sibling subagents from dogpiling the
+        root's rank. Requests without a session retain normal load balancing.
+        """
+        if explicit_rank is not None:
+            if self._dp_session_affinity_enabled:
+                # An explicit placement is authoritative and becomes the
+                # session's owner for subsequent unhinted requests.
+                session_id = getattr(seq, "dp_session_id", None)
+                if session_id:
+                    old_owner = self._dp_session_owners.get(session_id)
+                    if old_owner is not None and old_owner != explicit_rank:
+                        # The new rank cannot be assumed to own the old prefix.
+                        self._dp_session_prompt_tokens.pop(session_id, None)
+                    self._dp_session_owners[session_id] = explicit_rank
+            return self._record_dp_route_locked("explicit_total", explicit_rank)
+
+        session_id = getattr(seq, "dp_session_id", None)
+        parent_id = getattr(seq, "dp_parent_session_id", None)
+        if not self._dp_session_affinity_enabled or not session_id:
+            rank = self._select_dp_rank_locked()
+            return self._record_dp_route_locked("load_balanced_total", rank)
+
+        owner = self._dp_session_owners.get(session_id)
+        if owner is None or not 0 <= owner < self._routable_engine_count:
+            owner = self._select_new_session_rank_locked(session_id)
+            self._dp_session_owners[session_id] = owner
+            if parent_id:
+                self._dp_route_counters["affinity_parent_ignored_total"] += 1
+            logger.debug(
+                "%s: DPA load-aware affinity new session=%s parent=%s owner=rank%d "
+                "load=%d tokens=%d reqs=%d",
+                self.label,
+                session_id,
+                parent_id,
+                owner,
+                self._rank_tokens[owner]
+                + self._dp_lb_req_equiv * self._rank_reqs[owner],
+                self._rank_tokens[owner],
+                self._rank_reqs[owner],
+            )
+            return self._record_dp_route_locked("affinity_new_total", owner)
+
+        return self._record_dp_route_locked("affinity_owner_hit_total", owner)
+
+    def get_dp_router_statistics(self) -> dict:
+        """Return a consistent, non-mutating snapshot of DP routing state."""
+        with self._lb_lock:
+            sessions_per_rank = [0] * self._routable_engine_count
+            for rank in self._dp_session_owners.values():
+                if 0 <= rank < self._routable_engine_count:
+                    sessions_per_rank[rank] += 1
+            return {
+                "enabled": self._routable_engine_count > 1,
+                **self._dp_route_counters,
+                "requests_per_rank": list(self._rank_routed_total),
+                "inflight_requests_per_rank": list(self._rank_reqs),
+                "queued_prefill_tokens_per_rank": list(self._rank_tokens),
+                "session_count_per_rank": sessions_per_rank,
+            }
+
     def _charge_seq_load_locked(self, seq: Sequence, dp_rank: int) -> None:
         """Record a seq's in-flight load on dp_rank. Caller must hold _lb_lock."""
         req_cost = 1
-        tok_cost = int(getattr(seq, "num_prompt_tokens", 0) or 0)
+        prompt_tokens = int(getattr(seq, "num_prompt_tokens", 0) or 0)
+        tok_cost = prompt_tokens
+        session_id = getattr(seq, "dp_session_id", None)
+        if self._dp_session_affinity_enabled and session_id:
+            previous_prompt_tokens = self._dp_session_prompt_tokens.get(session_id)
+            if previous_prompt_tokens is not None:
+                # Agentic turns normally extend their previous prompt.  Charge
+                # only that extension; request-equivalent load still accounts
+                # for lookup/decode pressure when the delta is zero.
+                tok_cost = max(0, prompt_tokens - previous_prompt_tokens)
+            self._dp_session_prompt_tokens[session_id] = prompt_tokens
         self._rank_reqs[dp_rank] += req_cost
         self._rank_tokens[dp_rank] += tok_cost
         self._seq_load[seq.id] = (dp_rank, req_cost, tok_cost)
@@ -970,6 +1143,18 @@ class CoreManager:
             dp_rank, req_cost, tok_cost = entry
             self._rank_reqs[dp_rank] -= req_cost
             self._rank_tokens[dp_rank] -= tok_cost
+
+    def _mark_seq_prefill_complete(self, seq_id) -> None:
+        """Release only a sequence's prefill-token charge, once."""
+        with self._lb_lock:
+            entry = self._seq_load.get(seq_id)
+            if entry is None:
+                return
+            dp_rank, req_cost, tok_cost = entry
+            if tok_cost == 0:
+                return
+            self._rank_tokens[dp_rank] -= tok_cost
+            self._seq_load[seq_id] = (dp_rank, req_cost, 0)
 
     def reset_dp_router(self) -> None:
         """Reset all DP routing state (rotation cursor + in-flight load).
@@ -997,6 +1182,8 @@ class CoreManager:
             self._rank_reqs = [0] * self._routable_engine_count
             self._rank_tokens = [0] * self._routable_engine_count
             self._seq_load.clear()
+            self._dp_session_owners.clear()
+            self._dp_session_prompt_tokens.clear()
 
     def send_utility_command(self, cmd: str, dp_rank: int | None = None):
         if dp_rank is None:

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -538,6 +538,7 @@ class LLMEngine:
                 ),
             },
             "offload": offload_totals,
+            "dp_router": self.core_mgr.get_dp_router_statistics(),
         }
 
 
@@ -596,6 +597,8 @@ class InputOutputProcessor:
         multimodal_data=None,
         request_id: str | None = None,
         data_parallel_rank: int | None = None,
+        dp_session_id: str | None = None,
+        dp_parent_session_id: str | None = None,
     ):
         """responsible for:
         1) Tokenize
@@ -618,6 +621,8 @@ class InputOutputProcessor:
             multimodal_data=multimodal_data,
             parent_request_id=request_id,
             data_parallel_rank=data_parallel_rank,
+            dp_session_id=dp_session_id,
+            dp_parent_session_id=dp_parent_session_id,
         )
         return seqs[0]
 
@@ -631,6 +636,8 @@ class InputOutputProcessor:
         multimodal_data=None,
         parent_request_id: str | None = None,
         data_parallel_rank: int | None = None,
+        dp_session_id: str | None = None,
+        dp_parent_session_id: str | None = None,
     ) -> list[Sequence]:
         """Tokenize once and materialize ``sampling_params.n`` Sequences.
 
@@ -703,6 +710,8 @@ class InputOutputProcessor:
                 sibling_index=i,
                 request_id=parent_request_id if n == 1 else None,
                 data_parallel_rank=data_parallel_rank,
+                dp_session_id=dp_session_id,
+                dp_parent_session_id=dp_parent_session_id,
             )
             seq.arrive_time = time.time()
             self.requests[seq.id] = seq

--- a/atom/model_engine/prefill_delayer.py
+++ b/atom/model_engine/prefill_delayer.py
@@ -81,7 +81,6 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Optional
 
 import torch
 
@@ -92,37 +91,37 @@ _DEBUG = os.environ.get("ATOM_PREFILL_DELAYER_DEBUG", "0") == "1"
 
 class PrefillDelayer:
     __slots__ = (
-        "dp_size",
-        "cpu_group",
-        "max_num_batched_tokens",
-        "target_fill",
-        "ttft_max_ticks",
-        "partial_max_ticks",
-        "stall_ticks",
-        "kv_high_watermark",
-        "token_usage_low_watermark",
-        "max_queue_ms",
-        "prefill_decode_interval",
+        "_decode_interval_remaining",
+        "_first",
+        "_hold_ticks",
+        "_prefill_executed_since_last_decision",
+        "_prev_pending",
         # buffer / episode state
         "_reduce_buf",
-        "_hold_ticks",
         "_stall_count",
-        "_prev_pending",
-        "_first",
-        "_decode_interval_remaining",
-        "_prefill_executed_since_last_decision",
         # stats
         "_stat_fire_fill",
+        "_stat_fire_kv",
+        "_stat_fire_nodecode",
+        "_stat_fire_partial",
+        "_stat_fire_queue_ms",
         "_stat_fire_stall",
         "_stat_fire_ttft",
-        "_stat_fire_kv",
-        "_stat_fire_partial",
-        "_stat_fire_nodecode",
-        "_stat_fire_queue_ms",
         "_stat_fire_vacuous",
         "_stat_hold",
         "_stat_hold_decode_interval",
         "_stat_log_every",
+        "cpu_group",
+        "dp_size",
+        "kv_high_watermark",
+        "max_num_batched_tokens",
+        "max_queue_ms",
+        "partial_max_ticks",
+        "prefill_decode_interval",
+        "stall_ticks",
+        "target_fill",
+        "token_usage_low_watermark",
+        "ttft_max_ticks",
     )
 
     def __init__(
@@ -135,8 +134,8 @@ class PrefillDelayer:
         partial_max_ticks: int = 100,
         stall_ticks: int = 10,
         kv_high_watermark: float = 0.9,
-        token_usage_low_watermark: Optional[float] = None,
-        max_queue_ms: Optional[float] = None,
+        token_usage_low_watermark: float | None = None,
+        max_queue_ms: float | None = None,
         prefill_decode_interval: int = 0,
     ):
         self.dp_size = dp_size

--- a/atom/model_engine/prefill_delayer.py
+++ b/atom/model_engine/prefill_delayer.py
@@ -9,10 +9,11 @@ prompt, or the small tail chunk of a chunked prefill). Every prefill forward
 has ~fixed cost (kernel launch, pad-to-shape, the lockstep MoE all-to-all), so a
 forward carrying 500 of a 16384-token budget wastes ~97% of that forward.
 
-The delayer's single job: **hold back prefill admission until the accumulated
-prefill is worth a forward, then release** — Nagle's algorithm for prefill.
-While it holds, decode keeps running (nothing is wasted); TTFT is bounded so a
-held request never starves.
+The delayer has two related jobs: **hold back prefill admission until the
+accumulated prefill is worth a forward, then release** — Nagle's algorithm for
+prefill — and optionally protect a fixed number of decode passes after every
+prefill. While it holds, decode keeps running; TTFT is bounded so a held request
+never starves.
 
 Single-rank / TP-only mode
 --------------------------
@@ -38,7 +39,10 @@ every rank computes the SAME FIRE/HOLD from the reduced values:
   G_running_dec   = total decode seqs across ranks
   any_kv_high/low = any prefillable rank at/above / below a KV watermark
   any_partial     = any rank mid-chunked-prefill
+  any_prefill_ran = any rank completed a prefill forward on the previous tick
 
+  if any_prefill_ran:                              arm decode interval
+  if post-prefill decode interval is active and decode exists: HOLD
   if n_prefillable == 0:                          FIRE   # nothing to do (vacuous)
   # -- must-fire bounds (release even if unaligned / underfilled) --
   if G_running_dec == 0:                          FIRE   # no decode to hide the wait behind
@@ -65,7 +69,7 @@ fires smaller — that is a request-routing problem, out of scope here.
 
 Cross-DP comms
 --------------
-Single ``all_reduce(SUM)`` over a 6-int64 cpu buffer (gloo-safe). Booleans are
+Single ``all_reduce(SUM)`` over an 8-int64 cpu buffer (gloo-safe). Booleans are
 encoded as 0/1 and read back as ``sum > 0`` (logical OR). All timing is
 tick-based (``hold_ticks``), which is deterministic across ranks — no per-rank
 wall-clock, so ranks never diverge on a timeout boundary. Fail-open on a
@@ -98,12 +102,15 @@ class PrefillDelayer:
         "kv_high_watermark",
         "token_usage_low_watermark",
         "max_queue_ms",
+        "prefill_decode_interval",
         # buffer / episode state
         "_reduce_buf",
         "_hold_ticks",
         "_stall_count",
         "_prev_pending",
         "_first",
+        "_decode_interval_remaining",
+        "_prefill_executed_since_last_decision",
         # stats
         "_stat_fire_fill",
         "_stat_fire_stall",
@@ -114,6 +121,7 @@ class PrefillDelayer:
         "_stat_fire_queue_ms",
         "_stat_fire_vacuous",
         "_stat_hold",
+        "_stat_hold_decode_interval",
         "_stat_log_every",
     )
 
@@ -122,13 +130,14 @@ class PrefillDelayer:
         dp_size: int,
         cpu_group,
         max_num_batched_tokens: int,
-        target_fill: float = 0.7,
-        ttft_max_ticks: int = 30,
-        partial_max_ticks: int = 8,
-        stall_ticks: int = 3,
+        target_fill: float = 0.9,
+        ttft_max_ticks: int = 200,
+        partial_max_ticks: int = 100,
+        stall_ticks: int = 10,
         kv_high_watermark: float = 0.9,
         token_usage_low_watermark: Optional[float] = None,
         max_queue_ms: Optional[float] = None,
+        prefill_decode_interval: int = 0,
     ):
         self.dp_size = dp_size
         self.cpu_group = cpu_group
@@ -170,8 +179,14 @@ class PrefillDelayer:
         # same tick. (Contrast the removed per-rank hold-clock E1, which compared
         # each rank's own clock to a threshold for a GLOBAL decision → skew.)
         self.max_queue_ms = max_queue_ms
+        if prefill_decode_interval < 0:
+            raise ValueError(
+                "prefill_decode_interval must be non-negative; "
+                f"got {prefill_decode_interval}"
+            )
+        self.prefill_decode_interval = prefill_decode_interval
 
-        # 7-slot SUM-reduce buffer (gloo-safe). Encoding:
+        # 8-slot SUM-reduce buffer (gloo-safe). Encoding:
         #   slot 0 = prefillable        (SUM → n_prefillable)
         #   slot 1 = pending_tokens     (SUM → G_pending; fresh + partial remain)
         #   slot 2 = running_decode     (SUM → G_running_dec)
@@ -180,7 +195,9 @@ class PrefillDelayer:
         #   slot 5 = has_partial flag   (SUM>0 → any rank mid-chunked-prefill)
         #   slot 6 = queue_hot flag     (SUM>0 → any rank's oldest waiting prefill
         #                                aged past max_queue_ms; TTFT SLA guard)
-        self._reduce_buf = torch.zeros(7, dtype=torch.int64, device="cpu")
+        #   slot 7 = prefill_ran flag   (SUM>0 → a rank completed a prefill
+        #                                forward on the previous scheduler tick)
+        self._reduce_buf = torch.zeros(8, dtype=torch.int64, device="cpu")
 
         # Episode state. All ticks decide FIRE/HOLD in lockstep, so these evolve
         # identically on every rank (deterministic).
@@ -190,6 +207,8 @@ class PrefillDelayer:
         # First call fires immediately to seed the initial decode batch build-up
         # (mirrors SGL PR #19836's skip_first).
         self._first = True
+        self._decode_interval_remaining = 0
+        self._prefill_executed_since_last_decision = False
 
         # Per-exit fire counters + hold counter for periodic logging. Each exit
         # is counted separately so the log shows WHICH reason released prefill —
@@ -204,6 +223,7 @@ class PrefillDelayer:
         self._stat_fire_queue_ms = 0
         self._stat_fire_vacuous = 0
         self._stat_hold = 0
+        self._stat_hold_decode_interval = 0
         self._stat_log_every = int(
             os.environ.get("ATOM_PREFILL_DELAYER_LOG_EVERY", "1000")
         )
@@ -217,7 +237,8 @@ class PrefillDelayer:
             f"stall_ticks={self.stall_ticks} "
             f"kv_high_watermark={kv_high_watermark} "
             f"token_usage_low_watermark={token_usage_low_watermark} "
-            f"max_queue_ms={max_queue_ms}"
+            f"max_queue_ms={max_queue_ms} "
+            f"prefill_decode_interval={prefill_decode_interval}"
         )
 
     @staticmethod
@@ -265,13 +286,6 @@ class PrefillDelayer:
                 rank flags the TTFT SLA guard and all ranks release. 0 / no
                 waiting prefill / max_queue_ms=None → guard inactive.
         """
-        # First call fires unconditionally (one-time warmup seed); not counted in
-        # the per-exit stats so `fire_vacuous` stays exactly "n_prefillable == 0".
-        if self._first:
-            self._first = False
-            self._reset()
-            return True
-
         # KV + queue-age bounds are gated on this rank actually having prefill to
         # push (firing when this rank can't admit anything would be a no-op).
         low = self.token_usage_low_watermark
@@ -290,6 +304,7 @@ class PrefillDelayer:
         self._reduce_buf[4] = 1 if kv_low else 0
         self._reduce_buf[5] = 1 if has_partial else 0
         self._reduce_buf[6] = 1 if queue_hot else 0
+        self._reduce_buf[7] = 1 if self._prefill_executed_since_last_decision else 0
         if self.cpu_group is not None:
             try:
                 torch.distributed.all_reduce(
@@ -305,8 +320,8 @@ class PrefillDelayer:
                 self._reset()
                 return True
 
-        # One host<-device readback for all 7 slots (a single .tolist() beats
-        # seven .item() boundary crossings on this per-tick hot path).
+        # One host<-device readback for all 8 slots (a single .tolist() beats
+        # eight .item() boundary crossings on this per-tick hot path).
         (
             n_prefillable,
             g_pending,
@@ -315,11 +330,41 @@ class PrefillDelayer:
             kv_low_n,
             partial_n,
             queue_hot_n,
+            prefill_ran_n,
         ) = self._reduce_buf.tolist()
+        # This local execution report has now participated in the global
+        # decision. A later successful prefill forward sets it again.
+        self._prefill_executed_since_last_decision = False
         any_kv_high = kv_high_n > 0
         any_kv_low = kv_low_n > 0
         any_partial = partial_n > 0
         any_queue_hot = queue_hot_n > 0
+
+        # A prefill that actually ran on the previous tick arms the same
+        # countdown on every rank. Delayer FIRE is only permission to try:
+        # allocation, remote-KV handling, or queue changes may still produce a
+        # decode/empty batch, which must not start a decode-protection window.
+        if prefill_ran_n > 0:
+            self._decode_interval_remaining = self.prefill_decode_interval
+
+        # First call fires unconditionally (one-time warmup seed).
+        if self._first:
+            self._first = False
+            self._reset()
+            return True
+
+        # Hard post-prefill decode protection. The countdown is identical on
+        # all ranks because it is armed from the globally reduced prefillable
+        # count and schedule() calls this method in lockstep. Do not advance the
+        # coalescer's own hold/TTFT episode: SGLang applies the interval before
+        # invoking PrefillDelayer, so its delay budget starts afterwards.
+        if self._decode_interval_remaining > 0:
+            self._decode_interval_remaining -= 1
+            if n_prefillable > 0 and g_running_dec > 0:
+                self._stat_hold += 1
+                self._stat_hold_decode_interval += 1
+                self._maybe_log()
+                return False
 
         # Nothing to prefill anywhere → allow (vacuous), reset the episode.
         if n_prefillable == 0:
@@ -380,6 +425,15 @@ class PrefillDelayer:
         self._maybe_log()
         return True
 
+    def notify_prefill_executed(self) -> None:
+        """Report a completed local prefill forward.
+
+        The next lockstep decision folds this flag into the existing SUM
+        reduction, so every DP rank arms the interval together without adding
+        a second collective to the scheduler hot path.
+        """
+        self._prefill_executed_since_last_decision = True
+
     def _hold(self, g_pending: int) -> bool:
         self._hold_ticks += 1
         self._stat_hold += 1
@@ -426,6 +480,7 @@ class PrefillDelayer:
                 f"fire_nodecode={self._stat_fire_nodecode} "
                 f"fire_queue_ms={self._stat_fire_queue_ms} "
                 f"fire_vacuous={self._stat_fire_vacuous} "
+                f"hold_decode_interval={self._stat_hold_decode_interval} "
                 f"hold={self._stat_hold} "
                 f"(hold_rate={self._stat_hold / total:.2%})"
             )

--- a/atom/model_engine/sequence.py
+++ b/atom/model_engine/sequence.py
@@ -89,6 +89,8 @@ class Sequence:
         mrope_positions: np.ndarray | None = None,
         mrope_position_delta: int = 0,
         data_parallel_rank: int | None = None,
+        dp_session_id: str | None = None,
+        dp_parent_session_id: str | None = None,
     ):
         # Built here rather than as a default argument: one instance shared by
         # every defaulting Sequence would be a mutable default in all but name.
@@ -245,6 +247,11 @@ class Sequence:
         # Explicitly requested DP rank, e.g. for cache aware DP routing.
         # Consumed by CoreManager._dispatch_to_dp_ranks as a routing hint.
         self.data_parallel_rank = data_parallel_rank
+        # Optional client session lineage used by CoreManager's cache-aware,
+        # token-load-aware DPA router.  These are routing metadata only; they
+        # are deliberately kept out of the model-facing request payload.
+        self.dp_session_id = dp_session_id
+        self.dp_parent_session_id = dp_parent_session_id
 
     def __len__(self):
         return self._num_tokens

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -39,6 +39,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # pressure) and a smaller value toward prompt-token balance (prefill
     # pressure). See engine_core_mgr.CoreManager._select_dp_rank_locked.
     "ATOM_DP_LB_REQ_EQUIV": lambda: int(os.getenv("ATOM_DP_LB_REQ_EQUIV", "512")),
+    # Place a new agent session on the lightest DP rank, then keep every later
+    # request on that immutable cache owner. Existing sessions never spill;
+    # child correlation ids are independently load-placed rather than
+    # inheriting their parent's owner.
+    "ATOM_DP_SESSION_AFFINITY": lambda: os.getenv(
+        "ATOM_DP_SESSION_AFFINITY", "0"
+    ).lower()
+    in {"1", "true", "yes", "on"},
     # Prefix for process titles set via set_process_title (shown in ps/top/rocm-smi)
     "ATOM_PROCESS_NAME_PREFIX": lambda: os.getenv("ATOM_PROCESS_NAME_PREFIX", "ATOM"),
     # SGLang's GLM-5.2 and DeepSeek V4 prefill CP paths still force

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -491,6 +491,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
         if os.getenv("ATOM_PREFILL_DELAYER_MAX_QUEUE_MS", "") == ""
         else float(os.getenv("ATOM_PREFILL_DELAYER_MAX_QUEUE_MS"))
     ),
+    # After a prefill forward, protect this many scheduler passes for decode
+    # before allowing another prefill. Mirrors SGLang's
+    # --prefill-decode-interval; 0 disables the hard interval.
+    "ATOM_PREFILL_DECODE_INTERVAL": lambda: int(
+        os.getenv("ATOM_PREFILL_DECODE_INTERVAL", "0")
+    ),
     # --- TBO prefill ubatch splitting ---
     # Split prefill ubatches at the exact token midpoint (vLLM-DBO style),
     # cutting through a request if needed for perfectly balanced 50/50 ubatches.

--- a/docs/distributed_guide.md
+++ b/docs/distributed_guide.md
@@ -221,6 +221,17 @@ decode-slot pressure. It helps most with heterogeneous prompt lengths under
 moderate load; with uniform-length requests it degenerates to `least_requests`.
 All strategies break ties with a round-robin cursor.
 
+When `ATOM_DP_SESSION_AFFINITY=1`, session routing adds a cache-locality layer
+above the configured fallback strategy. A new correlation/session ID is placed
+on the rank minimizing
+`estimated_uncached_prefill_tokens + ATOM_DP_LB_REQ_EQUIV * in_flight_requests`;
+rendezvous hashing only breaks exact ties. That owner is then immutable for the
+life of the process, so a busy owner never causes a later turn to lose its
+prefix-cache locality. Child correlation IDs are independent sessions and do
+not inherit the parent's rank. For an established session, load accounting
+charges only positive prompt-length growth rather than repeatedly charging the
+complete cached conversation.
+
 Bookkeeping is maintained entirely inside `CoreManager` (no engine-core protocol
 change): for the load-aware strategies, load is charged on dispatch and released
 when a sequence finishes (STREAM `finished` / offline `ADD` output) or is aborted
@@ -242,6 +253,8 @@ invoked while requests are still charged.
 - `Config.dp_load_balance` (str, default `"least_requests"`): DP routing strategy.
 - CLI: `--data-parallel-size N` or `-dp N`; `--dp-load-balance {round_robin,least_requests,least_tokens}`
 - Env: `ATOM_DP_LB_REQ_EQUIV` (int, default `512`): token-equivalent cost of one in-flight request for `least_tokens`.
+- Env: `ATOM_DP_SESSION_AFFINITY` (bool, default `0`): load-place each new
+  session once, then keep all later turns on its cache owner without spill.
 
 ## Expert Parallelism (EP)
 
@@ -344,6 +357,7 @@ The block configuration adapts to the batch type: prefill uses `block_num=128, w
 | `ATOM_DP_MASTER_IP` | str | `127.0.0.1` | IP address for DP Gloo rendezvous |
 | `ATOM_DP_MASTER_PORT` | int | `29500` | Port for DP Gloo rendezvous |
 | `ATOM_DP_LB_REQ_EQUIV` | int | `512` | Token-equivalent cost of one in-flight request for the `least_tokens` DP load-balance strategy |
+| `ATOM_DP_SESSION_AFFINITY` | bool | `0` | Load-place a new session, then keep later turns on its immutable prefix-cache owner |
 | ~~`ATOM_ENFORCE_EAGER`~~ | | | Removed. Use CLI flag `--enforce-eager` instead. |
 | `ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION` | bool | `False` | Fuse QK-norm + RoPE + cache quant for Qwen3 dense and MoE models |
 

--- a/docs/distributed_guide.md
+++ b/docs/distributed_guide.md
@@ -232,6 +232,12 @@ not inherit the parent's rank. For an established session, load accounting
 charges only positive prompt-length growth rather than repeatedly charging the
 complete cached conversation.
 
+The OpenAI server reads the session ID from `X-Dynamo-Session-ID`, falling back
+to `X-Correlation-ID`; `X-Dynamo-Parent-Session-ID` is retained for routing
+observability. For AIPerf agentic workloads, the normal correlation header is
+therefore sufficient. `AIPERF_HTTP_X_DYNAMO_SESSION_ID_FROM_CORRELATION_ID=1`
+can also be used when parent-session telemetry is desired.
+
 Bookkeeping is maintained entirely inside `CoreManager` (no engine-core protocol
 change): for the load-aware strategies, load is charged on dispatch and released
 when a sequence finishes (STREAM `finished` / offline `ADD` output) or is aborted
@@ -239,11 +245,12 @@ when a sequence finishes (STREAM `finished` / offline `ADD` output) or is aborte
 release on the per-rank output threads. Explicit `data_parallel_rank` hints are
 validated up front (a bad hint rejects the whole batch before any charge, so no
 partial load leaks) and, when valid, take priority but are still charged so they
-participate in balancing. `round_robin` skips this bookkeeping entirely. An
-invalid `dp_load_balance` value fails fast at `CoreManager` construction rather
-than silently defaulting. `reset_dp_router()` (called at the start of an offline
-`generate()` batch) assumes the previous batch has drained and warns if it is
-invoked while requests are still charged.
+participate in balancing. `round_robin` skips this bookkeeping unless session
+affinity is enabled, because new-session placement still needs the token-load
+counters. An invalid `dp_load_balance` value fails fast at `CoreManager`
+construction rather than silently defaulting. `reset_dp_router()` (called at
+the start of an offline `generate()` batch) assumes the previous batch has
+drained and warns if it is invoked while requests are still charged.
 
 ### Configuration
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -11,6 +11,8 @@ This document describes the environment variables used in the ATOM project.
 | **ATOM_DP_SIZE** | int | 1 | Total number of data parallel ranks. |
 | **ATOM_DP_MASTER_IP** | str | 127.0.0.1 | Master IP address for DP ranks coordination. |
 | **ATOM_DP_MASTER_PORT** | int | 29500 | Master port for DP ranks coordination. |
+| **ATOM_DP_LB_REQ_EQUIV** | int | 512 | Token-equivalent decode pressure assigned to each in-flight request by `least_tokens` routing. |
+| **ATOM_DP_SESSION_AFFINITY** | bool | false | Load-place each new session, then keep later turns on the same prefix-cache owner. Reads `X-Dynamo-Session-ID`, falling back to `X-Correlation-ID`. |
 
 ## Prefill delayer (DP attention)
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -29,13 +29,14 @@ no wall-clock skew). See `atom/model_engine/prefill_delayer.py`. Active only whe
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
 | **ATOM_ENABLE_PREFILL_DELAYER** | bool | true | Master switch for the prefill coalescer. |
-| **ATOM_PREFILL_DELAYER_TARGET_FILL** | float | 0.7 | Release once accumulated pending tokens reach `target_fill × max_num_batched_tokens` (averaged across prefillable ranks). In (0, 1]; higher = fewer, larger prefills at some TTFT cost. Clamped to (0, 1]. |
-| **ATOM_PREFILL_DELAYER_TTFT_MAX_TICKS** | int | 30 | Max consecutive scheduler ticks a held prefill waits before force-release. Values `< 1` clamped to 1. |
-| **ATOM_PREFILL_DELAYER_PARTIAL_MAX_TICKS** | int | 8 | Tighter bound for a held mid-chunked-prefill (it holds allocated KV). Values `< 1` clamped to 1. |
-| **ATOM_PREFILL_DELAYER_STALL_TICKS** | int | 3 | After this many consecutive non-growing ticks, release (burst ended, more won't come). Values `< 1` clamped to 1. |
+| **ATOM_PREFILL_DELAYER_TARGET_FILL** | float | 0.9 | Release once accumulated pending tokens reach `target_fill × max_num_batched_tokens` (averaged across prefillable ranks). In (0, 1]; higher = fewer, larger prefills at some TTFT cost. Clamped to (0, 1]. |
+| **ATOM_PREFILL_DELAYER_TTFT_MAX_TICKS** | int | 200 | Max consecutive scheduler ticks a held prefill waits before force-release. Values `< 1` clamped to 1. |
+| **ATOM_PREFILL_DELAYER_PARTIAL_MAX_TICKS** | int | 100 | Tighter bound for a held mid-chunked-prefill (it holds allocated KV). Values `< 1` clamped to 1. |
+| **ATOM_PREFILL_DELAYER_STALL_TICKS** | int | 10 | After this many consecutive non-growing ticks, release (burst ended, more won't come). Values `< 1` clamped to 1. |
 | **ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK** | float | 0.9 | At/above this KV usage a prefillable rank force-releases (can't accumulate a bigger batch anyway). |
 | **ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK** | float\|"" | "" (None) | If set, a prefillable rank below this KV usage force-releases (GPU starving). |
 | **ATOM_PREFILL_DELAYER_MAX_QUEUE_MS** | float\|"" | "" (None) | TTFT SLA guard: if any rank's oldest schedulable waiting prefill has queued (since arrival) ≥ this many ms, force-release regardless of the fill target. Measures true end-to-end wait (backlog + coalescer holds), unlike the tick-based TTFT bound which only caps one hold episode. Empty = disabled; set to your TTFT budget (a small value under heavy backlog fires every tick and defeats coalescing). |
+| **ATOM_PREFILL_DECODE_INTERVAL** | int | 0 | After an executed prefill forward, protect this many scheduler passes for decode before admitting another prefill. `0` disables the interval. |
 | **ATOM_PREFILL_DELAYER_DEBUG** | bool | false | Per-tick FIRE/HOLD debug logging. |
 | **ATOM_PREFILL_DELAYER_LOG_EVERY** | int | 1000 | Emit aggregate stats (per-exit fire counts + hold rate) every N decisions (0 disables). |
 

--- a/tests/entrypoints/test_api_server_helpers.py
+++ b/tests/entrypoints/test_api_server_helpers.py
@@ -182,6 +182,40 @@ class TestBuildSamplingParams:
             )
 
 
+class TestDPSessionAffinityHeaders:
+    def test_disabled_drops_session_metadata(self, monkeypatch):
+        monkeypatch.setenv("ATOM_DP_SESSION_AFFINITY", "0")
+        request = SimpleNamespace(
+            headers={
+                "x-dynamo-session-id": "child",
+                "x-dynamo-parent-session-id": "parent",
+            }
+        )
+        assert api_server._get_dp_session_affinity_ids(request) == (None, None)
+
+    def test_extracts_dynamo_session_lineage(self, monkeypatch):
+        monkeypatch.setenv("ATOM_DP_SESSION_AFFINITY", "1")
+        request = SimpleNamespace(
+            headers={
+                "x-dynamo-session-id": "child",
+                "x-dynamo-parent-session-id": "parent",
+                "x-correlation-id": "fallback",
+            }
+        )
+        assert api_server._get_dp_session_affinity_ids(request) == (
+            "child",
+            "parent",
+        )
+
+    def test_correlation_id_is_session_fallback(self, monkeypatch):
+        monkeypatch.setenv("ATOM_DP_SESSION_AFFINITY", "true")
+        request = SimpleNamespace(headers={"x-correlation-id": "session"})
+        assert api_server._get_dp_session_affinity_ids(request) == (
+            "session",
+            None,
+        )
+
+
 class TestAnthropicSamplingParams:
     def test_request_overrides_model_then_neutral_defaults(self, monkeypatch):
         captured = {}

--- a/tests/test_dp_load_balance.py
+++ b/tests/test_dp_load_balance.py
@@ -25,20 +25,46 @@ from atom.model_engine.engine_core_mgr import (
 class _FakeSeq:
     """Minimal stand-in for Sequence: routing only reads id/num_prompt_tokens."""
 
-    def __init__(self, seq_id, num_prompt_tokens=1, data_parallel_rank=None):
+    def __init__(
+        self,
+        seq_id,
+        num_prompt_tokens=1,
+        data_parallel_rank=None,
+        dp_session_id=None,
+        dp_parent_session_id=None,
+    ):
         self.id = seq_id
         self.num_prompt_tokens = num_prompt_tokens
+        self.dp_session_id = dp_session_id
+        self.dp_parent_session_id = dp_parent_session_id
         if data_parallel_rank is not None:
             self.data_parallel_rank = data_parallel_rank
 
 
-def _make_mgr(n_ranks, strategy="least_tokens", req_equiv=512):
+def _make_mgr(
+    n_ranks,
+    strategy="least_tokens",
+    req_equiv=512,
+    session_affinity=False,
+):
     """Build a bare CoreManager with just the routing state initialized."""
     mgr = CoreManager.__new__(CoreManager)
     mgr.label = "Engine Core Mgr"
     mgr.local_engine_count = n_ranks
     mgr._dp_lb_strategy = strategy
     mgr._dp_lb_req_equiv = req_equiv
+    mgr._dp_session_affinity_enabled = session_affinity
+    mgr._dp_session_owners = {}
+    mgr._dp_session_prompt_tokens = {}
+    mgr._dp_route_counters = {
+        "affinity_new_total": 0,
+        "affinity_owner_hit_total": 0,
+        "affinity_spill_total": 0,
+        "affinity_parent_ignored_total": 0,
+        "explicit_total": 0,
+        "load_balanced_total": 0,
+    }
+    mgr._rank_routed_total = [0] * n_ranks
     mgr._rank_rotation_cursor = 0
     mgr._rank_reqs = [0] * n_ranks
     mgr._rank_tokens = [0] * n_ranks
@@ -53,7 +79,8 @@ def _route(mgr, seqs):
     with mgr._lb_lock:
         for seq in seqs:
             hint = getattr(seq, "data_parallel_rank", None)
-            rank = int(hint) if hint is not None else mgr._select_dp_rank_locked()
+            hint = int(hint) if hint is not None else None
+            rank = mgr._select_dp_rank_for_seq_locked(seq, hint)
             mgr._charge_seq_load_locked(seq, rank)
             assigned.append(rank)
     return assigned
@@ -126,6 +153,152 @@ def test_least_tokens_combined_signal_counts_requests():
     assert sorted(ranks) == [0, 0, 0, 1, 1, 1]
 
 
+def test_affinity_new_session_uses_token_load_before_stable_tiebreak():
+    mgr = _make_mgr(3, session_affinity=True)
+    expected = mgr._stable_session_rank("session-root")
+    mgr._rank_tokens[expected] = 500_000
+    rank = _route(
+        mgr,
+        [_FakeSeq("root", 1000, dp_session_id="session-root")],
+    )[0]
+    assert rank != expected
+    assert mgr._rank_tokens[rank] == 1000
+    assert mgr._dp_session_owners["session-root"] == rank
+
+
+def test_affinity_hash_is_deterministic_across_managers():
+    first = _make_mgr(8, session_affinity=True)
+    second = _make_mgr(8, session_affinity=True)
+    assert first._stable_session_rank("stable-correlation-id") == (
+        second._stable_session_rank("stable-correlation-id")
+    )
+    assert first._select_new_session_rank_locked("stable-correlation-id") == (
+        second._select_new_session_rank_locked("stable-correlation-id")
+    )
+
+
+def test_affinity_existing_session_always_uses_cache_owner():
+    mgr = _make_mgr(2, session_affinity=True)
+    mgr._dp_session_owners["s"] = 0
+    # Even extreme transient backlog cannot move an existing session. Replaying
+    # a long agent prefix is more expensive than waiting for its cache owner.
+    mgr._rank_tokens = [10_000_000, 0]
+    rank = _route(mgr, [_FakeSeq("turn", 1000, dp_session_id="s")])[0]
+    assert rank == 0
+    assert mgr._dp_route_counters["affinity_spill_total"] == 0
+
+
+def test_affinity_later_turn_charges_only_prompt_growth():
+    mgr = _make_mgr(2, session_affinity=True, req_equiv=512)
+    first = _FakeSeq("first", 100_000, dp_session_id="s")
+    second = _FakeSeq("second", 101_500, dp_session_id="s")
+
+    owner = _route(mgr, [first])[0]
+    mgr._mark_seq_prefill_complete(first.id)
+    assert mgr._rank_tokens[owner] == 0
+
+    assert _route(mgr, [second]) == [owner]
+    assert mgr._rank_tokens[owner] == 1_500
+    assert mgr._seq_load[second.id][2] == 1_500
+
+
+def test_affinity_new_session_accounts_for_decode_pressure():
+    mgr = _make_mgr(2, session_affinity=True, req_equiv=512)
+    mgr._rank_reqs = [4, 0]
+    mgr._rank_tokens = [0, 1_000]
+
+    rank = _route(mgr, [_FakeSeq("new", 100, dp_session_id="new-session")])[0]
+    # score(rank0)=2048, score(rank1)=1000 before the new request is charged.
+    assert rank == 1
+
+
+def test_affinity_child_is_independent_of_parent_cache_owner():
+    mgr = _make_mgr(4, session_affinity=True)
+    parent_owner = 0
+    mgr._dp_session_owners["parent"] = parent_owner
+    mgr._rank_tokens[parent_owner] = 100_000
+    rank = _route(
+        mgr,
+        [
+            _FakeSeq(
+                "child-seq",
+                100,
+                dp_session_id="child",
+                dp_parent_session_id="parent",
+            )
+        ],
+    )[0]
+    assert rank != parent_owner
+    assert mgr._dp_session_owners["child"] == rank
+    assert mgr._dp_session_owners["parent"] == parent_owner
+    assert mgr._dp_route_counters["affinity_parent_ignored_total"] == 1
+
+
+def test_affinity_child_does_not_reserve_parent_owner():
+    mgr = _make_mgr(3, session_affinity=True)
+    child_rank = _route(
+        mgr,
+        [
+            _FakeSeq(
+                "child-seq",
+                100,
+                dp_session_id="child",
+                dp_parent_session_id="parent",
+            )
+        ],
+    )[0]
+    parent_rank = _route(
+        mgr,
+        [_FakeSeq("parent-seq", 100, dp_session_id="parent")],
+    )[0]
+    # The child's first-turn charge participates in the parent's independent
+    # placement instead of reserving or forcing the parent owner.
+    assert parent_rank != child_rank
+    assert mgr._dp_session_owners["parent"] == parent_rank
+
+
+def test_explicit_rank_is_authoritative_and_becomes_session_owner():
+    mgr = _make_mgr(4, session_affinity=True)
+    mgr._rank_tokens = [0, 0, 0, 100_000]
+    rank = _route(
+        mgr,
+        [
+            _FakeSeq(
+                "explicit",
+                100,
+                data_parallel_rank=3,
+                dp_session_id="s",
+            )
+        ],
+    )[0]
+    assert rank == 3
+    assert mgr._dp_session_owners["s"] == 3
+
+
+def test_dp_router_statistics_exposes_locality_and_rank_load():
+    mgr = _make_mgr(4, session_affinity=True)
+    session = "observed-session"
+    ranks = _route(
+        mgr,
+        [
+            _FakeSeq("first", 100, dp_session_id=session),
+            _FakeSeq("second", 200, dp_session_id=session),
+        ],
+    )
+    owner = ranks[0]
+
+    stats = mgr.get_dp_router_statistics()
+    assert stats["affinity_new_total"] == 1
+    assert stats["affinity_owner_hit_total"] == 1
+    assert stats["affinity_spill_total"] == 0
+    assert stats["requests_per_rank"][owner] == 2
+    assert stats["inflight_requests_per_rank"][owner] == 2
+    # First turn charges 100; the sticky second turn charges only its 100-token
+    # growth, not the full cached 200-token prompt.
+    assert stats["queued_prefill_tokens_per_rank"][owner] == 200
+    assert stats["session_count_per_rank"][owner] == 1
+
+
 def test_release_restores_counts():
     mgr = _make_mgr(3, strategy="least_tokens")
     seqs = [_FakeSeq(i, num_prompt_tokens=50) for i in range(6)]
@@ -147,6 +320,21 @@ def test_release_is_idempotent_no_leak_no_negative():
     mgr._release_seq_load("never-seen")
     assert mgr._rank_reqs == [0, 0]
     assert mgr._rank_tokens == [0, 0]
+
+
+def test_first_output_releases_prefill_tokens_but_not_request_count():
+    mgr = _make_mgr(2, strategy="least_tokens")
+    seq = _FakeSeq("a", num_prompt_tokens=20)
+    _route(mgr, [seq])
+    rank = mgr._seq_load[seq.id][0]
+
+    mgr._mark_seq_prefill_complete(seq.id)
+    mgr._mark_seq_prefill_complete(seq.id)  # idempotent across stream chunks
+    assert mgr._rank_tokens[rank] == 0
+    assert mgr._rank_reqs[rank] == 1
+
+    mgr._release_seq_load(seq.id)
+    assert mgr._rank_reqs == [0, 0]
 
 
 def test_burst_does_not_dogpile_one_rank():
@@ -216,12 +404,16 @@ def test_invalid_hint_still_supported_via_add_request_validation():
 
 def test_reset_dp_router_clears_all_state():
     mgr = _make_mgr(3, strategy="least_tokens")
+    mgr._dp_session_owners["session"] = 1
+    mgr._dp_session_prompt_tokens["session"] = 1234
     _route(mgr, [_FakeSeq(i, num_prompt_tokens=40) for i in range(5)])
     mgr.reset_dp_router()
     assert mgr._rank_rotation_cursor == 0
     assert mgr._rank_reqs == [0, 0, 0]
     assert mgr._rank_tokens == [0, 0, 0]
     assert mgr._seq_load == {}
+    assert mgr._dp_session_owners == {}
+    assert mgr._dp_session_prompt_tokens == {}
 
 
 def test_tie_break_rotates_starting_rank():

--- a/tests/test_dp_load_balance.py
+++ b/tests/test_dp_load_balance.py
@@ -212,6 +212,22 @@ def test_affinity_new_session_accounts_for_decode_pressure():
     assert rank == 1
 
 
+def test_affinity_routes_across_global_ranks_on_multinode_coordinator():
+    mgr = _make_mgr(2, session_affinity=True)
+    # A coordinator owns two local engines but routes across all four global
+    # ranks. Routing state must use the global width so a remote rank can win.
+    mgr.global_engine_count = 4
+    mgr._rank_reqs = [0, 0, 0, 0]
+    mgr._rank_tokens = [1000, 1000, 1000, 0]
+    mgr._rank_routed_total = [0, 0, 0, 0]
+
+    rank = _route(mgr, [_FakeSeq("new", 100, dp_session_id="global-session")])[0]
+
+    assert rank == 3
+    assert mgr._dp_session_owners["global-session"] == 3
+    assert len(mgr.get_dp_router_statistics()["requests_per_rank"]) == 4
+
+
 def test_affinity_child_is_independent_of_parent_cache_owner():
     mgr = _make_mgr(4, session_affinity=True)
     parent_owner = 0

--- a/tests/test_prefill_delayer.py
+++ b/tests/test_prefill_delayer.py
@@ -48,6 +48,7 @@ def make_delayer(**kw):
         "stall_ticks": 3,
         "kv_high_watermark": 0.9,
         "token_usage_low_watermark": None,
+        "prefill_decode_interval": 0,
     }
     defaults.update(kw)
     # The cross-DP all_reduce only runs when cpu_group is not None (dp=1/TP-only
@@ -284,6 +285,67 @@ class TestParamClamps:
         assert d.ttft_max_ticks == 1
         assert d.partial_max_ticks == 1
         assert d.stall_ticks == 1
+
+    def test_negative_prefill_decode_interval_rejected(self):
+        with pytest.raises(ValueError, match="must be non-negative"):
+            make_delayer(prefill_decode_interval=-1)
+
+
+class TestPrefillDecodeInterval:
+    def test_protects_exact_number_of_decode_passes(self):
+        d = make_delayer(
+            prefill_decode_interval=3,
+            ttft_max_ticks=1,
+            stall_ticks=1,
+            kv_high_watermark=0.1,
+        )
+        # FIRE only grants admission; the completed prefill forward arms it.
+        assert call(d, pending_tokens=MAX_BATCHED, kv_usage=1.0) is True
+        d.notify_prefill_executed()
+        # The hard interval takes precedence over all ordinary coalescer
+        # release conditions and does not consume the coalescer TTFT budget.
+        for _ in range(3):
+            assert call(d, pending_tokens=MAX_BATCHED, kv_usage=1.0) is False
+        assert d._hold_ticks == 0
+        assert d._stat_hold_decode_interval == 3
+        # The next pass reaches the normal decision and fires on KV pressure.
+        assert call(d, pending_tokens=MAX_BATCHED, kv_usage=1.0) is True
+
+    def test_countdown_advances_when_no_prefill_is_waiting(self):
+        d = make_delayer(prefill_decode_interval=2)
+        assert call(d, pending_tokens=MAX_BATCHED) is True
+        d.notify_prefill_executed()
+        assert call(d, prefillable=False, pending_tokens=0) is True
+        assert call(d, prefillable=False, pending_tokens=0) is True
+        assert d._decode_interval_remaining == 0
+
+    def test_no_decode_does_not_block_prefill_progress(self):
+        d = make_delayer(prefill_decode_interval=10)
+        assert call(d, pending_tokens=MAX_BATCHED, running_decode_batch=0) is True
+        d.notify_prefill_executed()
+        # A partial-only workload has no decode pass to protect, so it may
+        # continue instead of producing ten empty scheduler iterations.
+        assert call(d, pending_tokens=1000, running_decode_batch=0) is True
+
+    def test_fire_without_executed_prefill_does_not_arm_interval(self):
+        d = make_delayer(
+            prefill_decode_interval=3,
+            ttft_max_ticks=1,
+            stall_ticks=1,
+            kv_high_watermark=0.1,
+        )
+        assert call(d, pending_tokens=MAX_BATCHED, kv_usage=1.0) is True
+        # Admission may still yield no prefill batch. Without an execution
+        # notification, the next eligible prefill must not be delayed.
+        assert call(d, pending_tokens=MAX_BATCHED, kv_usage=1.0) is True
+        assert d._stat_hold_decode_interval == 0
+
+    def test_execution_on_peer_arms_all_ranks(self):
+        d = make_delayer(dp_size=2, prefill_decode_interval=1)
+        skip_first(d)
+        peer_prefill_ran = _add_rank({7: 1})
+        assert call(d, pending_tokens=1000, reduce=peer_prefill_ran) is False
+        assert d._stat_hold_decode_interval == 1
 
 
 class TestStatsDistinct:


### PR DESCRIPTION
## Summary

- propagate `X-Dynamo-Session-ID` / `X-Correlation-ID` through the OpenAI path and load-place new DPA sessions using estimated uncached prefill tokens plus request-equivalent decode pressure
- keep established sessions on an immutable cache owner so later agent turns preserve prefix-cache locality; child correlation IDs are placed independently
- add an opt-in post-prefill decode interval, synchronized across DPA ranks through the existing delayer reduction
- arm the interval only after a prefill forward actually completes, rather than when the delayer merely permits admission
- expose routing counters/gauges and document the new controls and production defaults

## Enablement

```bash
export ATOM_DP_SESSION_AFFINITY=1
export ATOM_DP_LB_REQ_EQUIV=512
export ATOM_ENABLE_PREFILL_DELAYER=1
export ATOM_PREFILL_DECODE_INTERVAL=10

# server
--dp-load-balance least_tokens
```

All new behavior is opt-in: session affinity defaults to off and the post-prefill decode interval defaults to `0`. Existing sessions never migrate.

## Benchmark evidence

On the 3600-second DPA8 agentic comparison, the combined routing + PDI configuration measured:

- input throughput: `+0.05%` (neutral)
- mean TTFT: `-4.15%`
- p50 TTFT: `-3.10%`
- mean ITL: `-1.16%`
- p50 ITL: `-0.23%`

That run also included the dense low-batch-size CUDA Graph change, so the result is evidence for the combined configuration and is not presented as isolated PDI attribution.

A separate 600-second replay-cost migration experiment reduced input throughput by `0.71%`, cache read by `0.94 pp`, and actual prefix hits by roughly `2.04 pp`. This PR therefore keeps established session ownership strict and excludes migration.

The prior `+4.47%` DPA result depended on a separate device-synchronization change and is intentionally not claimed here.

## Validation

- `69 passed, 1 skipped`: DP routing, API header propagation, prefill delayer, and partial-prefill-tail tests
- `33 passed`: sequence and prefill scheduler tests
- Black check passed on changed Python files
- Ruff passed on changed Python files
- `compileall` and `git diff --check` passed

## Scope notes

This PR intentionally excludes device synchronization, session migration, LMCache/offload, MegaMoE fixed-slot transport, and independent-replica experiments.

InferenceX currently reports `Unsupported agentic server metrics backend` for ATOM metrics during final aggregation. Raw AIPerf JSON/CSV export completes successfully; aggregator support is outside this ATOM change.