### PR TITLE
reduce mem pressure raised by multiple comm groups init

### DIFF
--- a/atom/distributed/group_reuse.py
+++ b/atom/distributed/group_reuse.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: MIT
+# Share one set of RCCL communicators among parallel groups spanning identical ranks.
+
+"""Deduplicate parallel groups whose rank sets coincide.
+
+``GroupCoordinator.__init__`` builds, for every group with ``world_size > 1``:
+
+* ``device_group`` -- ``torch.distributed.new_group(backend="nccl")``
+* ``pynccl_comm``  -- a second, independent RCCL communicator over the *same* ranks
+* ``ca_comm`` / ``qr_comm`` -- CustomAllreduce / QuickAllReduce IPC buffers
+
+On MI355X (8x288GB) those cost 2.40GB, 2.40GB and 2.00GB respectively, i.e. 6.8GB
+per group. When ``tensor_parallel_size == decode_context_parallel_size == world_size``
+the TP, DCP and EP groups all span ranks ``{0..N-1}`` yet each builds its own set,
+and PCP/PP/DP degenerate to single-rank groups that still pay 0.54GB apiece for a
+communicator no message ever crosses. Measured on 8xMI355X with ``-tp 8 -dcp 8``:
+12.61GB for the six groups, of which 7.75GB is duplication.
+
+That matters because the KV cache is sized as the *residual* of the memory budget
+(see ``ModelRunner.get_num_blocks``): whatever the communicators hold is subtracted
+from ``available_for_kv`` one-for-one.
+
+The reuse trick is the one ATOM already applies to the vLLM plugin path in
+``atom/plugin/vllm/tp_group_reuse.py`` (PR #1804): skip ``GroupCoordinator.__init__``,
+which is what allocates, and graft the fields of an already-built group instead.
+
+Trade-off: aliased groups issue their collectives on one communicator, so those
+collectives serialize against each other. That is already true for TP/DCP/EP, whose
+collectives are issued in sequence from the forward pass. Groups that must stay
+isolated -- notably eplb's migration group, which uses ``new_group`` directly so its
+isend/irecv cannot cross-match in-flight forward ops -- do not go through
+``init_model_parallel_group`` and are therefore untouched.
+"""
+
+import contextlib
+import logging
+
+from atom.utils import envs
+
+logger = logging.getLogger("atom")
+
+# Every attribute GroupCoordinator.__init__ assigns; an alias must carry all of
+# them or callers reaching past the collective API will find a half-built object.
+_COORD_FIELDS = (
+    "rank",
+    "local_rank",
+    "ranks",
+    "world_size",
+    "rank_in_group",
+    "cpu_group",
+    "device_group",
+    "device",
+    "use_device_communicator",
+    "device_communicator",
+    "mq_broadcaster",
+)
+
+
+@contextlib.contextmanager
+def reuse_identical_rank_groups():
+    """Make ``init_model_parallel_group`` hand back an alias for a repeated rank set.
+
+    Scoped to the ``init_dist_env`` call: groups built later (eplb migration) keep
+    their own communicators. A no-op unless ``ATOM_REUSE_COMM_GROUPS`` is set.
+    """
+    if not envs.ATOM_REUSE_COMM_GROUPS:
+        yield
+        return
+
+    from aiter.dist import parallel_state as ps
+
+    class _AliasGroup(ps.GroupCoordinator):
+        """A GroupCoordinator sharing another one's communicators.
+
+        Deliberately does not call ``super().__init__`` -- that is the allocating
+        path. Only ``unique_name`` is its own, so ``_register_group`` and any
+        name-keyed lookup still resolve to distinct entries.
+        """
+
+        def __init__(self, source: "ps.GroupCoordinator", group_name: str | None):
+            self.unique_name = ps._get_unique_name(group_name or "anonymous")
+            ps._register_group(self)
+            for field in _COORD_FIELDS:
+                setattr(self, field, getattr(source, field))
+
+    built: dict[tuple[tuple[int, ...], ...], "ps.GroupCoordinator"] = {}
+    original = ps.init_model_parallel_group
+
+    def init_or_alias(
+        group_ranks,
+        local_rank,
+        backend,
+        use_device_communicator=True,
+        use_message_queue_broadcaster=False,
+        group_name=None,
+    ):
+        key = tuple(tuple(r) for r in group_ranks)
+        source = built.get(key)
+        if (
+            source is not None
+            and source.use_device_communicator == use_device_communicator
+        ):
+            alias = _AliasGroup(source, group_name)
+            # The broadcaster is a shared-memory queue built over the gloo
+            # cpu_group, so it costs no VRAM and there is no reason to make two
+            # groups drive one queue. TP is the group that asks for one, and it is
+            # also the first built -- refusing to alias over it would strand the
+            # largest duplicate.
+            if use_message_queue_broadcaster and alias.world_size > 1:
+                from aiter.dist.shm_broadcast import MessageQueue
+
+                alias.mq_broadcaster = MessageQueue.create_from_process_group(
+                    alias.cpu_group, 1 << 22, 6
+                )
+            logger.info(
+                "group_reuse: %s reuses the communicators of %s (ranks=%s)",
+                group_name,
+                source.unique_name,
+                list(key[0]) if len(key) == 1 else key,
+            )
+            return alias
+
+        group = original(
+            group_ranks,
+            local_rank,
+            backend,
+            use_device_communicator,
+            use_message_queue_broadcaster,
+            group_name,
+        )
+        built[key] = group
+        return group
+
+    ps.init_model_parallel_group = init_or_alias
+    try:
+        yield
+    finally:
+        ps.init_model_parallel_group = original

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -26,6 +26,7 @@ from aiter.dist.utils import get_distributed_init_method
 from torch.profiler import record_function
 
 from atom.config import Config, CUDAGraphMode, set_current_atom_config
