### PR TITLE
feat(mori-v2): let the MoE dispatch wire be chosen, for the fp4 GEMM it feeds

### DIFF
--- a/atom/model_ops/fused_moe/mori_v2_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_v2_prepare_finalize.py
@@ -193,6 +193,11 @@ def _cco_per_rank_vmm(
 # are config-wide, so the first layer's are the model's.
 _MEGA_TRANSPORTS: dict = {}
 
+# bf16 | fp8 | fp4, and it must MATCH the expert GEMM's A operand -- on gfx1250
+# that is fp4 unless AITER_FORCE_A8W4=1. A mismatch is a row-width error, not a
+# slow path. Read once: init_mega_transport runs per MoE layer (61x for V4-Pro).
+_MEGA_WIRE = os.environ.get("MEGA_WIRE", "bf16")
+
 
 def init_mega_transport(
     *,
@@ -235,6 +240,8 @@ def init_mega_transport(
         hidden_pad,
         intermediate_pad,
         swiglu_limit,
+        # Keyed on: the wire sets the payload width and whether out_scales exists.
+        _MEGA_WIRE,
     )
     cached = _MEGA_TRANSPORTS.get(key)
     if cached is not None:
@@ -266,13 +273,16 @@ def init_mega_transport(
         swiglu_limit=swiglu_limit,
         situ_beta=situ_beta,
         situ_linear_beta=situ_linear_beta,
+        # Passed, not left to aiter's own read of $MEGA_WIRE, so the key and the
+        # transport cannot drift.
+        dispatch_wire=_MEGA_WIRE,
     )
     comm.barrier()
     _MEGA_TRANSPORTS[key] = mega
     logger.info(
         "[MORI-V2] Created MegaMoE: ep_rank=%d ep_size=%d hidden=%d inter=%d "
         "experts=%d topk=%d M=%d act=%s gate=%s quant=%s pad=(%d,%d) "
-        "swiglu_limit=%s dispatch=%s",
+        "swiglu_limit=%s dispatch=%s wire=%s force_a8w4=%s",
         ep_rank,
         ep_size,
         hidden_dim,
@@ -287,6 +297,9 @@ def init_mega_transport(
         intermediate_pad,
         swiglu_limit,
         mega._config.dispatch_backend,
+        mega._config.dispatch_wire,
+        # The other half of the pair: logged together so a mismatch is readable.
+        os.environ.get("AITER_FORCE_A8W4", "0"),
     )
     return mega
 

--- a/atom/model_ops/fused_moe/mori_v2_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_v2_prepare_finalize.py
@@ -196,7 +196,15 @@ _MEGA_TRANSPORTS: dict = {}
 # bf16 | fp8 | fp4, and it must MATCH the expert GEMM's A operand -- on gfx1250
 # that is fp4 unless AITER_FORCE_A8W4=1. A mismatch is a row-width error, not a
 # slow path. Read once: init_mega_transport runs per MoE layer (61x for V4-Pro).
-_MEGA_WIRE = os.environ.get("MEGA_WIRE", "bf16")
+#
+# Checked here as well as in aiter: this module passes dispatch_wire= down
+# explicitly, so aiter's own env read -- and its guard -- never runs for us.
+if os.environ.get("MEGA_WIRE") not in (None, os.environ.get("MEGA_DISPATCH_WIRE")):
+    raise RuntimeError(
+        "MEGA_WIRE was renamed to MEGA_DISPATCH_WIRE; update the launch script, "
+        "the old name is no longer read"
+    )
+_MEGA_DISPATCH_WIRE = os.environ.get("MEGA_DISPATCH_WIRE", "bf16")
 
 
 def init_mega_transport(
@@ -240,8 +248,9 @@ def init_mega_transport(
         hidden_pad,
         intermediate_pad,
         swiglu_limit,
-        # Keyed on: the wire sets the payload width and whether out_scales exists.
-        _MEGA_WIRE,
+        # Keyed on: the wire sets the payload width and whether the scale
+        # region exists.
+        _MEGA_DISPATCH_WIRE,
     )
     cached = _MEGA_TRANSPORTS.get(key)
     if cached is not None:
@@ -273,9 +282,18 @@ def init_mega_transport(
         swiglu_limit=swiglu_limit,
         situ_beta=situ_beta,
         situ_linear_beta=situ_linear_beta,
-        # Passed, not left to aiter's own read of $MEGA_WIRE, so the key and the
+        # Passed, not left to aiter's own read of the env, so the key and the
         # transport cannot drift.
-        dispatch_wire=_MEGA_WIRE,
+        dispatch_wire=_MEGA_DISPATCH_WIRE,
+        # Only mori's dispatch carries the scale row, so a quantizing wire has
+        # no other backend to run on. Named here rather than left to
+        # $MEGA_DISPATCH, whose default is flydsl: otherwise asking for fp4 is
+        # rejected at the first MoE layer for a reason the operator did not set.
+        **(
+            {"dispatch_backend": "mori"}
+            if _MEGA_DISPATCH_WIRE in ("fp8", "fp4")
+            else {}
+        ),
     )
     comm.barrier()
     _MEGA_TRANSPORTS[key] = mega


### PR DESCRIPTION
## What

Lets the MoE dispatch wire be chosen for the mori-v2 (MegaMoE) path, so it can ship an already-quantized payload instead of bf16:

```
MEGA_DISPATCH_WIRE=bf16 | fp8 | fp4      default bf16 -- unchanged behaviour
```

## Why

Dispatch ships bf16 today and every receiver quantizes the copy it got, so a token routed to `topk` peers is quantized `topk` times on the same values. Quantizing on the sender does it once per local token and shrinks the wire; at hidden 7168 a token crosses as 14336 B on bf16, 7424 on fp8, **3840 on fp4**.

The wire has to match the expert GEMM's A operand — on gfx1250 that is fp4 unless `AITER_FORCE_A8W4=1`. A mismatch is a row-width error, not a slow path, so `wire=` and `force_a8w4=` are logged on the same line: a failed start is then readable instead of a width assert with no context.

A quantizing wire also runs only on mori's dispatch, which is the only one that carries the scale row, so this layer names that backend rather than leaving it to `$MEGA_DISPATCH` (whose default is flydsl).

## Measured

DSV4-Pro on 4x gfx1250, DP4 + EP4 + fake-eplb, ISL/OSL 1024/1024, concurrency 2048, 8192 requests:

| | bf16 wire | fp4 wire | |
|---|---|---|---|
| total token throughput | 57851.6 tok/s | 60226.5 tok/s | **+4.1%** |
| mean TTFT | 11967.9 ms | 11248.0 ms | **−6.0%** |
| mean TPOT | 58.93 ms | 56.79 ms | −3.6% |
| benchmark duration | 290.0 s | 278.6 s | −3.9% |

Two containers off the same image on the same box, only the env var differing. At the MoE-layer level the same change is −6.4% per layer at 16384 tokens/rank, all of it in dispatch.

Output is bit-identical either way — MX quant is destination-independent, so moving it to the sender changes no bytes (`test_mega_moe_gfx1250.py` scores 0.042041 against an fp32 reference on both wires).

## Usage

The DSV4 serve scripts under `/app/scripts` are not part of this repo, so turning the wire on is a launch-time change:

```bash
MEGA_DISPATCH_WIRE=fp4 python -m atom.entrypoints.openai_server -tp 4 --model ... \
  --enable-expert-parallel --enable-dp-attention ...
```

Confirm it took effect from the startup log:

```
[MORI-V2] Created MegaMoE: ... dispatch=mori wire=fp4 force_a8w4=0
```

`MEGA_WIRE` was the name during development. It now **raises** rather than falling back, because an env var that is silently ignored would serve bf16 while the operator believed they were on fp4. Setting both names to the same value is allowed, so a fleet can be rolled over one script at a time.

## Depends on

**ROCm/aiter#4984**, which adds `MegaMoEGfx1250(dispatch_wire=...)` and the quantizing wire behind it. Without it the `dispatch_wire=` keyword is unknown and construction raises — including on the bf16 default — so this should land after it.

The quantizing wire additionally needs a mori that forwards a per-token scale row (ROCm/mori#593, merged); aiter raises a message naming it if you ask for fp8/fp4 without one. The bf16 default needs neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
