### PR TITLE
fix(engine): a rejected request never reached the client waiting on it

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -529,12 +529,44 @@ def _get_engine_max_model_len() -> int | None:
     return getattr(_get_engine_config(), "max_model_len", None)
 
 
+def _get_engine_max_pool_tokens() -> int | None:
+    """Longest prompt the KV pool can hold, as each engine rank reported it.
+
+    None before the engine is up, or on a manager that never learned it, in
+    which case the scheduler remains the only enforcer.
+    """
+    return getattr(getattr(engine, "core_mgr", None), "max_pool_tokens", None)
+
+
+def _validate_pool_capacity(
+    num_prompt_tokens: int, max_pool_tokens: int | None
+) -> None:
+    """Refuse a prompt whose KV cannot fit even a completely empty pool.
+
+    `max_model_len` is a declared limit; this is a physical one, since the pool
+    is sized from whatever device memory is free once the weights are loaded, so
+    on a tight pool it binds first. The scheduler checks it too, but only once
+    the request reaches the engine — by then the client holds a response it will
+    never be answered on, so the request has to be turned away here instead.
+    """
+    if max_pool_tokens is None or int(num_prompt_tokens) <= int(max_pool_tokens):
+        return
+
+    raise ValueError(
+        f"This server's KV cache holds at most {max_pool_tokens} tokens for a "
+        f"single request, and your prompt contains at least {num_prompt_tokens} "
+        f"input tokens. Please shorten the prompt, or restart the server with a "
+        f"higher --gpu-memory-utilization to enlarge the cache."
+    )
+
+
 def _validate_sequence_context_length(seq) -> None:
     _validate_context_length(
         seq.num_prompt_tokens,
         seq.max_tokens,
         _get_engine_max_model_len(),
     )
