### PR TITLE
fix(scheduler): admission counted KV blocks globally against a per-rank pool

### DIFF
--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -295,7 +295,16 @@ class BlockManager:
             return self.kv.has_free(count)
         return self.paged_state_checkpoints.ensure_free_units(count)
 
-    def _dcp_num_blocks(self, seq_len: int) -> int:
+    def num_pool_blocks(self, seq_len: int) -> int:
+        """KV pool blocks a `seq_len`-token sequence occupies on this rank.
+
+        Under DCP a rank stores only its interleaved shard, so this is a factor
+        of `dcp_world_size` below the global `ceil(seq_len / block_size)`. The
+        pool is sized in these same per-rank units, so this is the only count
+        that may be compared against `kv.num_blocks` — whether to draw from the
+        pool (`can_allocate`/`allocate`) or to reject a prompt as too large for
+        it (`Scheduler._unschedulable_reason`).
+        """
         if self.dcp_world_size <= 1:
             return (seq_len + self.block_size - 1) // self.block_size
         from atom.model_ops.dcp_ops import get_dcp_local_seq_lens
@@ -399,7 +408,7 @@ class BlockManager:
         if seq.has_per_req_cache and not self.state.has_free():
             return -1
         if not self.enable_prefix_caching:
-            if not self._has_page_units(self._dcp_num_blocks(len(seq))):
+            if not self._has_page_units(self.num_pool_blocks(len(seq))):
                 return -1
             return 0
         # Step 1: compressed prefix (CSA/HCA/indexer share the block hash and
@@ -479,7 +488,7 @@ class BlockManager:
         # Pin the restore before fresh blocks can evict its checkpoint.
         if seq.has_per_req_cache and self.paged_state_checkpoints is not None:
             self._attach_state_group(seq, h if num_cached_blocks > 0 else -1)
-        for _ in range(num_cached_blocks, self._dcp_num_blocks(len(seq))):
+        for _ in range(num_cached_blocks, self.num_pool_blocks(len(seq))):
             seq.block_table.append(self._fresh_block())
         seq.num_cached_tokens = num_cached_blocks * self._hash_block_size()
 

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -1038,8 +1038,11 @@ class Scheduler:
           - prompt longer than `max_num_batched_tokens` AND chunked prefill
             disabled → no single prefill forward can ever fit it (with chunked
             prefill enabled, the prompt is split across steps and this is fine)
-          - prompt's KV blocks (+ per-req cache reservation) exceed the total
-            pool size → never fits even on a fully empty pool
+          - prompt's KV blocks exceed the total pool size → never fits even on
+            a fully empty pool. Counted per-rank (dcp-local, via
+            `BlockManager.num_pool_blocks`) to match how the pool is sized and
+            drawn, so a dcp>1 deployment admits prompts `dcp_world_size` times
+            longer than the global block count alone would suggest.
 
         Called at submit time (`_warn_if_unschedulable`, which logs the
         reason and adds extra dynamic warnings) and at schedule time
@@ -1071,11 +1074,18 @@ class Scheduler:
             )
         bm = self.block_manager
         total_blocks = bm.kv.num_blocks
-        if seq.num_blocks > total_blocks:
+        # `num_pool_blocks`, not `seq.num_blocks`: the latter counts global
+        # blocks, while the pool is sized and drawn per-rank. Under dcp>1 the
+        # two differ by `dcp_world_size`.
+        pool_blocks = bm.num_pool_blocks(num_tokens)
+        if pool_blocks > total_blocks:
+            scope = (
+                f" (per-rank, dcp={bm.dcp_world_size})" if bm.dcp_world_size > 1 else ""
+            )
             return (
-                f"needs {seq.num_blocks} KV blocks for {num_tokens} input tokens "
-                f"> total pool blocks={total_blocks}. Reduce prompt length or "
-                f"raise --gpu-memory-utilization. (Per-req state cache lives in "
+                f"needs {pool_blocks} KV blocks{scope} for {num_tokens} input "
+                f"tokens > total pool blocks={total_blocks}. Reduce prompt length "
+                f"or raise --gpu-memory-utilization. (Per-req state cache lives in "
                 f"its own pre-allocated tensor and does not consume pool blocks.)"
             )
         return None

--- a/docs/scheduling_kv_cache_guide.md
+++ b/docs/scheduling_kv_cache_guide.md
@@ -403,7 +403,7 @@ def can_allocate(self, seq: Sequence) -> int:
     if seq.has_per_req_cache and not self.state.has_free():
         return -1
     if not self.enable_prefix_caching:
-        if not self.kv.has_free(self._dcp_num_blocks(len(seq))):
+        if not self.kv.has_free(self.num_pool_blocks(len(seq))):
             return -1
     # ... (prefix caching dry-run returns the contiguous hit-block count)
 

--- a/tests/test_block_manager.py
+++ b/tests/test_block_manager.py
@@ -142,7 +142,7 @@ class TestPublishLoadedPrefix:
         # from the GPU-only dcp_ops module used to calculate local block counts.
         monkeypatch.setattr(
             bm,
-            "_dcp_num_blocks",
+            "num_pool_blocks",
             lambda seq_len: (seq_len + bm.hash_block_size - 1) // bm.hash_block_size,
         )
         loaded = seq_factory(list(range(16)))


### PR DESCRIPTION
## Motivation

`Scheduler._unschedulable_reason` rejects a prompt whose KV blocks cannot fit the pool even when it is empty. It compared `seq.num_blocks` — `ceil(num_tokens / block_size)`, a **global** count — against `block_manager.kv.num_blocks`, which is a **single rank's** pool. Under decode context parallelism a rank stores only its interleaved shard, so the two are `dcp_world_size` apart and the check rejects prompts that fit comfortably.

