### PR TITLE
perf(frontend): merge_chunk rebuilt the whole backlog on every merge

### DIFF
--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -73,17 +73,12 @@ class IncrementalStreamDetokenizer:
 def merge_chunk(into: dict, new: dict) -> None:
     """Fold ``new`` into the chunk already waiting. ``into`` is modified.
 
-    ``text`` and ``token_ids`` are deltas, so concatenating them is exact. Both
-    are extended in place -- ``into`` carries the copy
-    :meth:`StreamOutputCollector.put_nowait` made on the way in. Rebuilding them
-    walked the whole accumulation again on every merge, and the accumulation is
-    exactly what deepens while a stream is being merged into.
+    Both deltas extend in place: ``into`` holds the copy ``put_nowait`` took,
+    and rebuilding them walked the whole accumulation on every merge.
     """
     into["token_ids"].extend(new.get("token_ids") or ())
-    # Popped so the string has one reference and CPython grows it in place.
-    # `into["text"] = into["text"] + ...` leaves the dict holding one, which
-    # forces a fresh allocation and a full copy per merge -- restoring this is
-    # silent, so it survives both the tests and the linter.
+    # Popped so the string has one reference and CPython grows it in place;
+    # assigning `into["text"] + ...` back reallocates and copies per merge.
     text = into.pop("text", "")
     try:
         text += new.get("text", "")
@@ -127,10 +122,8 @@ class StreamOutputCollector:
             tag, chunk = None, payload
         waiting = self._pending.get(tag)
         if waiting is None:
-            # A merge extends this list, so it has to be one we own. The engine
-            # already hands out a per-step copy (the sole `RequestOutput` site,
-            # in the scheduler), but that is a long way from here to rely on,
-            # and copying once per stall is cheaper than once per merge.
+            # A merge extends this list, so it has to be ours. The scheduler
+            # already copies per step, but that is too far away to rely on.
             chunk["token_ids"] = list(chunk.get("token_ids") or ())
             self._pending[tag] = chunk
         else:

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -70,6 +70,10 @@ class IncrementalStreamDetokenizer:
         return ""
 
 
+class _MergedIds(list):
+    """Marks a token_ids list this module owns and may extend in place."""
+
+
 def merge_chunk(into: dict, new: dict) -> None:
     """Fold ``new`` into the chunk already waiting. ``into`` is modified.
 
@@ -77,8 +81,18 @@ def merge_chunk(into: dict, new: dict) -> None:
     ``token_ids`` is rebuilt rather than extended: the first chunk's list is the
     engine's own ``output_tokens``, which must not be appended to.
     """
-    into["token_ids"] = [*into.get("token_ids", ()), *new.get("token_ids", ())]
-    into["text"] = into.get("text", "") + new.get("text", "")
+    ids = new.get("token_ids")
+    if ids:
+        cur = into.get("token_ids")
+        if cur.__class__ is _MergedIds:
+            cur.extend(ids)
+        else:
+            merged = _MergedIds(cur or ())
+            merged.extend(ids)
+            into["token_ids"] = merged
+    text = into.pop("text", "")
+    text += new.get("text", "")
+    into["text"] = text
     into["finished"] = bool(into.get("finished") or new.get("finished"))
     for key in _LATEST_WINS:
         if new.get(key):

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -70,29 +70,25 @@ class IncrementalStreamDetokenizer:
         return ""
 
 
-class _MergedIds(list):
-    """Marks a token_ids list this module owns and may extend in place."""
-
-
 def merge_chunk(into: dict, new: dict) -> None:
     """Fold ``new`` into the chunk already waiting. ``into`` is modified.
 
-    ``text`` and ``token_ids`` are deltas, so concatenating them is exact.
-    ``token_ids`` is rebuilt rather than extended: the first chunk's list is the
-    engine's own ``output_tokens``, which must not be appended to.
+    ``text`` and ``token_ids`` are deltas, so concatenating them is exact. Both
+    are extended in place -- ``into`` carries the copy
+    :meth:`StreamOutputCollector.put_nowait` made on the way in. Rebuilding them
+    walked the whole accumulation again on every merge, and the accumulation is
+    exactly what deepens while a stream is being merged into.
     """
