### PR TITLE
[MiniMax-M3][GFX1250] Enable SwiGLU activation for Triton MoE dense shared expert

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1656,16 +1656,18 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         """
         from aiter.ops.triton.fusions.fused_clamp_act_mul import fused_clamp_act_mul
         from aiter.ops.triton.gemm.basic.gemm_a16wfp4 import gemm_a16wfp4
+        from atom.model_ops.swiglu_oai import swiglu_oai_split
 
-        # The dense shared-expert GEMM only implements the SiLU activation
-        # path; SwiGLU models have no fused shared experts, so this assert
-        # documents the supported scope.
-        assert (
-            activation != ActivationType.Swiglu
-        ), "dense shared-expert GEMM only supports the SiLU activation path"
-
+        # Two activation flavours are supported, matching the routed experts:
+        #   * SiLU (DeepSeek): silu(gate) * clamp(up), split [gate | up] layout.
+        #   * SwiGLU-OAI (MiniMax-M3 / gpt-oss): gate * sigmoid(alpha*gate) *
+        #     (up + beta) with optional clamp. MiniMax-M3 does not interleave
+        #     gate/up, so the dense GEMM output is split [gate | up] - exactly
+        #     what swiglu_oai_split consumes.
         M = x.shape[0]
         swiglu_limit = getattr(layer, "swiglu_limit", 0.0)
+        swiglu_alpha = getattr(layer, "swiglu_alpha", 1.702)
+        swiglu_beta = getattr(layer, "swiglu_beta", 1.0)
 
         use_a4w4 = self.act_quant == MoEActivationQuant.FP4
         if use_a4w4:
@@ -1691,14 +1693,23 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             if shared_w13_bias is not None:
                 gate_up = gate_up + shared_w13_bias[e]
             half_n = gate_up.shape[-1] // 2
-            intermediate = torch.empty((M, half_n), device=x.device, dtype=x.dtype)
-            fused_clamp_act_mul(
-                gate_up,
-                out=intermediate,
-                swiglu_limit=swiglu_limit,
-                activation="silu",
-                dtype_quant=None,
-            )
+            if activation == ActivationType.Swiglu:
+                intermediate = swiglu_oai_split(
+                    gate_up,
+                    alpha=swiglu_alpha,
+                    beta=swiglu_beta,
+                    limit=max(swiglu_limit, 0.0),
+                    out_dtype=x.dtype,
+                )
+            else:
+                intermediate = torch.empty((M, half_n), device=x.device, dtype=x.dtype)
+                fused_clamp_act_mul(
+                    gate_up,
+                    out=intermediate,
+                    swiglu_limit=swiglu_limit,
+                    activation="silu",
+                    dtype_quant=None,
+                )
             out_e = _shared_expert_gemm(
                 intermediate,
                 layer.shared_w2_weight[e],

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1493,7 +1493,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 n_expts_act = routing_data.n_expts_act
 
                 # Convert to triton routing data structures
-                num_tokens, n_expts_tot = router_logits.shape
+                _, n_expts_tot = router_logits.shape
 
                 if global_num_experts > 0:
                     n_expts_tot = global_num_experts
@@ -1656,6 +1656,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         """
         from aiter.ops.triton.fusions.fused_clamp_act_mul import fused_clamp_act_mul
         from aiter.ops.triton.gemm.basic.gemm_a16wfp4 import gemm_a16wfp4
+
         from atom.model_ops.swiglu_oai import swiglu_oai_split
 
         # Two activation flavours are supported, matching the routed experts:

--- a/atom/models/minimax_m3.py
+++ b/atom/models/minimax_m3.py
@@ -232,6 +232,56 @@ class MiniMaxM3MLP(nn.Module):
         return self.down_proj(x)
 
 