+    _validate_pool_capacity(seq.num_prompt_tokens, _get_engine_max_pool_tokens())
 
 
 def _has_multimodal_content(messages: list[Any]) -> bool:

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -317,6 +317,38 @@ class BlockManager:
         )[0]
         return int((local_len + self.block_size - 1) // self.block_size)
 
+    @property
+    def max_pool_tokens(self) -> int:
+        """Longest prompt, in global tokens, whose KV fits an entirely empty pool.
+
+        Bisects `num_pool_blocks`, which is monotone in `seq_len`, rather than
+        inverting it in closed form: under block-level interleaving
+        (`cp_kv_cache_interleave_size > 1`) a rank's share is not a plain
+        `seq_len / dcp_world_size`, and an inverse derived by hand would drift
+        from the allocator as soon as that arithmetic moved. Runs once, at
+        startup.
+
+        Mirrors the ceiling `Scheduler._unschedulable_reason` enforces, so the
+        frontend can predict that verdict and refuse an oversized prompt with an
+        error while it is still answering the client, instead of leaving the
+        scheduler to discover it once the client is already waiting. The API
+        server needs it published because `num_kvcache_blocks` is measured in
+        the engine subprocess and its own Config never learns the value.
+        """
+        capacity = self.kv.num_blocks
+        # A prompt this long needs more than `capacity` blocks on some rank, so
+        # it bounds the search from above: each rank holds at least
+        # `1 / dcp_world_size` of it, i.e. over `capacity` blocks' worth.
+        hi = (capacity + 1) * self.block_size * max(1, self.dcp_world_size)
+        lo = 0
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if self.num_pool_blocks(mid) <= capacity:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo
+
     def _effective_block_size(self):
         return self.block_size * self.dcp_world_size
 

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -222,7 +222,20 @@ class EngineCore:
         maybe_attach_gc_debug_callback(name)
 
     def _send_ready_signal(self):
-        self.output_queue.put_nowait(("READY", None))
+        self.output_queue.put_nowait(("READY", self._ready_payload()))
+
+    def _ready_payload(self) -> dict[str, int] | None:
+        """Startup facts the frontend cannot read off its own Config.
+
+        `num_kvcache_blocks` is measured in this subprocess, so the API server's
+        Config still holds the placeholder. Publishing the derived prompt
+        ceiling rather than the raw block count leaves the dcp arithmetic with
+        its owner, `BlockManager`, and gives the frontend a single number to
+        compare a prompt against.
+        """
+        if self.scheduler is None:
+            return None
+        return {"max_pool_tokens": self.scheduler.block_manager.max_pool_tokens}
 
     def _post_model_load_hook(self):
         """Called after ModelRunner is initialized (model loaded) but before
@@ -574,7 +587,7 @@ class EngineCore:
 
                 if isinstance(item, tuple) and item[0] == "READY":
                     # Send READY signal to indicate EngineCore is fully initialized
-                    obj = pickle.dumps((EngineCoreRequestType.READY, None))
+                    obj = pickle.dumps((EngineCoreRequestType.READY, item[1]))
                     socket.send(obj)
                     logger.debug(f"{self.label}: sent READY signal")
                     continue

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -17,6 +17,7 @@ import zmq.asyncio
 
 from atom.config import Config
 from atom.model_engine.engine_core_protocol import EngineCoreRequestType
+from atom.model_engine.request import RequestOutput
 from atom.model_engine.sequence import Sequence
 from atom.utils import (
     envs,
@@ -188,6 +189,11 @@ class CoreManager:
         # an api_server <-> engine_core_mgr import cycle). Stays None on every
         # path that never streams, which the output thread checks for.
         self._flush_stream_batch_fn = None
+        # Longest prompt the KV pool can hold, reported by each rank's READY.
+        # None until the first one arrives, and thereafter the smallest across
+        # ranks: a DP rank sizes its pool from its own free memory, so a prompt
+        # is only safe to admit if it fits wherever the router sends it.
+        self.max_pool_tokens: int | None = None
         self.engine_core_processes = []
         self.input_sockets = []
         self.output_sockets = []
@@ -477,6 +483,18 @@ class CoreManager:
         self._output_handler_task = None
         self._asyncio_mode = config.asyncio_mode
 
+    def _record_ready_payload(self, data) -> None:
+        """Fold one rank's READY facts into the manager's view of capacity."""
+        if not data:
+            return
+        reported = data.get("max_pool_tokens")
+        if reported is None:
+            return
+        if self.max_pool_tokens is None:
+            self.max_pool_tokens = reported
+        else:
+            self.max_pool_tokens = min(self.max_pool_tokens, reported)
+
     def _wait_for_all_ready_signals(self):
         """Wait for READY signals from all DP ranks in parallel (no timeout)."""
         poller = zmq.Poller()
@@ -505,6 +523,7 @@ class CoreManager:
                     logger.info(
                         f"{self.label}: DP rank {dp_rank} is fully initialized and ready"
                     )
+                    self._record_ready_payload(data)
                     ready_received[dp_rank] = True
                     remaining -= 1
                 elif request_type == EngineCoreRequestType.SHUTDOWN:
@@ -610,8 +629,32 @@ class CoreManager:
                         seqs = data
                         # Offline (non-streaming) completions arrive here as
                         # finished sequences; release their in-flight DP load.
+                        #
+                        # So do sequences the scheduler rejected before they
+                        # ever ran (`_unschedulable_reason`, abort-while-waiting)
+                        # — those never reach `postprocess`, so no STREAM chunk
+                        # is ever built for them. An online client is still
+                        # holding a callback and would wait forever, so the
+                        # terminal output it is owed has to be raised here.
+                        # Anything already delivered through STREAM has had its
+                        # callback popped by then (STREAM is enqueued ahead of
+                        # the finished-seq list and this socket is FIFO), so a
+                        # normal completion finds nothing to do below.
+                        delivered = False
                         for seq in seqs:
+                            delivered |= self._deliver_terminal_output(seq)
                             self._release_seq_load(seq.id)
+                        if delivered and self._flush_stream_batch_fn is not None:
+                            # The callbacks above only buffer into a thread-local;
+                            # without this flush the chunk never reaches the
+                            # request's collector and the client still hangs.
+                            try:
+                                self._flush_stream_batch_fn()
+                            except Exception as e:
+                                logger.warning(
+                                    f"{self.label}: flush_stream_batch failed: {e}",
+                                    exc_info=True,
+                                )
                         self.outputs_queue.put_nowait(seqs)
             finally:
                 # Close sockets.
@@ -956,6 +999,47 @@ class CoreManager:
         self._rank_reqs[dp_rank] += req_cost
         self._rank_tokens[dp_rank] += tok_cost
         self._seq_load[seq.id] = (dp_rank, req_cost, tok_cost)
+
+    def _deliver_terminal_output(self, seq) -> bool:
+        """Give an online client the terminal output for a seq that never streamed.
+
+        A sequence the scheduler rejected before it ran produced no tokens and
+        no STREAM chunk, so nothing has answered the client yet. Synthesises the
+        finished `RequestOutput` the normal path would have built in
+        `postprocess`, carrying `leave_reason` as the finish reason so the
+        response says why it ended rather than closing empty.
+
+        Returns whether a callback was invoked, so the caller knows to flush the
+        batch the callback buffered into. Offline sequences register no callback
+        and normal completions have had theirs popped by the STREAM that
+        delivered them, so both answer False and keep their existing path.
+        """
+        callback = self._seq_id_to_callback.pop(seq.id, None)
+        if callback is None:
+            return False
+        # Never empty: an empty reason reaches the client as `finish_reason:
+        # null`, which the OpenAI schema reserves for a choice still being
+        # generated -- so a client would keep waiting on a finished stream.
+        reason = seq.leave_reason or "rejected"
+        try:
+            callback(
+                RequestOutput(
+                    request_id=seq.id,
+                    output_tokens=[],
+                    finished=True,
+                    finish_reason=reason,
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                f"Error delivering terminal output for sequence {seq.id}: {e}",
+                exc_info=True,
+            )
+            return False
+        logger.info(
+            "%s: seq %s returned without running: %s", self.label, seq.id, reason
+        )
+        return True
 
     def _release_seq_load(self, seq_id) -> None:
         """Undo a seq's in-flight load when it finishes or is aborted.
@@ -1379,8 +1463,9 @@ class DisaggCoreManager(CoreManager):
         sock = self.output_sockets[idx]
         while True:
             obj = sock.recv(copy=False)
-            request_type, _ = pickle.loads(obj)
+            request_type, data = pickle.loads(obj)
             if request_type == EngineCoreRequestType.READY:
+                self._record_ready_payload(data)
                 return
             if request_type == EngineCoreRequestType.SHUTDOWN:
                 raise RuntimeError(


### PR DESCRIPTION
## Motivation

A sequence the scheduler refuses before it ever runs is marked FINISHED and routed through `_rejected`, which leaves the engine as an `ADD` message. `CoreManager`'s `ADD` branch serves the offline `llm.generate()` queue — it releases DP load and pushes to `outputs_queue`, and never touches `_seq_id_to_callback`. So an online client's callback was never invoked: the SSE stream stayed open, no chunk was ever sent, and the request hung until the client gave up.

The path was not wrong for what it was built for. `_rejected` carries aborts, where the client is already gone, and offline generation, which reads that queue. An unschedulable prompt is the one case where an online client is still waiting on the other end, and it had no delivery.