-    ids = new.get("token_ids")
-    if ids:
-        cur = into.get("token_ids")
-        if cur.__class__ is _MergedIds:
-            cur.extend(ids)
-        else:
-            merged = _MergedIds(cur or ())
-            merged.extend(ids)
-            into["token_ids"] = merged
+    into["token_ids"].extend(new.get("token_ids") or ())
+    # Popped so the string has one reference and CPython grows it in place.
+    # `into["text"] = into["text"] + ...` leaves the dict holding one, which
+    # forces a fresh allocation and a full copy per merge -- restoring this is
+    # silent, so it survives both the tests and the linter.
     text = into.pop("text", "")
-    text += new.get("text", "")
-    into["text"] = text
+    try:
+        text += new.get("text", "")
+    finally:
+        into["text"] = text
     into["finished"] = bool(into.get("finished") or new.get("finished"))
     for key in _LATEST_WINS:
         if new.get(key):
@@ -131,6 +127,11 @@ class StreamOutputCollector:
             tag, chunk = None, payload
         waiting = self._pending.get(tag)
         if waiting is None:
+            # A merge extends this list, so it has to be one we own. The engine
+            # already hands out a per-step copy (the sole `RequestOutput` site,
+            # in the scheduler), but that is a long way from here to rely on,
+            # and copying once per stall is cheaper than once per merge.
+            chunk["token_ids"] = list(chunk.get("token_ids") or ())
             self._pending[tag] = chunk
         else:
             merge_chunk(waiting, chunk)

--- a/tests/entrypoints/test_streaming_dispatch.py
+++ b/tests/entrypoints/test_streaming_dispatch.py
@@ -340,10 +340,7 @@ def test_two_steps_keep_their_order_within_one_stream():
 
 
 def test_merge_keeps_end_of_stream_and_never_extends_the_producers_list():
-    """A swallowed terminal flag hangs its client; a mutated list corrupts the producer.
-
-    Driven through the collector because that is where the copy is taken now.
-    """
+    """A swallowed terminal flag hangs its client; a mutated list corrupts the producer."""
     produced = [1]
     collector = StreamOutputCollector("request-1")
     collector.put_nowait({"token_ids": produced, "text": "a", "finished": True})
@@ -358,11 +355,7 @@ def test_merge_keeps_end_of_stream_and_never_extends_the_producers_list():
 
 
 def test_put_nowait_gives_merge_chunk_a_list_it_may_extend():
-    """`merge_chunk` extends in place, so the key it needs is established here.
-
-    It used to create the key itself on every merge; losing that is only safe
-    while this holds.
-    """
+    """`merge_chunk` extends in place; it used to create this key itself."""
     collector = StreamOutputCollector("request-1")
     collector.put_nowait({"text": "a"})
 
@@ -370,8 +363,7 @@ def test_put_nowait_gives_merge_chunk_a_list_it_may_extend():
 
 
 def test_merge_extends_in_place_instead_of_rebuilding():
-    """Rebuilding walks the whole accumulation per merge, and it is the accumulation
-    that grows while a stream is stalled."""
+    """Rebuilding walks the whole accumulation, which is what a stall grows."""
     collector = StreamOutputCollector("request-1")
     collector.put_nowait({"token_ids": [1], "text": "a"})
     accumulating = collector._pending[None]["token_ids"]