+def _interleave_gate_up_rows_(layer: nn.Module, n_experts: int | None = None) -> None:
+    """Reorder w13 gate/up rows from SEPARATED (gguu) to INTERLEAVED (gugu).
+
+    MiniMax-M3 MXFP4 checkpoints store w13 rows as ``[gate(0..I-1) | up(0..I-1)]``
+    (gguu), but the routed triton a16w4 SwiGLU kernel splits each tile as
+    ``[gate0, up0, gate1, up1, ...]`` (gugu). This reorders ``layer.w13_weight``,
+    ``layer.w13_weight_scale`` and ``layer.w13_bias`` (if present) in place along
+    the row axis so the kernel reads matching gate/up pairs. ``w2`` (down_proj)
+    has no gate/up split and is untouched.
+
+    ``n_experts`` limits the reorder to the FIRST ``n_experts`` experts (default
+    None = all). MiniMax-M3 passes the routed count so the trailing fused shared
+    experts stay gguu for the dense shared-expert path (which half-splits
+    ``[gate | up]`` in ``swiglu_oai_split``).
+
+    The reorder is on whole rows; the MXFP4-packed pairs live on the LAST axis
+    (``H//2`` bytes/row), so it never splits a packed byte. For FP4 we reorder a
+    ``uint8`` view (bit-exact, no dequant/requant - torch has no ``index_select``
+    for ``float4_e2m1fn_x2``). It is applied in place per expert, reusing the
+    existing storage (a full-tensor ``index_select().contiguous()`` would double
+    peak memory and OOM across many layers at load time). Sets
+    ``layer._w13_gate_up_interleaved`` as an idempotency guard.
+    """
+    if getattr(layer, "_w13_gate_up_interleaved", False):
+        return
+
+    def _interleave_inplace(t: torch.Tensor) -> None:
+        # Only FP4 needs the uint8 view (torch has no index_select/reshape for it,
+        # and its bytes are row-contiguous so the row reorder is exact). Other
+        # dtypes (uint8 e8m0 scale, bf16/float bias) reorder directly.
+        _fp4 = getattr(torch, "float4_e2m1fn_x2", None)
+        buf = t.view(torch.uint8) if (_fp4 is not None and t.dtype == _fp4) else t
+
+        E, two_i = buf.shape[0], buf.shape[1]
+        assert two_i % 2 == 0, f"w13 row dim {two_i} not even"
+        n = E if n_experts is None else min(n_experts, E)
+        i = two_i // 2
+        rest = buf.shape[2:]
+        for e in range(n):
+            rows = buf[e]  # view into storage, shape (2I, *rest)
+            gugu = rows.view(2, i, *rest).transpose(0, 1).reshape(two_i, *rest)
+            rows.copy_(gugu)  # write back into the same storage
+
+    _interleave_inplace(layer.w13_weight.data)
+    _interleave_inplace(layer.w13_weight_scale.data)
+    if getattr(layer, "w13_bias", None) is not None:
+        _interleave_inplace(layer.w13_bias.data)
+    layer._w13_gate_up_interleaved = True
+
+
 class MiniMaxM3MoE(nn.Module):
     """MiniMax-M3 routed MoE for MXFP4 checkpoints."""
 
@@ -291,6 +341,8 @@ class MiniMaxM3MoE(nn.Module):
             # padded intermediate avoids backend pad-skip precision issues.
             self.experts.quant_method.intermediate_pad = 0
         self.experts.swiglu_limit = getattr(config, "swiglu_limit", 7.0)
+        self.experts.swiglu_alpha = getattr(config, "swiglu_alpha", 1.702)
+        self.experts.swiglu_beta = getattr(config, "swiglu_beta", 1.0)
         self.fuse_shared_experts = (
             getattr(self.experts, "num_fused_shared_experts", 0) > 0
         )
@@ -304,6 +356,30 @@ class MiniMaxM3MoE(nn.Module):
                 reduce_results=False,
                 prefix=f"{prefix}.shared_experts",
             )
+
+    def process_weights_after_loading(self):
+        """Interleave routed w13 gate/up rows (gguu -> gugu) for the triton path.
+
+        MiniMax-M3 MXFP4 checkpoints store w13 gate/up rows SEPARATED
+        ("gguu": [all-gate | all-up]), but the routed triton a16w4 SwiGLU kernel
+        splits each tile INTERLEAVED ("gugu": even rows = gate, odd = up). We
+        interleave the routed experts in place once at load time so the kernel
+        reads matching gate/up pairs. The non-triton (aiter CK) path consumes
+        gguu directly, so it is left untouched.
+
+        Only the ROUTED experts are interleaved. The fused shared experts occupy
+        the trailing ``num_fused_shared_experts`` slots and must stay gguu: the
+        dense shared-expert path (``_apply_shared_experts_dense`` ->
+        ``swiglu_oai_split``) half-splits ``[gate | up]``, and
+        ``Mxfp4MoEMethod.process_weights_after_loading`` (invoked by the loader
+        AFTER this model hook) clones those trailing slots in gguu for it.
+        """
+        qm = getattr(self.experts, "quant_method", None)
+        if not getattr(qm, "use_triton", False):
+            return
+        n_total = self.experts.w13_weight.shape[0]
+        n_shared = getattr(self.experts, "num_fused_shared_experts", 0)
+        _interleave_gate_up_rows_(self.experts, n_experts=n_total - n_shared)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         orig_shape = hidden_states.shape
@@ -395,7 +471,7 @@ class MiniMaxM3Attention(nn.Module):
         hidden_states_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         qkv = self.qkv_proj(hidden_states, x_scale=hidden_states_scale)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        q, k, v = torch.split(qkv, [self.q_size, self.kv_size, self.kv_size], dim=-1)
         attn_output = self.attn(q, k, v, positions=positions, qkv=qkv)
         return self.o_proj(attn_output)
 
@@ -536,7 +612,8 @@ class MiniMaxM3SparseAttention(nn.Module):
         # Keep index Q/K packed with main QKV. Layers that reuse cached top-k skip
         # the indexer norm/rope/top-k path, but still compute the packed GEMM.
         qkv = self.qkv_proj(hidden_states, x_scale=hidden_states_scale)
-        q, k, v, _, _ = qkv.split(
+        q, k, v, _, _ = torch.split(
+            qkv,
             [
                 self.q_size,
                 self.kv_size,


### PR DESCRIPTION
This PR try to support swiglu activation for Triton MoE dense shared export GEMM, when `ATOM_USE_TRITON_MOE=1` is set.

The request comes from MiniMax-M3 GFX1250 enabling.

The 2 main changes:
1. allow swiglu activation in triton moe path
2. fix prefill gemm weight layout mismatch by do interleaving in minimax-m3 `process_weights_after_loading` when `use_triton` is true.