+from atom.distributed.group_reuse import reuse_identical_rank_groups
 from atom.distributed.pcp_utils import (
     PcpBalGroup,
     pcp_allgather_rerange,
@@ -920,36 +921,39 @@ class ModelRunner:
             config.parallel_config.data_parallel_master_ip,
             config.parallel_config.data_parallel_base_port,
         )
-        if config.pipeline_parallel_size > 1:
-            from atom.distributed.pp_comm import init_pp_aware_dist_env
+        # Groups spanning the same ranks each build their own RCCL communicators,
+        # and the KV cache gets whatever the memory budget has left after them.
+        with reuse_identical_rank_groups():
+            if config.pipeline_parallel_size > 1:
+                from atom.distributed.pp_comm import init_pp_aware_dist_env
 
-            dp_size = config.parallel_config.data_parallel_size
-            world_size = dp_size * pp_size * stage_span
-            dp_rank = config.parallel_config.data_parallel_rank
-            global_rank = (dp_rank * pp_size + pp_rank) * stage_span + rank
-            init_pp_aware_dist_env(
-                tensor_model_parallel_size=config.tensor_parallel_size,
-                pipeline_model_parallel_size=pp_size,
-                global_rank=global_rank,
-                world_size=world_size,
-                distributed_init_method=distributed_init_method,
-                backend="nccl",
-                data_parallel_size=dp_size,
-                prefill_context_model_parallel_size=config.prefill_context_parallel_size,
-            )
-        else:
-            init_dist_env(
-                config.tensor_parallel_size,
-                rankID=rank,
-                backend="nccl",
-                distributed_init_method=distributed_init_method,
-                data_parallel_size=config.parallel_config.data_parallel_size,
-                data_parallel_rank=config.parallel_config.data_parallel_rank,
-                prefill_context_model_parallel_size=config.prefill_context_parallel_size,
-                decode_context_parallel_size=getattr(
-                    config, "decode_context_parallel_size", 1
-                ),
-            )
+                dp_size = config.parallel_config.data_parallel_size
+                world_size = dp_size * pp_size * stage_span
+                dp_rank = config.parallel_config.data_parallel_rank
+                global_rank = (dp_rank * pp_size + pp_rank) * stage_span + rank
+                init_pp_aware_dist_env(
+                    tensor_model_parallel_size=config.tensor_parallel_size,
+                    pipeline_model_parallel_size=pp_size,
+                    global_rank=global_rank,
+                    world_size=world_size,
+                    distributed_init_method=distributed_init_method,
+                    backend="nccl",
+                    data_parallel_size=dp_size,
+                    prefill_context_model_parallel_size=config.prefill_context_parallel_size,
+                )
+            else:
+                init_dist_env(
+                    config.tensor_parallel_size,
+                    rankID=rank,
+                    backend="nccl",
+                    distributed_init_method=distributed_init_method,
+                    data_parallel_size=config.parallel_config.data_parallel_size,
+                    data_parallel_rank=config.parallel_config.data_parallel_rank,
+                    prefill_context_model_parallel_size=config.prefill_context_parallel_size,
+                    decode_context_parallel_size=getattr(
+                        config, "decode_context_parallel_size", 1
+                    ),
+                )
 
     def _make_buffer(
         self, *size: int | torch.SymInt, dtype: torch.dtype, numpy: bool = True

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -505,6 +505,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # sends only its 1/tp_size slice and the receiver all-gathers, cutting PP
     # link traffic by tp_size. Default on; set "0" for full-tensor sends.
     "ATOM_PP_SEND_ALLGATHER": lambda: os.getenv("ATOM_PP_SEND_ALLGATHER", "1") == "1",
+    # Let parallel groups spanning identical ranks (TP/DCP/EP at tp==dcp==world
+    # size, and the degenerate single-rank PCP/PP/DP) share one set of RCCL
+    # communicators instead of building one each. Worth 7.75GB per GPU of KV cache
+    # on 8xMI355X at -tp 8 -dcp 8; costs serialization between those groups'
+    # collectives. Off until measured on a given topology.
+    "ATOM_REUSE_COMM_GROUPS": lambda: os.getenv("ATOM_REUSE_COMM_GROUPS", "0") == "1",
 }
 
 


### PR DESCRIPTION
## Motivation
Reduce the non-torch memory by half, from 30G to ~12G. This is achieved by reusing comm group from aiter, e.g., TP/DCP/PCP/DP/EP. Only reuse when the env guard is on and the comm groups share the same key. 
It's safe when these comm groups DONOT execute comm in parallel.

Before:
<img width="1754" height="50" alt="image" src="https://github.com/user-attachments/assets/79ed5d7d-93bb-48ed-ae0a-6b8975dc4c56" />


After:
<img width="1136" height="75" alt="image" src="https://github.com/user-attachments/assets/e98cb43f-2e41-4420-bba7-d4cc6abc6c11" />

With less non-torch memory, KV cache pool gets larger, boosting the hit rate and e2e performance:
<img width="2160" height="1248" alt="image" src="https://github.com/user-attachments/assets/3b9e3c9f-1741-48c2-b4f7-bceddc3795f3" />


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