--- a/tests/entrypoints/test_streaming_dispatch.py
+++ b/tests/entrypoints/test_streaming_dispatch.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from atom.entrypoints.openai.streaming_dispatch import (
     IncrementalStreamDetokenizer,
     StreamBatchDispatcher,
@@ -337,16 +339,80 @@ def test_two_steps_keep_their_order_within_one_stream():
     assert chunk["finished"] is True
 
 
-def test_merge_keeps_end_of_stream_and_never_extends_the_engines_list():
-    """A swallowed terminal flag hangs its client; a mutated list corrupts the engine."""
-    engine_tokens = [1]
-    into = {"token_ids": engine_tokens, "text": "a", "finished": True}
-    merge_chunk(into, {"token_ids": [2], "text": "b", "finished": False})
+def test_merge_keeps_end_of_stream_and_never_extends_the_producers_list():
+    """A swallowed terminal flag hangs its client; a mutated list corrupts the producer.
 
-    assert into["finished"] is True
-    assert into["text"] == "ab"
-    assert into["token_ids"] == [1, 2]
-    assert engine_tokens == [1]
+    Driven through the collector because that is where the copy is taken now.
+    """
+    produced = [1]
+    collector = StreamOutputCollector("request-1")
+    collector.put_nowait({"token_ids": produced, "text": "a", "finished": True})
+    collector.put_nowait({"token_ids": [2], "text": "b", "finished": False})
+
+    chunk = _resolve(collector.get())
+
+    assert chunk["finished"] is True
+    assert chunk["text"] == "ab"
+    assert chunk["token_ids"] == [1, 2]
+    assert produced == [1]
+
+
+def test_put_nowait_gives_merge_chunk_a_list_it_may_extend():
+    """`merge_chunk` extends in place, so the key it needs is established here.
+
+    It used to create the key itself on every merge; losing that is only safe
+    while this holds.
+    """
+    collector = StreamOutputCollector("request-1")
+    collector.put_nowait({"text": "a"})
+
+    assert collector._pending[None]["token_ids"] == []
+
+
+def test_merge_extends_in_place_instead_of_rebuilding():
+    """Rebuilding walks the whole accumulation per merge, and it is the accumulation
+    that grows while a stream is stalled."""
+    collector = StreamOutputCollector("request-1")
+    collector.put_nowait({"token_ids": [1], "text": "a"})
+    accumulating = collector._pending[None]["token_ids"]
+    for token in (2, 3, 4):
+        collector.put_nowait({"token_ids": [token], "text": "b"})
+
+    assert collector._pending[None]["token_ids"] is accumulating
+    assert accumulating == [1, 2, 3, 4]
+
+
+@pytest.mark.parametrize("depth", (1, 2, 17, 500))
+def test_a_merged_stream_reads_the_same_as_an_unmerged_one(depth):
+    """A consumer must not be able to tell how far behind it fell."""
+    tokens = list(range(depth + 1))
+    unmerged = StreamOutputCollector("request-1")
+    merged = StreamOutputCollector("request-2")
+    delivered = []
+    for index, token in enumerate(tokens):
+        finished = index == len(tokens) - 1
+        unmerged.put_nowait(
+            {"token_ids": [token], "text": f"{token} ", "finished": finished}
+        )
+        delivered.append(_resolve(unmerged.get()))
+        merged.put_nowait(
+            {"token_ids": [token], "text": f"{token} ", "finished": finished}
+        )
+
+    folded = _resolve(merged.get())
+
+    assert folded["text"] == "".join(chunk["text"] for chunk in delivered)
+    assert folded["token_ids"] == tokens
+    assert folded["finished"] is True
+
+
+def test_merge_keeps_the_text_it_had_when_the_delta_is_not_a_string():
+    """The text is popped to keep its refcount at one; a raise must not drop it."""
+    into = {"token_ids": [1], "text": "acc"}
+    with pytest.raises(TypeError):
+        merge_chunk(into, {"token_ids": [2], "text": None})
+
+    assert into["text"] == "acc"
 
 
 def test_dispatcher_keeps_no_per_stream_state():


### PR DESCRIPTION
## Motivation

`StreamOutputCollector` folds an arriving chunk into the one still waiting whenever the consumer lags. `merge_chunk` rebuilt `token_ids` and re-concatenated `text` from scratch on every fold, which walks the whole accumulation per merge — and it runs on the event loop, so it feeds back on itself: the further the frontend falls behind the engine, the deeper the accumulation, the more each merge costs.

py-spy over 60s of steady decode at c=8192, self time: `merge_chunk` 27.5% across three lines, the `token_ids` rebuild alone 20.3% and the largest single consumer in the process.

## Technical Details

Both deltas are extended in place. The producer's list is copied once in `put_nowait`, where the chunk is first taken, so `merge_chunk` is a single unconditional `extend` with no per-merge branch.

The copy is defence in depth, not necessity: `scheduler.py` is the only `RequestOutput` site in the repo and already hands out a per-step copy, and the object is unpickled fresh after crossing ZMQ. The collector should still not extend a list handed to it across two files and a process boundary on the strength of a comment, and `test_put_nowait_gives_merge_chunk_a_list_it_may_extend` pins the precondition rather than leaving it to be rediscovered.

`text` is popped before the concatenation so the string has a single reference and CPython grows it in place; the write-back is in a `finally`, so a non-string delta raises as it always did without losing the text already accumulated.

Behaviour differences from the previous code, both only reachable by calling `merge_chunk` outside the collector: `token_ids` is de-aliased on the way in rather than on the first merge carrying ids, and a chunk that never went through `put_nowait` raises `KeyError` instead of silently growing the key.

## Test Plan

- `tests/entrypoints/`.
- `test_merge_extends_in_place_instead_of_rebuilding` and `test_put_nowait_gives_merge_chunk_a_list_it_may_extend` both fail with the source change reverted.
- `test_a_merged_stream_reads_the_same_as_an_unmerged_one` at backlog depths 1, 2, 17 and 500.
- `test_merge_keeps_the_text_it_had_when_the_delta_is_not_a_string`.
- gsm8k 3-shot through `lm_eval`.
- `benchmark_serving`, DSR1 fp4, tp8 with DP attention, c=8192, ISL 1024 / OSL 4096, `--ignore-eos`, fresh server per run, otherwise identical builds.

`lm_eval` drives `/v1/completions` without `stream`, so gsm8k does not reach the code this PR touches. The backlog-depth cases were written for that.

## Test Result

| | |
|---|---|
| `tests/entrypoints/` | 1867 passed, 52 skipped, 3 xfailed |
| source reverted, tests kept | 2 failed — the two that pin the change |
| gsm8k 3-shot | 0.9507 flexible / 0.9492 strict, 1319/1319 |

Throughput, measured on the first implementation of this change (the ownership-tag one); being re-measured on the reworked patch and this section will be replaced with those numbers.

One wave, 8192 requests, `--max-num-batched-tokens 4096`:

| | before | after | |
|---|---|---|---|
| output throughput | 42,970 | 57,735 tok/s | +34.4% |
| mean TPOT | 179.86 | 130.94 ms | −27.2% |
| median ITL | 17,475 | 912 ms | −94.8% |

Two waves, 16384 requests, default `--max-num-batched-tokens`:

| | before | after | |
|---|---|---|---|
| output throughput | 40,873 | 57,980 tok/s | +41.8% |
| mean TPOT | 183.35 | 130.41 ms | −28.9% |
| median ITL | 20,497 | 1,797 ms | −91.2% |

Five waves, 40960 requests, 48 minutes: 57,514 tok/s, mean TPOT 131.19 ms, p99 TPOT 140.73 ms, 40959/40960 successful, no traceback and no preemption. One, two and five waves land within 0.8% of each other; before the change more waves meant worse, since the wave boundary is where the accumulation is deepest.

The engine's last decode step lands at 568.6s in both one-wave runs, counted from the `decode[bs=...]` annotations. The run used to end at 793s and now ends at 581s.

Reverting the engine-side GC tuning from #1980, with `merge_chunk` untouched, also gains 10.2% on this config: a slower engine keeps the accumulation shallow enough that the per-merge cost stays cheap. Included as evidence for the mechanism, not as an alternative.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
