### PR TITLE
feat(mla): optionally run sparse MLA on aiter's Gluon kernel

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -565,13 +565,7 @@ class MLAAttention(nn.Module):
         self.dcp_persistent_supported = dcp_persistent_supported()
         self.dcp_prefill_merge_bf16_ok = dcp_prefill_merge_bf16_ok()
 
-        # Run the sparse decode on the Gluon kernel instead of the asm one. It
-        # takes num_heads < 16 natively, gfx950 only. Anything it does not cover
-        # keeps the asm path, so the flag only changes which kernel runs:
-        #   - DCP: its cross-rank merge needs an LSE this kernel cannot return
-        #   - an f16 KV cache: not covered by the kernel's format inference
-        # Page size does not enter it: sparse indices are physical token ids, so
-        # the cache reads flat whatever ATOM_MLA_PAGE_SIZE is.
+        # Run the sparse decode on the Gluon kernel instead, if available.
         self.use_gluon_sparse_mla = (
             envs.ATOM_USE_TRITON_SPARSE_MLA
             and self.is_sparse_mla

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -123,6 +123,20 @@ triton_fused_qk_rope_cat_and_cache_mla = mark_trace(
     torch_compile=False,
 )
 
+# Gluon sparse (top-k gathered) MLA, gated by ATOM_USE_TRITON_SPARSE_MLA.
+# Optional: older aiter builds have no sparse_mla_fwd.
+try:
+    from aiter.ops.triton.attention.sparse_mla import (
+        sparse_mla_fwd as _gluon_sparse_mla_fwd,
+    )
+
+    gluon_sparse_mla_fwd = mark_trace(
+        _gluon_sparse_mla_fwd, prefix="mla_decode_sparse_gluon", torch_compile=False
+    )
+except Exception:  # noqa: BLE001
+    gluon_sparse_mla_fwd = None
+
+
 # torch.set_printoptions(threshold=10_000)
 
 logger = logging.getLogger("atom")
@@ -148,6 +162,19 @@ def mla_min_query_heads(kv_cache_dtype: str, block_width: int) -> int:
     if block_width == 2 and kv_cache_dtype.startswith("fp8"):
         return 32
     return _MLA_MIN_HEADS
+
+
+def gluon_sparse_mla_supported() -> bool:
+    """Whether the Gluon sparse-MLA kernel can run on this GPU (gfx950 only).
+
+    Like ``dcp_persistent_supported``: cache it once per ``__init__`` to keep
+    ``get_gfx()`` off the per-forward path (graph-break).
+    """
+    if gluon_sparse_mla_fwd is None:
+        return False
+    from aiter.jit.utils.chip_info import get_gfx
+
+    return get_gfx() == "gfx950"
 
 
 def mla_kernel_num_heads(num_heads: int) -> int:
@@ -537,6 +564,32 @@ class MLAAttention(nn.Module):
 
         self.dcp_persistent_supported = dcp_persistent_supported()
         self.dcp_prefill_merge_bf16_ok = dcp_prefill_merge_bf16_ok()
+
+        # Run the sparse decode on the Gluon kernel instead of the asm one. It
+        # takes num_heads < 16 natively, gfx950 only. Anything it does not cover
+        # keeps the asm path, so the flag only changes which kernel runs:
+        #   - DCP: its cross-rank merge needs an LSE this kernel cannot return
+        #   - an f16 KV cache: not covered by the kernel's format inference
+        # Page size does not enter it: sparse indices are physical token ids, so
+        # the cache reads flat whatever ATOM_MLA_PAGE_SIZE is.
+        self.use_gluon_sparse_mla = (
+            envs.ATOM_USE_TRITON_SPARSE_MLA
+            and self.is_sparse_mla
+            and self.dcp_world_size == 1
+            and self.kv_cache_dtype in ("auto", "fp8")
+            and self.dtype in (torch.bfloat16, torch.float8_e4m3fn)
+            and gluon_sparse_mla_supported()
+        )
+        # Layer 0 only: this runs per layer and the answer is model-wide.
+        if (
+            envs.ATOM_USE_TRITON_SPARSE_MLA
+            and not self.use_gluon_sparse_mla
+            and self.layer_num == 0
+        ):
+            logger.warning(
+                "ATOM_USE_TRITON_SPARSE_MLA=1 but this configuration is not "
+                "covered by the Gluon sparse-MLA kernel; using the asm decode."
+            )
 
         # Compacted per-layer sparse offsets for DCP decode; rebound by the
         # metadata builder to the shared buffer (see aiter_mla.py).
@@ -1441,6 +1494,52 @@ class MLAAttention(nn.Module):
         # [num_token_slots, 1, d] -> [num_blocks, block_size, d] -> [.., 1, ..]
         return kv_cache.view(num_blocks, block_size, d).unsqueeze(1)
 
+    def _forward_decode_gluon_sparse(
+        self,
+        q: torch.Tensor,  # [num_tokens, num_heads, d_qk], NOT head-padded
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: AttentionMetaData,
+    ) -> torch.Tensor:
+        """The same sparse decode as the asm path, on aiter's Gluon kernel.
+
+        Sparse KV is packed per token at page_size 1, so ``sparse_kv_indptr``
+        and the indexer's flat slot ids are already the kernel's ``kv_indptr`` /
+        ``kv_indices`` -- MTP verify included, its layout is per-token too. Two
+        things the asm path needs and this one does not:
+
+        - query-head padding: the kernel runs num_heads < 16 natively.
+        - the persistent work-stealing metadata: never read, since the split-K
+          count comes from the shapes.
+        """
+        num_tokens = q.shape[0]
+        d_qk = self.kv_lora_rank + self.qk_rope_head_dim
+        o = torch.empty(
+            num_tokens,
+            q.shape[1],
+            self.kv_lora_rank,
+            dtype=self.dtype,
+            device=q.device,
+        )
+        # fp8 q carries the layer's static scale and the cache is fp8 in the same
+        # case, so both dots run on the fp8 matrix core with no dequant.
+        q_is_fp8 = q.dtype == torch.float8_e4m3fn
+        gluon_sparse_mla_fwd(
+            q,
+            # The same flattening the asm call applies, so both paths stay
+            # indifferent to the cache buffer's shape.
+            kv_c_and_k_pe_cache.view(-1, 1, 1, d_qk),
+            attn_metadata.sparse_kv_indptr[: num_tokens + 1],
+            self.sparse_kv_indices_buffer,
+            self.scale,
+            kv_scale=self._k_scale if self.kv_cache_dtype == "fp8" else None,
+            kv_lora_rank=self.kv_lora_rank,
+            qk_rope_head_dim=self.qk_rope_head_dim,
+            dot_precision="fp8" if q_is_fp8 else "bf16",
+            q_scale=self._q_scale if q_is_fp8 else None,
+            out=o,
+        )
+        return o
+
     def _forward_decode(
         self,
         q: torch.Tensor,
@@ -1456,6 +1555,13 @@ class MLAAttention(nn.Module):
         assert attn_metadata is not None
         B = q.shape[0]
         num_heads_q = q.shape[1]
+
+        # Before _pad_decode_query_heads: running num_heads natively is the point.
+        # return_lse is the one runtime gate; only DCP asks for it.
+        if self.use_gluon_sparse_mla and not return_lse:
+            return self._forward_decode_gluon_sparse(
+                q, kv_c_and_k_pe_cache, attn_metadata
+            )
 
         q = self._pad_decode_query_heads(q)
 

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -61,6 +61,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_USE_TRITON_MLA_SHUFFLE_KV": lambda: (
         os.getenv("ATOM_USE_TRITON_MLA_SHUFFLE_KV", "0") == "1"
     ),
+    # Run the sparse (top-k gathered) MLA attention on aiter's Gluon
+    # sparse_mla_fwd instead of the asm mla_decode_fwd. It takes num_heads < 16
+    # natively, so it also drops the query-head padding. gfx950 only; anything
+    # it does not cover falls back to the asm decode.
+    "ATOM_USE_TRITON_SPARSE_MLA": lambda: (
+        os.getenv("ATOM_USE_TRITON_SPARSE_MLA", "0") == "1"
+    ),
     "ATOM_USE_TRITON_MOE": lambda: os.getenv("ATOM_USE_TRITON_MOE", "0") == "1",
     "ATOM_USE_TRITON_MOE_DECODE": lambda: os.getenv("ATOM_USE_TRITON_MOE_DECODE", "0")
     == "1",


### PR DESCRIPTION
## Motivation

Enabling Gluon sparse MLA kernel for decode and prefill, off by default and hidden behind env. flag (ATOM_USE_TRITON_SPARSE_MLA)

## Technical Details

The new kernel mainly targets num_heads={8,16} for sparse MLA attention used in GLM 5.2, only for gfx950 (gluon kernel). The accuracy and performance is verified on 8xMI355, TP8.

The new approach doesnt require head padding as it supports H=8 natively (in kernel masking for mfmas).

## Test Plan

gsm8k runs.

## Test Result

With the following flags:
```
export ATOM_USE_TRITON_SPARSE_MLA=1     # 1 = gluon arm, 0 = asm arm  (the only variable changed)
export AITER_QUICK_REDUCE_QUANTIZATION=INT4    # from recipes/GLM-5.md
export AITER_USE_FLYDSL_MOE_SORTING=1          # from recipes/GLM-5.md
```

**Model** `/data/GLM-5.2-MXFP4` (`glm_moe_dsa`, 78 layers, `index_topk=2048`, 64 attn heads)
**Config** TP8 (→ 8 heads/rank), fp8 KV cache, `--max-model-len 32768`, `--max-num-batched-tokens 16384`,
`--no-enable_prefix_caching`, `--gpu-memory-utilization 0.90`, MI355X / gfx950

### Accuracy — GSM8K, 3-shot, 1319 problems

| spec decode | arm | flexible-extract | strict-match |
|---|---|---|---|
| MTP, 3 draft | **gluon** | 0.9272 ± 0.0072 | 0.9295 ± 0.0071 |
| MTP, 3 draft | baseline | 0.9265 ± 0.0072 | 0.9265 ± 0.0072 |
| off | **gluon** | 0.9318 ± 0.0069 | 0.9333 ± 0.0069 |
| off | baseline  | 0.9295 ± 0.0071 | 0.9303 ± 0.0070 |

### Performance no spec decode, ISL 8192 / OSL 1024, N = 10·C


| C | gluon tok/s | baseline tok/s | gluon | TTFT gluon/baseline (ms) | TPOT gluon/baseline (ms) |
|---:|---:|---:|---:|---:|---:|
| 4 | 328.2 | 299.9 | **+9.4%** | 192.9 / 220.6 | 11.38 / 12.41 |
| 8 | 554.2 | 511.0 | **+8.4%** | 190.2 / 209.7 | 13.20 / 14.28 |
| 16 | 887.7 | 818.7 | **+8.4%** | 196.4 / 212.2 | 16.72 / 18.13 |
| 32 | 1311.8 | 1209.6 | **+8.5%** | 202.8 / 224.5 | 22.77 / 24.66 |
| 64 | 1722.2 | 1581.5 | **+8.9%** | 214.3 / 237.2 | 35.21 / 38.32 |
| 128 | 2274.4 | 2061.1 | **+10.4%** | 243.6 / 273.6 | 54.10 / 59.81 |

**Geomean +9.0%.** Gluon also wins TTFT (10–13% lower) and TPOT (5–10% lower) at every point.

The kernel doesnt support work stealing but I think there is no need as we have topk which leads to regular work per WG.

It relies on this AITER PR: https://github.com/ROCm/aiter/pull/4919

In draft mode for now till that PR lands.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
