### PR TITLE
perf(spec-decode): warm every draft forward at a batch the target captured

### DIFF
--- a/.claude/skills/capture-trace/SKILL.md
+++ b/.claude/skills/capture-trace/SKILL.md
@@ -154,9 +154,16 @@ ATOM annotates the critical path with `torch.profiler.record_function`. The **ki
 | `dummy_decode[...]` | **DP-sync dummy** (idle rank keeps the MoE collective aligned) |
 | `dummy_eager_decode[...]` | DP-sync dummy, forced eager |
 | `dummy_prefill[...]` | warmup dummy prefill |
-| `draft[i/k bs=]` | eagle/MTP draft mid-step |
+| `propose_eagle[i/k tok= bs=<real>/<pad> (graph)]` | eagle/MTP draft step `i` of `k` |
+| `propose_dspark[bs=<real>/<pad> T= (graph)]` | DSpark block draft (one parallel pass) |
+| `draft_kv[bs= tok=]` | DSpark rolling-window KV write, after every target forward |
+| `dspark_sched[bs=]` | DSpark confidence-schedule ell computation |
 
-Fields: `bs` effective (real) batch — on the CUDAGraph path shown as `bs=<real>/<graph>` (e.g. `bs=117/128`) when the replayed graph is padded above the real batch; `tok` total tokens, `ctx` per-seq context lens (truncated if many), `p`/`d` prefill/decode seq counts, `spec` speculative steps, and **`tbo=1`** appended when the step ran Two-Batch-Overlap ubatches.
+Every drafter's propose pass shares the `propose_` prefix, so one grep covers all flavors; `draft_kv` and `dspark_sched` keep their own names because neither is a propose. The `/<pad>` field marks a pass that *can* pad — eagle's step 0 cannot, so it carries no field at all — and padding actually happened only when the two numbers differ (`bs=44/44` is a pass that declined). The trailing ` graph` is the one that appears only on a replay, which makes "did the draft get into a graph" a grep rather than an inference.
+
+`bs` and `tok` are different counts on purpose: `bs` is sequences, `tok` the rows of that particular forward. An eagle step 0 runs the whole token stream while steps 1+ run one row per sequence, and the draft's shape-driven JIT tracks `tok`.
+
+Fields: `bs` effective (real) batch — on the CUDAGraph path shown as `bs=<real>/<graph>` (e.g. `bs=117/128`), the second number being the shape actually run, equal to the first when nothing was padded; `tok` total tokens, `ctx` per-seq context lens (truncated if many), `p`/`d` prefill/decode seq counts, `spec` speculative steps, and **`tbo=1`** appended when the step ran Two-Batch-Overlap ubatches.
 
 Distinguishing dummy vs real matters: e.g. the leading `dummy_decode[bs=1 tok=1]` runs are DP-sync idle steps, NOT real decode. `parse_trace.py` matches only the exact `prefill[` / `decode[` prefixes, so dummy/eager variants are auto-excluded from its stats.
 

--- a/atom/config.py
+++ b/atom/config.py
@@ -1869,17 +1869,17 @@ class Config:
         # only for server mode or plugin mode(vllm)
         # for torch compile policy, plugin mode(vllm) uses the ATOM compile policy
         # for cuda graph capture, plugin mode(vllm) uses the vLLM's cuda graph capture policy
-        if not is_plugin_mode() or (
-            self.plugin_config is not None and self.plugin_config.is_vllm
-        ):
-            if self.compilation_config.level == CompilationLevel.PIECEWISE:
-                self.compilation_config.set_splitting_ops_for_v1()
-                # Keep an explicit cudagraph_mode (e.g. FULL); default to
-                # PIECEWISE only when unset. splitting_ops/sizes are set either
-                # way so the model is still piece-split-compiled at level 3.
-                if self.compilation_config.cudagraph_mode is None:
-                    self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
-                self.compilation_config.init_with_cudagraph_sizes()
+        if (
+            not is_plugin_mode()
+            or (self.plugin_config is not None and self.plugin_config.is_vllm)
+        ) and self.compilation_config.level == CompilationLevel.PIECEWISE:
+            self.compilation_config.set_splitting_ops_for_v1()
+            # Keep an explicit cudagraph_mode (e.g. FULL); default to
+            # PIECEWISE only when unset. splitting_ops/sizes are set either
+            # way so the model is still piece-split-compiled at level 3.
+            if self.compilation_config.cudagraph_mode is None:
+                self.compilation_config.cudagraph_mode = CUDAGraphMode.PIECEWISE
+            self.compilation_config.init_with_cudagraph_sizes()
 
         self.torch_dtype = (
             self.hf_config.dtype

--- a/atom/config.py
+++ b/atom/config.py
@@ -1545,7 +1545,6 @@ class Config:
     # sizes the process group and the token collectives.
     dp_logical_size: int = 0
     master_addr: str = "127.0.0.1"
-    graph_bs: list[int] | None = None
     enable_dp_attention: bool = False
     # DP request-routing strategy used by CoreManager to pick an engine rank:
     # "round_robin" | "least_requests" (default) | "least_tokens". Only has an
@@ -1634,17 +1633,22 @@ class Config:
         visible = torch.cuda.device_count()
         return visible if 0 < visible < tp else tp
 
-    def _set_cudagraph_sizes(self):
-        if self.compilation_config.cudagraph_capture_sizes:
-            self.graph_bs = self.compilation_config.cudagraph_capture_sizes
-        else:
-            cuda_graph_sizes = self.compilation_config.cuda_graph_sizes
-            if len(cuda_graph_sizes) == 1:
-                self.graph_bs = [1, 2, 4, 8] + [
-                    i for i in range(16, cuda_graph_sizes[0] + 1, 16)
-                ]
-            elif len(cuda_graph_sizes) > 1:
-                self.graph_bs = cuda_graph_sizes
+    @property
+    def capture_sizes(self) -> list[int]:
+        """The declared CUDAGraph capture ladder, in batch sizes.
+
+        Declared, not schedulable -- `ModelRunner` drops what its own token
+        budget can never produce, a bound needing the drafter's resolved
+        `mtp_k` that config cannot see. Returns a copy: the runner sorts and
+        filters in place.
+        """
+        declared = self.compilation_config.cudagraph_capture_sizes
+        if declared:
+            return list(declared)
+        sizes = self.compilation_config.cuda_graph_sizes
+        if len(sizes) == 1:
+            return [1, 2, 4, 8] + list(range(16, sizes[0] + 1, 16))
+        return list(sizes)
 
     def __post_init__(self):
         self.moe_backend = self.moe_backend.strip().lower()
@@ -1870,7 +1874,6 @@ class Config:
         ):
             if self.compilation_config.level == CompilationLevel.PIECEWISE:
                 self.compilation_config.set_splitting_ops_for_v1()
-                self._set_cudagraph_sizes()
                 # Keep an explicit cudagraph_mode (e.g. FULL); default to
                 # PIECEWISE only when unset. splitting_ops/sizes are set either
                 # way so the model is still piece-split-compiled at level 3.

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2555,7 +2555,7 @@ class ModelRunner:
         bs = batch.total_seqs_num
         scheduled_tokens = batch.total_tokens_num
         num_scheduled_tokens = np.asarray(batch.num_scheduled_tokens)
-        cu_seqlens_q, arange = self._get_cumsum_and_arange(num_scheduled_tokens)
+        cu_seqlens_q, _arange = self._get_cumsum_and_arange(num_scheduled_tokens)
         if preprocessed is None:
             preprocessed = self._preprocess(
                 batch,
@@ -2567,7 +2567,7 @@ class ModelRunner:
             running_tokens,
             num_tokens_across_dp,
             dp_uniform_decode,
-            max_tokens,
+            _max_tokens,
             tbo_collective_active,
             ub_max_tokens_across_dp,
             _dspark_shape_max,

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -9,6 +9,7 @@ import math
 import os
 import time
 from contextlib import contextmanager, nullcontext
+from functools import partial
 from typing import Any, NamedTuple
 
 import numpy as np
@@ -4305,8 +4306,20 @@ class ModelRunner:
                         prof.step()
                         self._capture_trace_tag = None
             # Inside the `with`: graph_capture() arms the custom all-reduce for
-            # capture and pause_gc() keeps the collector from aborting one.
-            self._warmup_draft_graphs(full_q_len, capture_ctx.stream)
+            # capture and pause_gc() keeps the collector from aborting one. The
+            # drafter gets the capture builder already bound to this backend's
+            # signature -- which of them takes a `max_q_len` is the runner's to
+            # know, and it is the same probe the loop above ran.
+            if hasattr(self, "drafter"):
+                self.drafter.warmup_draft_graphs(
+                    (
+                        partial(build_capture, max_q_len=full_q_len)
+                        if supports_dynamic_q_len
+                        else build_capture
+                    ),
+                    full_q_len,
+                    capture_ctx.stream,
+                )
         self.graph_bs.sort(reverse=False)
 
         # PIECEWISE: sorted 1D num_tokens buckets for run_model's round_up_1d(Σ)
@@ -4359,56 +4372,6 @@ class ModelRunner:
             )
 
         return time.time() - start_time, self.graph_bs, _pool_bytes
-
-    @torch.inference_mode()
-    def _warmup_draft_graphs(self, max_q_len: int, stream) -> None:
-        """Run every declared draft pass once per `graph_bs`, paying its JIT here.
-
-        aiter's flydsl hgemm builds a kernel per tile config, in-process, so a
-        batch first seen mid-serve stalls that step and every restart pays
-        again: `hipModuleLoadData` per rank went 6 -> 0 on the 16k/20/50c
-        reproducer, with this and the drafter's rounding.
-
-        Warming `self.graph_bs` is the point -- the drafter rounds up to that
-        same list, so warmed and reachable are one set by construction rather
-        than two that drift.
-
-        Call INSIDE ``graph_capture()`` (it arms the custom all-reduce for the
-        optional capture) and after ``allocate_kv_cache``, so the builder's
-        context has real ring slots and ``is_dummy_run=False``.
-        """
-        drafter = getattr(self, "drafter", None)  # unset when spec decode is off
-        if drafter is None or not drafter.draft_graphs:
-            return
-        build_capture = self.attn_metadata_builder.build_for_cudagraph_capture
-        # Only DeepSeek-V4's builder takes `max_q_len`; the rest raise TypeError
-        # on the keyword. Probed the same way the main capture loop does.
-        supports_dynamic_q_len = (
-            "max_q_len" in inspect.signature(build_capture).parameters
-        )
-        start = time.time()
-        for pass_ in drafter.draft_graphs:
-            for bs in self.graph_bs:
-                attn_metadata, context = (
-                    build_capture(bs=bs, max_q_len=max_q_len)
-                    if supports_dynamic_q_len
-                    else build_capture(bs=bs)
-                )
-                set_forward_context(
-                    attn_metadata=attn_metadata,
-                    atom_config=self.config,
-                    context=context,
-                    num_tokens=bs * max_q_len,
-                )
-                self.graph_pool = pass_.warmup(bs, pool=self.graph_pool, stream=stream)
-        torch.cuda.synchronize()
-        if self.rank == 0:
-            logger.info(
-                "Draft passes warmed at %s in %.2fs: %s",
-                list(self.graph_bs),
-                time.time() - start,
-                [g.name for g in drafter.draft_graphs],
-            )
 
     @torch.inference_mode()
     def _maybe_calibrate_dspark_sps(self, max_q_len: int, n_iters: int = 20) -> None:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -254,6 +254,14 @@ class tokenIDProcessor:
             cpu_tensor = gpu_tensor.to("cpu", non_blocking=True)
             event = torch.cuda.Event()
             event.record(self.async_copy_stream)
+        # No reverse wait here. `gpu_tensor` is a draft pass's captured output,
+        # so its address is fixed and the NEXT replay rewrites it -- but that
+        # replay sits behind a whole target forward on the default stream, while
+        # this copy is a few KB. Ordering the default stream against it would
+        # stall it for the copy every step, which is the overlap the side stream
+        # exists to buy. If a future change ever puts a replay closer than one
+        # forward away, the wait belongs immediately before THAT replay, not
+        # here.
         self.draft_token_ids_cpu.append((cpu_tensor, event))
 
     def recv_async_output_draft(self) -> np.ndarray:
@@ -3412,14 +3420,14 @@ class ModelRunner:
         # Runs after EVERY target forward -- `postprocess` (hence propose) is
         # skipped for a middle chunk. Not on the aligning step: that pass is one
         # the peers never mirror.
-        run_context_pass = (
+        run_compute_draft_kv = (
             drafter is not None
             and not pp_non_last
             and not batch.is_dummy_run
-            and not (will_align_draft and drafter.precompute_duplicates_propose)
+            and not (will_align_draft and drafter.draft_kv_duplicates_propose)
         )
-        if run_context_pass:
-            drafter.precompute_context_kv(
+        if run_compute_draft_kv:
+            drafter.compute_draft_kv(
                 get_forward_context().context.positions,
                 hidden_states,
                 batch.next_token_ids,
@@ -4296,6 +4304,9 @@ class ModelRunner:
                     if prof is not None:
                         prof.step()
                         self._capture_trace_tag = None
+            # Inside the `with`: graph_capture() arms the custom all-reduce for
+            # capture and pause_gc() keeps the collector from aborting one.
+            self._warmup_draft_graphs(full_q_len, capture_ctx.stream)
         self.graph_bs.sort(reverse=False)
 
         # PIECEWISE: sorted 1D num_tokens buckets for run_model's round_up_1d(Σ)
@@ -4348,6 +4359,56 @@ class ModelRunner:
             )
 
         return time.time() - start_time, self.graph_bs, _pool_bytes
+
+    @torch.inference_mode()
+    def _warmup_draft_graphs(self, max_q_len: int, stream) -> None:
+        """Run every declared draft pass once per `graph_bs`, paying its JIT here.
+
+        aiter's flydsl hgemm builds a kernel per tile config, in-process, so a
+        batch first seen mid-serve stalls that step and every restart pays
+        again: `hipModuleLoadData` per rank went 6 -> 0 on the 16k/20/50c
+        reproducer, with this and the drafter's rounding.
+
+        Warming `self.graph_bs` is the point -- the drafter rounds up to that
+        same list, so warmed and reachable are one set by construction rather
+        than two that drift.
+
+        Call INSIDE ``graph_capture()`` (it arms the custom all-reduce for the
+        optional capture) and after ``allocate_kv_cache``, so the builder's
+        context has real ring slots and ``is_dummy_run=False``.
+        """
+        drafter = getattr(self, "drafter", None)  # unset when spec decode is off
+        if drafter is None or not drafter.draft_graphs:
+            return
+        build_capture = self.attn_metadata_builder.build_for_cudagraph_capture
+        # Only DeepSeek-V4's builder takes `max_q_len`; the rest raise TypeError
+        # on the keyword. Probed the same way the main capture loop does.
+        supports_dynamic_q_len = (
+            "max_q_len" in inspect.signature(build_capture).parameters
+        )
+        start = time.time()
+        for pass_ in drafter.draft_graphs:
+            for bs in self.graph_bs:
+                attn_metadata, context = (
+                    build_capture(bs=bs, max_q_len=max_q_len)
+                    if supports_dynamic_q_len
+                    else build_capture(bs=bs)
+                )
+                set_forward_context(
+                    attn_metadata=attn_metadata,
+                    atom_config=self.config,
+                    context=context,
+                    num_tokens=bs * max_q_len,
+                )
+                self.graph_pool = pass_.warmup(bs, pool=self.graph_pool, stream=stream)
+        torch.cuda.synchronize()
+        if self.rank == 0:
+            logger.info(
+                "Draft passes warmed at %s in %.2fs: %s",
+                list(self.graph_bs),
+                time.time() - start,
+                [g.name for g in drafter.draft_graphs],
+            )
 
     @torch.inference_mode()
     def _maybe_calibrate_dspark_sps(self, max_q_len: int, n_iters: int = 20) -> None:

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -577,7 +577,7 @@ class tokenIDProcessor:
         )
 
         # CUDAGraph tail padding. A replayed decode graph reads a fixed
-        # `graph_bs * tokens_per_seq` tokens out of this persistent buffer, but a
+        # `running_bs * tokens_per_seq` tokens out of this buffer, but a
         # step writes only the `total` it scheduled, and `bs` sits between two
         # captured buckets on most steps -- a 65-request batch replays the 128
         # graph, so 63 requests' worth of slots are never written. Nobody else
@@ -587,7 +587,9 @@ class tokenIDProcessor:
         # id, so the embedding gather stays in bounds either way.
         fill_to = total
         if not self.runner.enforce_eager:
-            gbs = next((g for g in reversed(self.runner.graph_bs) if g >= bs), None)
+            gbs = next(
+                (g for g in reversed(self.runner.capture_sizes) if g >= bs), None
+            )
             if gbs is not None:
                 fill_to = max(fill_to, int(gbs) * tokens_per_seq)
         if fill_to > total:
@@ -673,7 +675,7 @@ class ModelRunner:
 
         self._setup_device_and_distributed(rank, config)
 
-        self.graph_bs = [0]  # for eager fallback
+        self.capture_sizes = [0]  # for eager fallback
         # PIECEWISE cudagraph state, populated by capture_cudagraph. Empty when
         # capture never ran (enforce_eager), so the ragged-bucket paths no-op.
         self._piecewise_captured_tokens: set[int] = set()
@@ -2079,7 +2081,7 @@ class ModelRunner:
         batch,
         is_prefill,
         scheduled_bs,
-        actual_num_tokens,
+        scheduled_tokens,
         num_scheduled_tokens,
         tbo_collective_active: bool,
     ):
@@ -2098,7 +2100,7 @@ class ModelRunner:
         # so we don't desync from peers and hang.
         ubatch_slices = maybe_create_ubatch_slices(
             num_reqs=tbo_num_reqs,
-            num_tokens=actual_num_tokens,
+            num_tokens=scheduled_tokens,
             is_prefill=is_prefill,
             num_scheduled_tokens=num_scheduled_tokens if is_prefill else None,
             force=True,
@@ -2128,11 +2130,11 @@ class ModelRunner:
         to apply via ``_apply_dspark_shape_max``.
 
         Returns:
-            (num_input_tokens, num_tokens_across_dp, dp_uniform_decode,
+            (running_tokens, num_tokens_across_dp, dp_uniform_decode,
              max_tokens, tbo_collective_active, ub_max_tokens_across_dp,
              dspark_shape_max)
         """
-        num_input_tokens = batch.total_tokens_num
+        scheduled_tokens = batch.total_tokens_num
         is_prefill = batch.total_tokens_num_prefill > 0
         tbo_on = self.config.enable_tbo
         dp_size = self.config.parallel_config.data_parallel_size
@@ -2215,11 +2217,12 @@ class ModelRunner:
             # be forced into eager and lose the CUDAGraph decode path.
             self._dspark_decode_replay = True
             self._eplb_any_rank_has_prefill = None
+            # One rank pads to nobody, so running == scheduled here.
             return (
-                num_input_tokens,
+                scheduled_tokens,
                 None,
                 True,
-                num_input_tokens,
+                scheduled_tokens,
                 local_meets_min_tokens and local_can_split,
                 None,
                 dspark_shape,
@@ -2228,7 +2231,7 @@ class ModelRunner:
         sync = sync_dp_metadata(
             dp_group=get_dp_group().cpu_group,
             dp_size=dp_size,
-            num_input_tokens=num_input_tokens,
+            scheduled_tokens=scheduled_tokens,
             is_prefill=is_prefill,
             tbo_on=tbo_on,
             local_meets_min_tokens=local_meets_min_tokens,
@@ -2245,15 +2248,15 @@ class ModelRunner:
         dp_uniform_decode = (not sync.any_rank_has_prefill) or (
             not self.config.enable_dp_attention
         )
-        if dp_uniform_decode:
-            # CUDAGraph path: all ranks pad to the same max for fixed-size all_gather.
-            num_input_tokens = max_tokens
-        # else: variable-length path — each rank keeps its own token count.
+        # Only here does the count stop being this rank's own: under uniform
+        # decode every rank pads to the same max for a fixed-size all_gather.
+        # The variable-length path keeps its own, so the two stay equal.
+        running_tokens = max_tokens if dp_uniform_decode else scheduled_tokens
 
         self._dspark_decode_replay = dp_uniform_decode
 
         return (
-            num_input_tokens,
+            running_tokens,
             sync.num_tokens_across_dp,
             dp_uniform_decode,
             max_tokens,
@@ -2550,6 +2553,7 @@ class ModelRunner:
         # cached _preprocess tuple here so we DON'T issue a second all_gather.
         is_prefill = batch.total_tokens_num_prefill > 0
         bs = batch.total_seqs_num
+        scheduled_tokens = batch.total_tokens_num
         num_scheduled_tokens = np.asarray(batch.num_scheduled_tokens)
         cu_seqlens_q, arange = self._get_cumsum_and_arange(num_scheduled_tokens)
         if preprocessed is None:
@@ -2560,7 +2564,7 @@ class ModelRunner:
             )
             self._apply_dspark_shape_max(batch, preprocessed[6])
         (
-            num_input_tokens,
+            running_tokens,
             num_tokens_across_dp,
             dp_uniform_decode,
             max_tokens,
@@ -2581,12 +2585,12 @@ class ModelRunner:
         self.forward_vars["cu_seqlens_q"].np[1 : bs + 1] = cu_seqlens_q
 
         # mtp_step = per-seq decode token count, used by ForwardMode.decide to
-        # recover batch size as num_input_tokens // mtp_step. This is exactly
+        # recover batch size as running_tokens // mtp_step. This is exactly
         # the batch's single-source-of-truth decode length (= mtp_k+1, or the
-        # DSpark q-bucket when shrunk); num_input_tokens = scheduled_bs *
+        # DSpark q-bucket when shrunk); running_tokens = scheduled_bs *
         # num_spec_query_tokens, so the division recovers bs correctly. Prefill
         # has no drafter / uses 1.
-        decide_num_input_tokens = num_input_tokens
+        decide_running_tokens = running_tokens
         dp_bs = batch.dspark_dp_bs
         is_ragged = (
             getattr(batch, "dynamic_spec_query_tokens_per_req", None) is not None
@@ -2602,28 +2606,39 @@ class ModelRunner:
             q_eff = int(batch.num_spec_query_tokens)
             eff_bs = dp_bs if dp_bs is not None else batch.total_seqs_num_decode
             mtp_step = q_eff
-            decide_num_input_tokens = int(eff_bs) * q_eff
+            decide_running_tokens = int(eff_bs) * q_eff
         elif not is_prefill and hasattr(self, "drafter"):
             mtp_step = batch.num_spec_query_tokens
         else:
             mtp_step = (self.drafter.mtp_k + 1) if hasattr(self, "drafter") else 1
         forward_mode = ForwardMode.decide(
             is_prefill=is_prefill,
-            total_seqs_num=batch.total_seqs_num,
-            scheduled_bs_decode=batch.total_seqs_num_decode,
-            num_input_tokens=decide_num_input_tokens,
+            # `total_seqs_num`, not `total_seqs_num_prefill`: equal today, and
+            # the one that stays right once a prefill batch may also carry
+            # decode rows -- they go through the same attention call.
+            scheduled_bs=(
+                batch.total_seqs_num if is_prefill else batch.total_seqs_num_decode
+            ),
+            running_tokens=decide_running_tokens,
             dp_uniform_decode=dp_uniform_decode,
             enforce_eager=self.enforce_eager,
-            graph_bs=self.graph_bs,
+            capture_sizes=self.capture_sizes,
             mtp_step=mtp_step,
         )
 
         if not is_prefill:
-            scheduled_bs = batch.total_seqs_num_decode
-            bs = forward_mode.effective_bs  # single source of truth
-            assert bs >= scheduled_bs, (
-                f"effective_bs={bs} < scheduled_bs={scheduled_bs}; "
-                f"ForwardMode.decide invariant violated"
+            scheduled_bs = forward_mode.scheduled_bs
+            # Attention reads the padded width only where its tensors carry the
+            # padding; eager keeps the scheduled rows so aiter's t == t_slot
+            # holds against the local input_ids.
+            bs = (
+                forward_mode.running_bs
+                if forward_mode.attn_tensors_are_padded
+                else scheduled_bs
+            )
+            assert forward_mode.running_bs >= scheduled_bs, (
+                f"running_bs={forward_mode.running_bs} < "
+                f"scheduled_bs={scheduled_bs}; ForwardMode.decide invariant violated"
             )
             # Only pad cu_seqlens_q out to the cudagraph capture size if we
             # actually grew bs. Eager (bs == scheduled_bs) leaves the slice
@@ -2633,29 +2648,32 @@ class ModelRunner:
                     self.forward_vars["cu_seqlens_q"].np[scheduled_bs]
                 )
         attn_metadata, positions = self.attn_metadata_builder.build(batch=batch, bs=bs)
-        context_bs = batch.total_seqs_num_prefill if is_prefill else scheduled_bs
 
-        # MoE's pad_for_all_gather reads context.graph_bs to pad hidden_states
-        # before a cross-DP all_gather, so it must be unified across DP ranks
-        # under uniform decode (where pad path is taken). Use forward_mode's
-        # moe_pad_bs, which equals effective_bs except in the uniform-eager
-        # corner (enforce_eager / bs>graph_bs[-1]) where attention needs local
-        # but MoE pad needs the DP-unified padded_scheduled_bs.
-        graph_bs = num_input_tokens if is_prefill else forward_mode.moe_pad_bs
+        # The step's padded shape, in the two units its consumers read. Both
+        # must be identical on every DP rank: MoE pads hidden_states to
+        # `running_tokens` before the cross-DP all_gather, and a captured graph
+        # holds its collective at `running_bs`.
+        running_bs = forward_mode.running_bs
+        if not is_prefill:
+            # Prefill keeps whatever `_preprocess` settled on -- padded to the
+            # group max under uniform decode, its own count otherwise. Decode
+            # recomputes from the batch `decide` rounded up to, which is wider
+            # than that count whenever it landed on a captured size.
+            running_tokens = running_bs * int(attn_metadata.max_seqlen_q)
         drafter = getattr(self, "drafter", None)
         if not is_prefill and drafter is not None and drafter.is_block_drafter:
-            graph_bs = self._dspark_ragged_moe_graph_bs(batch, graph_bs)
+            running_tokens = self._dspark_ragged_running_tokens(batch, running_tokens)
         context = Context(
             positions=positions,
             is_prefill=is_prefill,
             is_dummy_run=batch.is_dummy_run,
-            batch_size=context_bs,
-            graph_bs=graph_bs,
+            scheduled_bs=forward_mode.scheduled_bs,
+            scheduled_tokens=scheduled_tokens,
+            running_bs=running_bs,
+            running_tokens=running_tokens,
             dp_uniform_decode=dp_uniform_decode,
             forward_mode=forward_mode,
         )
-
-        actual_num_tokens = batch.total_tokens_num
 
         spec_decode_metadata = None
         if not is_prefill and hasattr(self, "drafter") and not batch.is_dummy_run:
@@ -2685,7 +2703,7 @@ class ModelRunner:
                 batch,
                 is_prefill,
                 scheduled_bs if not is_prefill else 0,
-                actual_num_tokens,
+                scheduled_tokens,
                 num_scheduled_tokens,
                 tbo_collective_active,
             )
@@ -2694,13 +2712,12 @@ class ModelRunner:
             attn_metadata=attn_metadata,
             atom_config=self.config,
             context=context,
-            num_tokens=actual_num_tokens,
+            num_tokens=scheduled_tokens,
             num_tokens_across_dp=num_tokens_across_dp,
             spec_decode_metadata=spec_decode_metadata,
             ubatch_slices=ubatch_slices,
             ub_max_tokens_across_dp=ub_max_tokens_across_dp,
         )
-        return graph_bs
 
     def prepare_sample(
         self, batch: ScheduledBatch
@@ -3011,7 +3028,7 @@ class ModelRunner:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         forward_context = get_forward_context()
         context = forward_context.context
-        bs = context.batch_size
+        bs = context.scheduled_bs
         is_prefill = context.is_prefill
         positions = context.positions
 
@@ -3037,10 +3054,8 @@ class ModelRunner:
             use_cudagraph=forward_mode.use_cudagraph,
             is_dummy=context.is_dummy_run,
             tbo_on=forward_context.ubatch_slices is not None,
-            bs=bs,
-            # The CUDAGraph replays a padded batch (context.graph_bs); pass it so
-            # the label shows bs=<real>/<graph> when they differ.
-            graph_bs=context.graph_bs if forward_mode.use_cudagraph else None,
+            scheduled_bs=bs,
+            running_bs=context.running_bs,
             batch=batch,
             detailed_suffix=self._detailed_label_suffix(batch),
         )
@@ -3165,13 +3180,13 @@ class ModelRunner:
             # decode[bs=128 tok=128 d=128] / decode[... p=2 d=126 spec=3] /
             # dummy_decode[...] — see build_run_label.
             with record_function(label):
-                graph_bs = context.graph_bs
+                running_bs = context.running_bs
                 max_q_len = forward_context.attn_metadata.max_seqlen_q
-                num_tokens = context.batch_size * max_q_len  # real (output slice)
+                num_tokens = context.scheduled_bs * max_q_len  # real (output slice)
 
                 if self._piecewise_cg_active():
                     num_tokens_pad, real_tokens, _captured = (
-                        self._piecewise_replay_shape(batch, graph_bs, max_q_len)
+                        self._piecewise_replay_shape(batch, running_bs, max_q_len)
                     )
                     # Pad tail to a legal vocab id / position (builder fills to
                     # graph_cap >= num_tokens_pad, so a no-op safety net).
@@ -3211,7 +3226,7 @@ class ModelRunner:
                     logits = self.model.compute_logits(hidden_states)
                     return logits, hidden_states
 
-                graph_key = (graph_bs, max_q_len)
+                graph_key = (running_bs, max_q_len)
                 self.graphs[graph_key].replay()
                 hidden_states = self.forward_vars["outputs"][:num_tokens]
                 # Drafter aux buffers (if any) refresh on replay: their in-place
@@ -3642,7 +3657,7 @@ class ModelRunner:
                 # The window is named from the tag the capture loop stashes
                 # before each prof.step(), not from a step counter: batch sizes
                 # are skipped (_piecewise_skip_capture) and repeated (once per
-                # q-bucket), so any index into self.graph_bs drifts out of sync
+                # q-bucket), so any index into self.capture_sizes drifts out of sync
                 # with what was actually captured.
                 #
                 # A cleared tag means this is the trailing window that opens
@@ -3782,7 +3797,7 @@ class ModelRunner:
                 return int(b)
         return None
 
-    def _piecewise_replay_shape(self, batch, graph_bs, max_q_len):
+    def _piecewise_replay_shape(self, batch, running_bs, max_q_len):
         """Pick the PIECEWISE replay token count for one decode step.
 
         Returns ``(num_tokens_pad, real_tokens, captured)``:
@@ -3817,23 +3832,20 @@ class ModelRunner:
             for b in buckets:
                 if b >= real_tokens and q > 0 and b % q == 0:
                     return b, real_tokens, _replay
-            return max(real_tokens, graph_bs * max_q_len), real_tokens, False
+            return max(real_tokens, running_bs * max_q_len), real_tokens, False
 
-        num_tokens_pad = graph_bs * max_q_len
+        num_tokens_pad = running_bs * max_q_len
         captured = num_tokens_pad in self._piecewise_captured_tokens
         return num_tokens_pad, num_tokens_pad, captured
 
-    def _dspark_ragged_moe_graph_bs(self, batch, default_graph_bs):
-        """MoE all_gather pad row count for a DSpark ragged PIECEWISE decode step.
+    def _dspark_ragged_running_tokens(self, batch, default_running_tokens):
+        """``running_tokens`` for a DSpark ragged PIECEWISE decode step.
 
-        ``context.graph_bs`` is what MoE's ``pad_for_all_gather`` pads
-        hidden_states to before the cross-DP all_gather, so every DP rank must
-        agree on it. But DSpark ragged does NOT replay at a rectangular bs*q
-        grid: it replays at the flat num_tokens bucket ``_piecewise_replay_shape``
-        picks from the DP-max total token count. Derive graph_bs from that SAME
-        bucket (bucket // q) so the padded row count matches the tokens actually
-        forwarded. Falls back to ``default_graph_bs`` when this isn't a DSpark
-        ragged step or the bucket isn't an exact multiple of q.
+        A ragged step replays at a flat num_tokens bucket, not a rectangular
+        bs*q grid, so the height MoE pads to IS that bucket. Picking the same
+        one ``_piecewise_replay_shape`` will (hence the identical q-divisibility
+        filter) is what keeps the eager ranks' all_gather equal to the size
+        baked into the replaying ranks' graph.
         """
         dp_total_tokens = batch.dspark_dp_total_tokens
         if (
@@ -3841,18 +3853,12 @@ class ModelRunner:
             or dp_total_tokens is None
             or not self._piecewise_sorted_tokens
         ):
-            return default_graph_bs
+            return default_running_tokens
         q = int(batch.num_spec_query_tokens)
-        buckets = self._piecewise_sorted_tokens
-        # Select the SAME q-divisible bucket N that _piecewise_replay_shape picks
-        # (smallest captured bucket >= dp_total_tokens with q | N), and return
-        # graph_bs = N // q. Then graph_bs*max_seqlen_q == N on EVERY rank, so the
-        # eager (dummy) MoE all_gather size equals the size baked into the real
-        # ranks' replayed piecewise graph -> no cross-rank collective mismatch.
-        for b in buckets:
+        for b in self._piecewise_sorted_tokens:
             if b >= int(dp_total_tokens) and q > 0 and b % q == 0:
-                return int(b) // q
-        return default_graph_bs
+                return int(b)
+        return default_running_tokens
 
     def _dspark_capture_q_buckets(self, full_q: int) -> list[int]:
         """DSpark query-length buckets to capture graphs for (paper Phase 2).
@@ -3963,7 +3969,7 @@ class ModelRunner:
         key. The rectangle bucket was already captured by the caller.
         """
         positions = self.forward_vars["positions"].gpu
-        for b in self.graph_bs:
+        for b in self.capture_sizes:
             num_tokens_pad = b * max_q_len
             if num_tokens_pad >= rectangle_tokens or num_tokens_pad < bs:
                 # >= rectangle: the rectangle case (already captured) or larger.
@@ -4020,17 +4026,10 @@ class ModelRunner:
             )
             self._force_aiter_unreg_capture_for_piecewise()
         start_time = time.time()
-        if self.config.compilation_config.cudagraph_capture_sizes:
-            self.graph_bs = self.config.compilation_config.cudagraph_capture_sizes
-        else:
-            cuda_graph_sizes = self.config.compilation_config.cuda_graph_sizes
-            if len(cuda_graph_sizes) == 1:
-                self.graph_bs = [1, 2, 4, 8] + [
-                    i for i in range(16, cuda_graph_sizes[0] + 1, 16)
-                ]
-            elif len(cuda_graph_sizes) > 1:
-                self.graph_bs = cuda_graph_sizes
-        self.graph_bs.sort(reverse=True)
+        # Config owns the declared ladder; the runner only narrows it to what
+        # this deployment can actually schedule (see the bound below).
+        self.capture_sizes = self.config.capture_sizes
+        self.capture_sizes.sort(reverse=True)
 
         # Drop any capture size the scheduler could never produce. `schedule_decode`
         # bounds a decode batch two ways: at most `max_num_seqs` sequences, and at
@@ -4058,9 +4057,9 @@ class ModelRunner:
         max_bs = max_schedulable_decode_bs(
             max_seq_bs, self.config.max_num_batched_tokens, full_q_len
         )
-        oversized = [s for s in self.graph_bs if s > max_bs]
+        oversized = [s for s in self.capture_sizes if s > max_bs]
         if oversized:
-            self.graph_bs = [s for s in self.graph_bs if s <= max_bs]
+            self.capture_sizes = [s for s in self.capture_sizes if s <= max_bs]
             logger.warning(
                 "cudagraph capture sizes %s exceed the schedulable batch size "
                 "min(max_num_seqs=%d, max_num_batched_tokens=%d // (mtp_k+1)=%d "
@@ -4071,9 +4070,9 @@ class ModelRunner:
                 full_q_len,
                 max_tok_bs,
                 max_bs,
-                self.graph_bs,
+                self.capture_sizes,
             )
-        assert self.graph_bs, (
+        assert self.capture_sizes, (
             f"no cudagraph capture sizes left: the scheduler can only reach "
             f"bs <= min(max_num_seqs={max_seq_bs}, "
             f"max_num_batched_tokens={self.config.max_num_batched_tokens} // "
@@ -4155,7 +4154,9 @@ class ModelRunner:
         with pause_gc(), graph_capture() as capture_ctx, self.capture_profiler as prof:
             for max_q_len in q_buckets:
                 capture_range = (
-                    tqdm.tqdm(self.graph_bs) if self.rank == 0 else self.graph_bs
+                    tqdm.tqdm(self.capture_sizes)
+                    if self.rank == 0
+                    else self.capture_sizes
                 )
                 for bs in capture_range:
                     if self.rank == 0:
@@ -4317,10 +4318,9 @@ class ModelRunner:
                         if supports_dynamic_q_len
                         else build_capture
                     ),
-                    full_q_len,
                     capture_ctx.stream,
                 )
-        self.graph_bs.sort(reverse=False)
+        self.capture_sizes.sort(reverse=False)
 
         # PIECEWISE: sorted 1D num_tokens buckets for run_model's round_up_1d(Σ)
         # dispatch (bisect_left over this to pick the tightest captured shape).
@@ -4371,7 +4371,7 @@ class ModelRunner:
                 f"Consider reducing gpu_memory_utilization."
             )
 
-        return time.time() - start_time, self.graph_bs, _pool_bytes
+        return time.time() - start_time, self.capture_sizes, _pool_bytes
 
     @torch.inference_mode()
     def _maybe_calibrate_dspark_sps(self, max_q_len: int, n_iters: int = 20) -> None:
@@ -4414,7 +4414,7 @@ class ModelRunner:
 
         token_points: list[int] = []
         sps_points: list[float] = []
-        for bs in self.graph_bs:
+        for bs in self.capture_sizes:
             graph = self.graphs.get((bs, max_q_len))
             if graph is None:
                 continue

--- a/atom/model_engine/run_labels.py
+++ b/atom/model_engine/run_labels.py
@@ -29,7 +29,7 @@ fall outside those, so dummies never pollute the prefill/decode statistics.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from atom.model_engine.scheduler import ScheduledBatch
@@ -42,7 +42,7 @@ def build_run_label(
     is_dummy: bool,
     tbo_on: bool,
     scheduled_bs: int,
-    batch: Optional["ScheduledBatch"],
+    batch: ScheduledBatch | None,
     running_bs: int,
     detailed_suffix: str = "",
 ) -> str:

--- a/atom/model_engine/run_labels.py
+++ b/atom/model_engine/run_labels.py
@@ -12,7 +12,7 @@ Kinds (label prefix — groups in Perfetto UI, greppable):
   - ``dummy_prefill``      warmup dummy prefill
 
 Fields (``key=value`` inside brackets):
-  - ``bs``   effective (real) batch size; on the CUDAGraph path shown as
+  - ``bs``   the scheduled (real) batch size; on the CUDAGraph path shown as
              ``<real>/<graph>`` when the replayed graph is padded above the real
              batch (e.g. ``bs=117/128``). ``parse_trace.py`` reads the leading
              ``\\d+`` so the real batch is still what it extracts.
@@ -41,10 +41,10 @@ def build_run_label(
     use_cudagraph: bool,
     is_dummy: bool,
     tbo_on: bool,
-    bs: int,
+    scheduled_bs: int,
     batch: Optional["ScheduledBatch"],
+    running_bs: int,
     detailed_suffix: str = "",
-    graph_bs: Optional[int] = None,
 ) -> str:
     """Build the ``record_function`` label for one forward pass.
 
@@ -54,16 +54,20 @@ def build_run_label(
     (empty on the normal path) appended inside the brackets; see
     ``ModelRunner._detailed_label_suffix``.
 
-    ``graph_bs`` is the padded batch size the CUDAGraph actually replays. When it
-    is given and exceeds the real ``bs`` (CUDAGraph path only), the label shows
-    ``bs=<real>/<graph>`` so the padding is visible in the trace.
+    Both batch sizes are required: every step has both, and a step that ran
+    padded is exactly the one worth seeing in a trace. The cudagraph path
+    reports ``running_bs`` -- what actually ran -- and prefixes the real
+    ``scheduled_bs`` as ``bs=<real>/<graph>`` when the two differ. The eager
+    path reports ``scheduled_bs``, because eager attention runs the scheduled
+    rows even where MoE pads past them.
     """
     if use_cudagraph:
         kind = "dummy_decode" if is_dummy else "decode"
-        if graph_bs is not None and graph_bs > bs:
-            label = f"{kind}[bs={bs}/{graph_bs}"
+        if running_bs > scheduled_bs:
+            label = f"{kind}[bs={scheduled_bs}/{running_bs}"
         else:
-            label = f"{kind}[bs={bs}"
+            # `decide` ceils to a captured size, so not-greater means equal.
+            label = f"{kind}[bs={running_bs}"
         if batch is not None:
             label += f" tok={batch.total_tokens_num}"
             if batch.total_seqs_num_prefill > 0:
@@ -76,7 +80,7 @@ def build_run_label(
             kind = "dummy_prefill" if is_dummy else "prefill"
         else:
             kind = "dummy_eager_decode" if is_dummy else "eager_decode"
-        label = f"{kind}[bs={bs}"
+        label = f"{kind}[bs={scheduled_bs}"
         if batch is not None:
             ctx = batch.context_lens
             if len(ctx) == 1:

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -665,7 +665,7 @@ class PagedAttentionImpl(nn.Module):
             v_cache_5d = self._view_v_cache_for_pa_decode_bf16_asm(v_cache, k_cache)
 
             output = torch.empty(q_5d.shape, dtype=torch.bfloat16, device=q.device)
-            # CUDAGraph decode pads scheduled_bs up to graph_bs. PA ASM has no
+            # CUDAGraph decode pads scheduled_bs up to running_bs. PA ASM has no
             # work for padded rows (context_len == 0); zero output so padded rows
             # stay deterministic.
             split_rows = max(

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -850,7 +850,28 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             positions_out.stride(0) if update_positions else 1,
             BLOCK=128,
         )
-        return {"slot_mapping": slot_mapping}
+        workinfos = {"slot_mapping": slot_mapping}
+        if self._has_sparse_attention:
+            # `attention_mha` picks this up off the shared metadata with a plain
+            # `getattr`, and `prepare_decode` cut it at `scheduled_bs` -- so a
+            # mid-step would read seq_lens for fewer rows than it runs.
+            from atom.model_ops.minimax_m3.sparse_attn import (
+                make_sparse_decode_metadata,
+            )
+
+            workinfos["sparse_attention_metadata"] = make_sparse_decode_metadata(
+                seq_lens=context_lens[:pad_bs],
+                block_table=self._get_sparse_attention_block_tables(
+                    block_tables[:pad_bs], context_lens[:pad_bs], pad_bs
+                ),
+                slot_mapping=slot_mapping,  # this step's, not the verify fwd's
+                max_seq_len=max_seqlen_k,
+                # A mid-step is one row per sequence. Not the `max_seqlen_q`
+                # argument: on the `only_update` path that carries the verify
+                # forward's width.
+                max_query_len=1,
+            )
+        return workinfos
 
     def prepare_prefill(self, batch: ScheduledBatch):
         attn_metadata, positions = CommonAttentionBuilder.prepare_prefill(self, batch)

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -820,9 +820,9 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         unused here: there are no persistent worker buffers to roll over for
         ``block_size != 1024``.
         """
-        pad_bs = int(positions.shape[-1])  # rows; see the base contract
+        running_bs = int(positions.shape[-1])  # rows; see the base contract
         var = self.model_runner.forward_vars
-        slot_mapping = var["slot_mapping"].gpu[:pad_bs]
+        slot_mapping = var["slot_mapping"].gpu[:running_bs]
         block_tables = var["block_tables"].gpu
         context_lens = var["context_lens"].gpu
         update_positions = positions_out is not None
@@ -833,15 +833,15 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             last_token_indices = slot_mapping
         # Dummy runs skip the draft attention, so keep this launch as a no-op:
         # their synthetic context_lens can point past block_tables.
-        _mtp_prepare_decode_metadata_kernel[(max(1, triton.cdiv(pad_bs, 128)),)](
+        _mtp_prepare_decode_metadata_kernel[(max(1, triton.cdiv(running_bs, 128)),)](
             context_lens,
             block_tables,
             slot_mapping,
             positions,
             positions_out,
             last_token_indices,
-            pad_bs,
-            pad_bs == 0 or get_forward_context().context.is_dummy_run,
+            running_bs,
+            running_bs == 0 or get_forward_context().context.is_dummy_run,
             update_context_lens,
             update_positions,
             select_positions,
@@ -860,9 +860,9 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             )
 
             workinfos["sparse_attention_metadata"] = make_sparse_decode_metadata(
-                seq_lens=context_lens[:pad_bs],
+                seq_lens=context_lens[:running_bs],
                 block_table=self._get_sparse_attention_block_tables(
-                    block_tables[:pad_bs], context_lens[:pad_bs], pad_bs
+                    block_tables[:running_bs], context_lens[:running_bs], running_bs
                 ),
                 slot_mapping=slot_mapping,  # this step's, not the verify fwd's
                 max_seq_len=max_seqlen_k,
@@ -953,7 +953,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         self,
         attn_metadata: AttentionMetaData,
         ub_slice,
-        padded_bs: int,
+        running_bs: int,
         ubatch_idx: int = 0,
     ) -> AttentionMetaData:
         del ubatch_idx
@@ -962,7 +962,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             split_attn_metadata,
         )
 
-        ub_attn = split_attn_metadata(attn_metadata, ub_slice, padded_bs)
+        ub_attn = split_attn_metadata(attn_metadata, ub_slice, running_bs)
         self._attach_tbo_token_split_straddle_prefix(ub_attn, ub_slice)
         if self._has_sparse_attention:
             from atom.model_ops.minimax_m3.sparse_attn import (
@@ -1205,10 +1205,10 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         half = bs // N
 
         ub_ranges = [(0, half), (half, bs)]
-        padded_bs_list = [half, bs - half]
+        running_bs_list = [half, bs - half]
 
-        for ub_idx, ((req_start, req_end), padded_bs) in enumerate(
-            zip(ub_ranges, padded_bs_list)
+        for ub_idx, ((req_start, req_end), running_bs) in enumerate(
+            zip(ub_ranges, running_bs_list)
         ):
             p = f"ub{ub_idx}_"
             ub_real_reqs = max(0, min(scheduled_bs, req_end) - req_start)
@@ -1216,11 +1216,11 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             var[f"{p}context_lens"].np[:ub_real_reqs] = var["context_lens"].np[
                 req_start : req_start + ub_real_reqs
             ]
-            var[f"{p}context_lens"].np[ub_real_reqs:padded_bs] = 0
+            var[f"{p}context_lens"].np[ub_real_reqs:running_bs] = 0
 
             tok_start = req_start * max_seqlen_q
             ub_real_tokens = ub_real_reqs * max_seqlen_q
-            padded_tok_count = padded_bs * max_seqlen_q
+            padded_tok_count = running_bs * max_seqlen_q
             var[f"{p}slot_mapping"].np[:ub_real_tokens] = var["slot_mapping"].np[
                 tok_start : tok_start + ub_real_tokens
             ]
@@ -1229,7 +1229,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             var[f"{p}block_tables"].np[:ub_real_reqs] = var["block_tables"].np[
                 req_start : req_start + ub_real_reqs
             ]
-            var[f"{p}block_tables"].np[ub_real_reqs:padded_bs] = 0
+            var[f"{p}block_tables"].np[ub_real_reqs:running_bs] = 0
 
             full_kv_indptr = var["kv_indptr"].np
             base = full_kv_indptr[req_start]
@@ -1239,7 +1239,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                     full_kv_indptr[req_start + 1 : req_start + ub_real_reqs + 1] - base
                 )
             last_val = var[f"{p}kv_indptr"].np[ub_real_reqs] if ub_real_reqs > 0 else 0
-            var[f"{p}kv_indptr"].np[ub_real_reqs + 1 : padded_bs + 1] = last_val
+            var[f"{p}kv_indptr"].np[ub_real_reqs + 1 : running_bs + 1] = last_val
 
             last_cu = ub_real_reqs * max_seqlen_q
             var[f"{p}cu_seqlens_q"].np[: ub_real_reqs + 1] = np.arange(
@@ -1248,14 +1248,14 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                 max_seqlen_q,
                 dtype=np.int32,
             )
-            var[f"{p}cu_seqlens_q"].np[ub_real_reqs + 1 : padded_bs + 1] = last_cu
+            var[f"{p}cu_seqlens_q"].np[ub_real_reqs + 1 : running_bs + 1] = last_cu
 
             vars_used = [
-                (f"{p}context_lens", padded_bs),
+                (f"{p}context_lens", running_bs),
                 (f"{p}slot_mapping", padded_tok_count),
-                (f"{p}block_tables", padded_bs),
-                (f"{p}kv_indptr", padded_bs + 1),
-                (f"{p}cu_seqlens_q", padded_bs + 1),
+                (f"{p}block_tables", running_bs),
+                (f"{p}kv_indptr", running_bs + 1),
+                (f"{p}cu_seqlens_q", running_bs + 1),
             ]
             for el, num in vars_used:
                 var[el].copy_to_gpu(num)
@@ -1266,18 +1266,18 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
                 else 0
             )
             kv_indices_generate_triton(
-                var[f"{p}block_tables"].gpu[:padded_bs],
+                var[f"{p}block_tables"].gpu[:running_bs],
                 var[f"{p}kv_indices"].gpu,
-                var[f"{p}kv_indptr"].gpu[: padded_bs + 1],
+                var[f"{p}kv_indptr"].gpu[: running_bs + 1],
                 self.block_ratio,
                 ub_max_seqlen_k,
             )
 
             # Set PA persistent worker buffers for this ubatch
             if self.block_size in (256, 1024):
-                self._set_ubatch_pa_buffers(padded_bs, max_seqlen_q, ub_idx)
+                self._set_ubatch_pa_buffers(running_bs, max_seqlen_q, ub_idx)
 
-    def _set_ubatch_pa_buffers(self, padded_bs, max_q_len, ubatch_idx):
+    def _set_ubatch_pa_buffers(self, running_bs, max_q_len, ubatch_idx):
         """Compute PA work buffers for a per-ubatch forward_vars set."""
         config = self.model_runner.config
         hf_config = config.hf_config
@@ -1289,9 +1289,9 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         var = self.model_runner.forward_vars
 
         aiter.get_pa_metadata_v1(
-            var[f"{p}cu_seqlens_q"].gpu[: padded_bs + 1],
-            var[f"{p}kv_indptr"].gpu[: padded_bs + 1],
-            var[f"{p}context_lens"].gpu[:padded_bs],
+            var[f"{p}cu_seqlens_q"].gpu[: running_bs + 1],
+            var[f"{p}kv_indptr"].gpu[: running_bs + 1],
+            var[f"{p}context_lens"].gpu[:running_bs],
             num_query_heads // num_kv_heads,
             num_kv_heads,
             True,
@@ -1312,7 +1312,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
     def build_ubatch_metadata(
         self,
         ubatch_idx: int,
-        padded_bs: int,
+        running_bs: int,
     ) -> AttentionMetaData:
         """Create per-ubatch AttentionMetaData from pre-allocated forward_vars."""
         var = self.model_runner.forward_vars
@@ -1321,16 +1321,16 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
 
         # Compute PA work buffers for this ubatch
         if self.block_size in (256, 1024):
-            self._set_ubatch_pa_buffers(padded_bs, max_q_len, ubatch_idx)
+            self._set_ubatch_pa_buffers(running_bs, max_q_len, ubatch_idx)
 
         attn = AttentionMetaData(
-            slot_mapping=var[f"{p}slot_mapping"].gpu[: padded_bs * max_q_len],
-            context_lens=var[f"{p}context_lens"].gpu[:padded_bs],
-            block_tables=var[f"{p}block_tables"].gpu[:padded_bs],
+            slot_mapping=var[f"{p}slot_mapping"].gpu[: running_bs * max_q_len],
+            context_lens=var[f"{p}context_lens"].gpu[:running_bs],
+            block_tables=var[f"{p}block_tables"].gpu[:running_bs],
             max_seqlen_q=max_q_len,
             max_seqlen_k=self.model_runner.config.max_model_len,
-            cu_seqlens_q=var[f"{p}cu_seqlens_q"].gpu[: padded_bs + 1],
-            kv_indptr=var[f"{p}kv_indptr"].gpu[: padded_bs + 1],
+            cu_seqlens_q=var[f"{p}cu_seqlens_q"].gpu[: running_bs + 1],
+            kv_indptr=var[f"{p}kv_indptr"].gpu[: running_bs + 1],
             kv_indices=var[f"{p}kv_indices"].gpu,
             work_meta_data=var[f"{p}work_meta_data"],
             work_info_set=var[f"{p}work_info_set"],
@@ -1352,7 +1352,7 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             sparse_block_tables = self._get_sparse_attention_block_tables(
                 attn.block_tables,
                 attn.context_lens,
-                padded_bs,
+                running_bs,
             )
             attn.sparse_attention_metadata = make_sparse_decode_metadata(
                 seq_lens=attn.context_lens,
@@ -1407,6 +1407,12 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
 
         positions = var["positions"].copy_to_gpu(total_tokens)
         context = Context(
-            positions=positions, is_prefill=False, batch_size=bs, graph_bs=bs
+            positions=positions,
+            is_prefill=False,
+            scheduled_bs=bs,
+            running_bs=bs,
+            # A capture runs a full synthetic batch: nothing is padded.
+            scheduled_tokens=total_tokens,
+            running_tokens=total_tokens,
         )
         return attn_metadata, context

--- a/atom/model_ops/attentions/aiter_attention.py
+++ b/atom/model_ops/attentions/aiter_attention.py
@@ -820,8 +820,9 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
         unused here: there are no persistent worker buffers to roll over for
         ``block_size != 1024``.
         """
+        pad_bs = int(positions.shape[-1])  # rows; see the base contract
         var = self.model_runner.forward_vars
-        slot_mapping = var["slot_mapping"].gpu[:bs]
+        slot_mapping = var["slot_mapping"].gpu[:pad_bs]
         block_tables = var["block_tables"].gpu
         context_lens = var["context_lens"].gpu
         update_positions = positions_out is not None
@@ -832,15 +833,15 @@ class AiterAttentionMetadataBuilder(CommonAttentionBuilder):
             last_token_indices = slot_mapping
         # Dummy runs skip the draft attention, so keep this launch as a no-op:
         # their synthetic context_lens can point past block_tables.
-        _mtp_prepare_decode_metadata_kernel[(max(1, triton.cdiv(bs, 128)),)](
+        _mtp_prepare_decode_metadata_kernel[(max(1, triton.cdiv(pad_bs, 128)),)](
             context_lens,
             block_tables,
             slot_mapping,
             positions,
             positions_out,
             last_token_indices,
-            bs,
-            bs == 0 or get_forward_context().context.is_dummy_run,
+            pad_bs,
+            pad_bs == 0 or get_forward_context().context.is_dummy_run,
             update_context_lens,
             update_positions,
             select_positions,

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -818,18 +818,19 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         parity with the MHA backend but unused (MLA's ``positions`` is already
         one entry per sequence at this point).
         """
+        pad_bs = int(positions.shape[-1])  # rows; see the base contract
         del last_token_indices  # MLA positions are already per-seq (1 per token)
         var = self.model_runner.forward_vars
-        kv_indptr = var["kv_indptr"].gpu[: bs + 1]
-        cu_seqlens_q = var["cu_seqlens_q"].gpu[: bs + 1]
+        kv_indptr = var["kv_indptr"].gpu[: pad_bs + 1]
+        cu_seqlens_q = var["cu_seqlens_q"].gpu[: pad_bs + 1]
         if self.is_sparse:
-            sparse_kv_indptr = var["sparse_kv_indptr"].gpu[: bs + 1]
+            sparse_kv_indptr = var["sparse_kv_indptr"].gpu[: pad_bs + 1]
         else:
             assert self.block_size == 1
             sparse_kv_indptr = None
 
         update_positions = positions_out is not None
-        context_lens = var["context_lens"].gpu[:bs] if update_context_lens else None
+        context_lens = var["context_lens"].gpu[:pad_bs] if update_context_lens else None
 
         mtp_prepare_decode_mla_kernel[(1,)](
             kv_indptr,
@@ -837,7 +838,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             sparse_kv_indptr if self.is_sparse else kv_indptr,
             positions_out if update_positions else kv_indptr,
             context_lens if update_context_lens else kv_indptr,
-            bs,
+            pad_bs,
             self.index_topk if self.is_sparse else 0,
             positions_out.stride(0) if update_positions else 1,
             IS_SPARSE=self.is_sparse,
@@ -857,13 +858,15 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             assert self.block_size == 1
             W = self.dcp_world_size
             r = self.dcp_rank
-            ctx_g = var["context_lens"].gpu[:bs].to(torch.int64)
+            ctx_g = var["context_lens"].gpu[:pad_bs].to(torch.int64)
             base = ctx_g // W
             remainder = (ctx_g - base * W - r).clamp_(0, 1)
             local_ctx = (base + remainder).to(torch.int32)  # local KV tokens/blocks
             kv_indptr[0] = 0
-            kv_indptr[1 : bs + 1] = torch.cumsum(local_ctx, dim=0, dtype=torch.int32)
-            var["kv_last_page_lens"].gpu[:bs] = (local_ctx > 0).to(
+            kv_indptr[1 : pad_bs + 1] = torch.cumsum(
+                local_ctx, dim=0, dtype=torch.int32
+            )
+            var["kv_last_page_lens"].gpu[:pad_bs] = (local_ctx > 0).to(
                 var["kv_last_page_lens"].gpu.dtype
             )
             # Host upper bound for the index generator's loop (safe overestimate,
@@ -871,7 +874,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             local_max_k = max_seqlen_k // W + 1
 
         kv_indices_generate_triton(
-            var["block_tables"].gpu[:bs],
+            var["block_tables"].gpu[:pad_bs],
             var["kv_indices"].gpu,
             kv_indptr,
             self.block_ratio,
@@ -881,7 +884,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # qlen==1 local decode: full build (not cprr; is_cp_round_robin=False),
             # over the just-rebuilt LOCAL kv_indptr / kv_last_page_lens.
             return self.set_mla_persistent_worker_buffers(
-                bs, 1, only_update=False, num_reject_tokens=None
+                pad_bs, 1, only_update=False, num_reject_tokens=None
             )
         if self.is_sparse:
             # The MTP draft's single sparse block reads sparse_kv_indptr, but it
@@ -899,7 +902,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # reflects the reject-adjusted KV lengths, so num_reject_tokens is
             # not needed here.
             result = self.set_mla_persistent_worker_buffers(
-                bs,
+                pad_bs,
                 1,
                 only_update=False,
                 num_reject_tokens=None,
@@ -908,7 +911,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             result["sparse_kv_indptr"] = sparse_kv_indptr
         else:
             result = self.set_mla_persistent_worker_buffers(
-                bs, max_seqlen_q, only_update, num_reject_tokens
+                pad_bs, max_seqlen_q, only_update, num_reject_tokens
             )
         return result
 

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -690,6 +690,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         sparse_decode: bool = False,
         is_cp_round_robin: bool = False,
     ):
+        assert num_reject_tokens is None or num_reject_tokens.shape[0] >= bs, (
+            f"num_reject_tokens covers {num_reject_tokens.shape[0]} sequences "
+            f"but this asks for {bs}; the update kernel loads one per work item "
+            f"below `cu_num`, unconditionally"
+        )
         split_params = {
             "kv_granularity": max(self.block_size, 16),
             "max_seqlen_qo": max_q_len,
@@ -818,19 +823,21 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         parity with the MHA backend but unused (MLA's ``positions`` is already
         one entry per sequence at this point).
         """
-        pad_bs = int(positions.shape[-1])  # rows; see the base contract
+        running_bs = int(positions.shape[-1])  # rows; see the base contract
         del last_token_indices  # MLA positions are already per-seq (1 per token)
         var = self.model_runner.forward_vars
-        kv_indptr = var["kv_indptr"].gpu[: pad_bs + 1]
-        cu_seqlens_q = var["cu_seqlens_q"].gpu[: pad_bs + 1]
+        kv_indptr = var["kv_indptr"].gpu[: running_bs + 1]
+        cu_seqlens_q = var["cu_seqlens_q"].gpu[: running_bs + 1]
         if self.is_sparse:
-            sparse_kv_indptr = var["sparse_kv_indptr"].gpu[: pad_bs + 1]
+            sparse_kv_indptr = var["sparse_kv_indptr"].gpu[: running_bs + 1]
         else:
             assert self.block_size == 1
             sparse_kv_indptr = None
 
         update_positions = positions_out is not None
-        context_lens = var["context_lens"].gpu[:pad_bs] if update_context_lens else None
+        context_lens = (
+            var["context_lens"].gpu[:running_bs] if update_context_lens else None
+        )
 
         mtp_prepare_decode_mla_kernel[(1,)](
             kv_indptr,
@@ -838,7 +845,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             sparse_kv_indptr if self.is_sparse else kv_indptr,
             positions_out if update_positions else kv_indptr,
             context_lens if update_context_lens else kv_indptr,
-            pad_bs,
+            running_bs,
             self.index_topk if self.is_sparse else 0,
             positions_out.stride(0) if update_positions else 1,
             IS_SPARSE=self.is_sparse,
@@ -858,15 +865,15 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             assert self.block_size == 1
             W = self.dcp_world_size
             r = self.dcp_rank
-            ctx_g = var["context_lens"].gpu[:pad_bs].to(torch.int64)
+            ctx_g = var["context_lens"].gpu[:running_bs].to(torch.int64)
             base = ctx_g // W
             remainder = (ctx_g - base * W - r).clamp_(0, 1)
             local_ctx = (base + remainder).to(torch.int32)  # local KV tokens/blocks
             kv_indptr[0] = 0
-            kv_indptr[1 : pad_bs + 1] = torch.cumsum(
+            kv_indptr[1 : running_bs + 1] = torch.cumsum(
                 local_ctx, dim=0, dtype=torch.int32
             )
-            var["kv_last_page_lens"].gpu[:pad_bs] = (local_ctx > 0).to(
+            var["kv_last_page_lens"].gpu[:running_bs] = (local_ctx > 0).to(
                 var["kv_last_page_lens"].gpu.dtype
             )
             # Host upper bound for the index generator's loop (safe overestimate,
@@ -874,7 +881,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             local_max_k = max_seqlen_k // W + 1
 
         kv_indices_generate_triton(
-            var["block_tables"].gpu[:pad_bs],
+            var["block_tables"].gpu[:running_bs],
             var["kv_indices"].gpu,
             kv_indptr,
             self.block_ratio,
@@ -884,7 +891,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # qlen==1 local decode: full build (not cprr; is_cp_round_robin=False),
             # over the just-rebuilt LOCAL kv_indptr / kv_last_page_lens.
             return self.set_mla_persistent_worker_buffers(
-                pad_bs, 1, only_update=False, num_reject_tokens=None
+                running_bs, 1, only_update=False, num_reject_tokens=None
             )
         if self.is_sparse:
             # The MTP draft's single sparse block reads sparse_kv_indptr, but it
@@ -902,7 +909,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # reflects the reject-adjusted KV lengths, so num_reject_tokens is
             # not needed here.
             result = self.set_mla_persistent_worker_buffers(
-                pad_bs,
+                running_bs,
                 1,
                 only_update=False,
                 num_reject_tokens=None,
@@ -910,8 +917,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             )
             result["sparse_kv_indptr"] = sparse_kv_indptr
         else:
+            # `bs`, not `running_bs`, and paired with `num_reject_tokens`: this count
+            # becomes `cu_num`, and the update kernel loads
+            # `num_reject_tokens[batch_id]` for every work item below it, before
+            # any length test. That tensor is the sampler's, so it is `bs` long.
+            # The two branches above pass no counts and so take the row count.
             result = self.set_mla_persistent_worker_buffers(
-                pad_bs, max_seqlen_q, only_update, num_reject_tokens
+                bs, max_seqlen_q, only_update, num_reject_tokens
             )
         return result
 
@@ -1984,7 +1996,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 "sparse_kv_last_page_lens"
             ].gpu[:bs]
 
-        # Use bs (graph_bs) >= 2 instead of scheduled_bs >= 2 to avoid accuracy issue:
+        # Use bs (running_bs) >= 2 instead of scheduled_bs >= 2 to avoid accuracy issue:
         if self.model_runner.config.enable_tbo_decode and bs >= 2:
             self._prepare_ubatch_decode(
                 scheduled_bs,
@@ -2013,10 +2025,10 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             (0, half),
             (half, bs),
         ]
-        padded_bs_list = [half, bs - half]
+        running_bs_list = [half, bs - half]
 
-        for ub_idx, ((req_start, req_end), padded_bs) in enumerate(
-            zip(ub_ranges, padded_bs_list)
+        for ub_idx, ((req_start, req_end), running_bs) in enumerate(
+            zip(ub_ranges, running_bs_list)
         ):
             p = f"ub{ub_idx}_"
             # How many real requests fall in this ubatch's range
@@ -2025,16 +2037,16 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             var[f"{p}context_lens"].np[:ub_real_reqs] = var["context_lens"].np[
                 req_start : req_start + ub_real_reqs
             ]
-            var[f"{p}context_lens"].np[ub_real_reqs:padded_bs] = 0
+            var[f"{p}context_lens"].np[ub_real_reqs:running_bs] = 0
 
             var[f"{p}kv_last_page_lens"].np[:ub_real_reqs] = var[
                 "kv_last_page_lens"
             ].np[req_start : req_start + ub_real_reqs]
-            var[f"{p}kv_last_page_lens"].np[ub_real_reqs:padded_bs] = 0
+            var[f"{p}kv_last_page_lens"].np[ub_real_reqs:running_bs] = 0
 
             tok_start = req_start * max_seqlen_q
             ub_real_tokens = ub_real_reqs * max_seqlen_q
-            padded_tok_count = padded_bs * max_seqlen_q
+            padded_tok_count = running_bs * max_seqlen_q
             var[f"{p}slot_mapping"].np[:ub_real_tokens] = var["slot_mapping"].np[
                 tok_start : tok_start + ub_real_tokens
             ]
@@ -2043,7 +2055,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             var[f"{p}block_tables"].np[:ub_real_reqs] = var["block_tables"].np[
                 req_start : req_start + ub_real_reqs
             ]
-            var[f"{p}block_tables"].np[ub_real_reqs:padded_bs] = 0
+            var[f"{p}block_tables"].np[ub_real_reqs:running_bs] = 0
 
             full_kv_indptr = var["kv_indptr"].np
             base = full_kv_indptr[req_start]
@@ -2053,7 +2065,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                     full_kv_indptr[req_start + 1 : req_start + ub_real_reqs + 1] - base
                 )
             last_val = var[f"{p}kv_indptr"].np[ub_real_reqs] if ub_real_reqs > 0 else 0
-            var[f"{p}kv_indptr"].np[ub_real_reqs + 1 : padded_bs + 1] = last_val
+            var[f"{p}kv_indptr"].np[ub_real_reqs + 1 : running_bs + 1] = last_val
 
             if self.dcp_world_size > 1:
                 # Per-ubatch slice of the global kv_indptr (rebased); diffs (per-req
@@ -2069,7 +2081,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 g_last = (
                     var[f"{p}g_kv_indptr"].np[ub_real_reqs] if ub_real_reqs > 0 else 0
                 )
-                var[f"{p}g_kv_indptr"].np[ub_real_reqs + 1 : padded_bs + 1] = g_last
+                var[f"{p}g_kv_indptr"].np[ub_real_reqs + 1 : running_bs + 1] = g_last
 
             if self.is_sparse:
                 full_sparse = var["sparse_kv_indptr"].np
@@ -2086,7 +2098,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                     else 0
                 )
                 var[f"{p}sparse_kv_indptr"].np[
-                    ub_real_reqs + 1 : padded_bs + 1
+                    ub_real_reqs + 1 : running_bs + 1
                 ] = sparse_last
 
             last_cu = ub_real_reqs * max_seqlen_q
@@ -2096,20 +2108,20 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 max_seqlen_q,
                 dtype=np.int32,
             )
-            var[f"{p}cu_seqlens_q"].np[ub_real_reqs + 1 : padded_bs + 1] = last_cu
+            var[f"{p}cu_seqlens_q"].np[ub_real_reqs + 1 : running_bs + 1] = last_cu
 
             vars_used = [
-                (f"{p}context_lens", padded_bs),
-                (f"{p}kv_last_page_lens", padded_bs),
+                (f"{p}context_lens", running_bs),
+                (f"{p}kv_last_page_lens", running_bs),
                 (f"{p}slot_mapping", padded_tok_count),
-                (f"{p}block_tables", padded_bs),
-                (f"{p}kv_indptr", padded_bs + 1),
-                (f"{p}cu_seqlens_q", padded_bs + 1),
+                (f"{p}block_tables", running_bs),
+                (f"{p}kv_indptr", running_bs + 1),
+                (f"{p}cu_seqlens_q", running_bs + 1),
             ]
             if self.dcp_world_size > 1:
-                vars_used.append((f"{p}g_kv_indptr", padded_bs + 1))
+                vars_used.append((f"{p}g_kv_indptr", running_bs + 1))
             if self.is_sparse:
-                vars_used.append((f"{p}sparse_kv_indptr", padded_bs + 1))
+                vars_used.append((f"{p}sparse_kv_indptr", running_bs + 1))
 
             for el, num in vars_used:
                 var[el].copy_to_gpu(num)
@@ -2120,39 +2132,39 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 else 0
             )
             kv_indices_generate_triton(
-                var[f"{p}block_tables"].gpu[:padded_bs],
+                var[f"{p}block_tables"].gpu[:running_bs],
                 var[f"{p}kv_indices"].gpu,
-                var[f"{p}kv_indptr"].gpu[: padded_bs + 1],
+                var[f"{p}kv_indptr"].gpu[: running_bs + 1],
                 self.block_ratio,
                 ub_max_seqlen_k,
             )
 
             self._set_ubatch_mla_buffers(
-                padded_bs,
+                running_bs,
                 max_seqlen_q,
                 ub_idx,
                 is_cp_round_robin=self.dcp_world_size > 1 and max_seqlen_q > 1,
             )
 
     def _set_ubatch_mla_buffers(
-        self, padded_bs, max_q_len, ubatch_idx, is_cp_round_robin=False
+        self, running_bs, max_q_len, ubatch_idx, is_cp_round_robin=False
     ):
         """Compute MLA work buffers for a per-ubatch forward_vars set."""
         p = f"ub{ubatch_idx}_"
         var = self.model_runner.forward_vars
 
-        kv_indptr_for_mla = var[f"{p}kv_indptr"].gpu[: padded_bs + 1]
-        kv_last_page_lens_for_mla = var[f"{p}kv_last_page_lens"].gpu[:padded_bs]
+        kv_indptr_for_mla = var[f"{p}kv_indptr"].gpu[: running_bs + 1]
+        kv_last_page_lens_for_mla = var[f"{p}kv_last_page_lens"].gpu[:running_bs]
         if self.is_sparse:
-            kv_indptr_for_mla = var[f"{p}sparse_kv_indptr"].gpu[: padded_bs + 1]
+            kv_indptr_for_mla = var[f"{p}sparse_kv_indptr"].gpu[: running_bs + 1]
             # Sparse KV is packed per token at page_size=1 -> last_page_len is 1.
             # The dense per-block buffer would over-read past the sparse indices
             # (see set_mla_persistent_worker_buffers). The all-1s sparse buffer is
             # batch-independent, so the shared (non-ubatch) copy is safe here.
-            kv_last_page_lens_for_mla = var["sparse_kv_last_page_lens"].gpu[:padded_bs]
+            kv_last_page_lens_for_mla = var["sparse_kv_last_page_lens"].gpu[:running_bs]
 
         get_mla_metadata_v1(
-            var[f"{p}cu_seqlens_q"].gpu[: padded_bs + 1],
+            var[f"{p}cu_seqlens_q"].gpu[: running_bs + 1],
             kv_indptr_for_mla,
             kv_last_page_lens_for_mla,
             self.persistent_num_heads,
@@ -2275,14 +2287,20 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             ].gpu[:bs]
         positions = var["positions"].copy_to_gpu(sum_tokens)
         context = Context(
-            positions=positions, is_prefill=False, batch_size=bs, graph_bs=bs
+            positions=positions,
+            is_prefill=False,
+            scheduled_bs=bs,
+            running_bs=bs,
+            # A capture runs a full synthetic batch: nothing is padded.
+            scheduled_tokens=sum_tokens,
+            running_tokens=sum_tokens,
         )
         return attn_matadata, context
 
     def build_ubatch_metadata(
         self,
         ubatch_idx: int,
-        padded_bs: int,
+        running_bs: int,
     ) -> AttentionMetaData:
         """Create per-ubatch AttentionMetaData from pre-allocated forward_vars."""
         var = self.model_runner.forward_vars
@@ -2291,28 +2309,28 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
         # Compute MLA work buffers for this ubatch
         self._set_ubatch_mla_buffers(
-            padded_bs,
+            running_bs,
             max_q_len,
             ubatch_idx,
             is_cp_round_robin=self.dcp_world_size > 1 and max_q_len > 1,
         )
 
         attn = AttentionMetaData(
-            slot_mapping=var[f"{p}slot_mapping"].gpu[: padded_bs * max_q_len],
-            context_lens=var[f"{p}context_lens"].gpu[:padded_bs],
-            block_tables=var[f"{p}block_tables"].gpu[:padded_bs],
+            slot_mapping=var[f"{p}slot_mapping"].gpu[: running_bs * max_q_len],
+            context_lens=var[f"{p}context_lens"].gpu[:running_bs],
+            block_tables=var[f"{p}block_tables"].gpu[:running_bs],
             max_seqlen_q=max_q_len,
-            cu_seqlens_q=var[f"{p}cu_seqlens_q"].gpu[: padded_bs + 1],
-            kv_indptr=var[f"{p}kv_indptr"].gpu[: padded_bs + 1],
+            cu_seqlens_q=var[f"{p}cu_seqlens_q"].gpu[: running_bs + 1],
+            kv_indptr=var[f"{p}kv_indptr"].gpu[: running_bs + 1],
             kv_indices=var[f"{p}kv_indices"].gpu,
-            kv_last_page_lens=var[f"{p}kv_last_page_lens"].gpu[:padded_bs],
+            kv_last_page_lens=var[f"{p}kv_last_page_lens"].gpu[:running_bs],
             sparse_kv_indptr=(
-                var[f"{p}sparse_kv_indptr"].gpu[: padded_bs + 1]
+                var[f"{p}sparse_kv_indptr"].gpu[: running_bs + 1]
                 if self.is_sparse
                 else None
             ),
             sparse_kv_last_page_lens=(
-                var["sparse_kv_last_page_lens"].gpu[:padded_bs]
+                var["sparse_kv_last_page_lens"].gpu[:running_bs]
                 if self.is_sparse
                 else None
             ),
@@ -2327,7 +2345,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # Per-ubatch round-robin CP global kv_indptr (None when non-DCP). Consumed
         # by _forward_decode when dcp>1 and max_q_len>1 (MTP).
         attn.g_kv_indptr = (
-            var[f"{p}g_kv_indptr"].gpu[: padded_bs + 1]
+            var[f"{p}g_kv_indptr"].gpu[: running_bs + 1]
             if self.dcp_world_size > 1
             else None
         )
@@ -2337,7 +2355,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         self,
         attn_metadata: AttentionMetaData,
         ub_slice,
-        padded_bs: int,
+        running_bs: int,
         ubatch_idx: int = 0,
     ) -> AttentionMetaData:
         """
@@ -2346,7 +2364,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         del ubatch_idx  # MLA has no per-ubatch pooled buffers to disambiguate
         from atom.utils.tbo.ubatch_splitting import split_attn_metadata
 
-        ub_attn = split_attn_metadata(attn_metadata, ub_slice, padded_bs)
+        ub_attn = split_attn_metadata(attn_metadata, ub_slice, running_bs)
 
         ts = ub_slice.token_slice
         rs = ub_slice.request_slice

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -105,6 +105,35 @@ class AttentionMetadataBuilder(ABC, Generic[T]):
     def build(self, batch: ScheduledBatch, bs: int):
         raise NotImplementedError
 
+    def prepare_mtp_decode(
+        self,
+        bs: int,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        positions: torch.Tensor,
+        only_update: bool = False,
+        num_reject_tokens: torch.Tensor | None = None,
+    ):
+        """Rebuild this backend's metadata for one serial-draft mid-step.
+
+        The draft runs one row per sequence, and `positions` is that row buffer
+        -- so `positions.shape[-1]` is the ROW COUNT and is what every shape here
+        follows. It is not `bs`: a drafter may run a wider batch to land on a
+        captured shape, and `bs` stays the count of rows that carry a real
+        sequence. They are equal whenever nothing is padded.
+
+        The LAST axis, not the first: MRoPE positions are `[3, N]` (the token
+        axis is last), and every other layout is `[N]`, where the two agree.
+
+        Backends that distinguish the two mark the padded tail so downstream
+        kernels skip it; those that do not simply never read `bs`, the same way
+        most ignore `only_update` / `num_reject_tokens`.
+
+        Returns per-forward metadata the caller installs on `attn_metadata`;
+        `{}` when the backend mutates it in place.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def build_for_cudagraph_capture(self, bs: int) -> AttentionMetaData:
         raise NotImplementedError

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -118,8 +118,8 @@ class AttentionMetadataBuilder(ABC, Generic[T]):
 
         The draft runs one row per sequence, and `positions` is that row buffer
         -- so `positions.shape[-1]` is the ROW COUNT and is what every shape here
-        follows. It is not `bs`: a drafter may run a wider batch to land on a
-        captured shape, and `bs` stays the count of rows that carry a real
+        follows. It is not `bs`: a drafter may run the wider batch the target
+        itself just ran, and `bs` stays the count of rows that carry a real
         sequence. They are equal whenever nothing is padded.
 
         The LAST axis, not the first: MRoPE positions are `[3, N]` (the token
@@ -291,6 +291,13 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         ).interleave_size
         self.max_num_batched_tokens = model_runner.max_num_batched_tokens
         self.max_bs = model_runner.max_bs
+        # Every row's own index, resident so no step rebuilds it. One buffer for
+        # three readers that each want the same numbers: a cu_seqlens ramp at one
+        # token per sequence (hence `+ 1`), the real prefix a padded
+        # `batch_id_per_token` is restored from, and DSpark's token -> request map.
+        self.row_ids = torch.arange(
+            self.max_bs + 1, device=self.device, dtype=torch.int32
+        )
         self.max_num_blocks_per_seq = (
             config.max_model_len + self.block_size - 1
         ) // self.block_size

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -117,10 +117,11 @@ class AttentionMetadataBuilder(ABC, Generic[T]):
         """Rebuild this backend's metadata for one serial-draft mid-step.
 
         The draft runs one row per sequence, and `positions` is that row buffer
-        -- so `positions.shape[-1]` is the ROW COUNT and is what every shape here
-        follows. It is not `bs`: a drafter may run the wider batch the target
-        itself just ran, and `bs` stays the count of rows that carry a real
-        sequence. They are equal whenever nothing is padded.
+        -- so `positions.shape[-1]` is this step's `running_bs`, and it is what
+        every shape here follows. The `bs` argument is the `scheduled_bs`: the
+        count of those rows that carry a real sequence. They are equal whenever
+        nothing is padded, and an override must read the buffer rather than the
+        argument, because a drafter may run the wider batch the target just ran.
 
         The LAST axis, not the first: MRoPE positions are `[3, N]` (the token
         axis is last), and every other layout is `[N]`, where the two agree.
@@ -539,11 +540,11 @@ class CommonAttentionBuilder(AttentionMetadataBuilder[T], Generic[T]):
         self,
         attn_metadata: AttentionMetaData,
         ub_slice: UBatchSlice,
-        padded_bs: int,
+        running_bs: int,
         ubatch_idx: int = 0,
     ) -> AttentionMetaData:
         del ubatch_idx  # only used by builders with per-ubatch plan buffers
-        return split_attn_metadata(attn_metadata, ub_slice, padded_bs)
+        return split_attn_metadata(attn_metadata, ub_slice, running_bs)
 
     def _attach_tbo_prefill_cpu_lens(
         self, attn_metadata: AttentionMetaData, bs: int

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -167,10 +167,10 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     defaults.
 
     Shape symbols used below:
-      bs         = scheduled_bs            actual decode/prefill seqs
-      padded_bs  = capture-time graph_bs   (= bs in eager / prefill)
+      bs         = scheduled_bs            the seqs the scheduler gave us
+      running_bs  = running_bs              what the step runs (= bs when eager)
       T          = total_tokens this fwd   (= sum of token_num_per_seq)
-      padded_T   = padded_bs * max_q_len   (>= T; captured kernels iterate this)
+      padded_T   = running_bs * max_q_len   (>= T; captured kernels iterate this)
       win        = self.window_size        (128 for V4-Pro)
       index_topk = self.index_topk         (1024 for V4-Pro)
     """
@@ -2036,7 +2036,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         _rbs = int(ragged_lens.shape[0])
         cu_seq_q = torch.zeros(_rbs + 1, dtype=torch.int32, device=ragged_lens.device)
         torch.cumsum(ragged_lens.to(torch.int32), dim=0, out=cu_seq_q[1:])
-        # n_committed is padded_bs-long (index_topk pad sentinels); slice to `_rbs`
+        # n_committed is running_bs-long (index_topk pad sentinels); slice to `_rbs`
         # so its length matches cu_seq_q (else the binary search over cu_seq_q
         # reads OOB / maps real rows onto sentinel pad seqs).
         _ncmt = attn_metadata.n_committed_csa_per_seq[:_rbs]
@@ -2353,7 +2353,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
 
         var = self.model_runner.forward_vars
-        pad_bs = int(positions.shape[-1])  # rows; see the base contract
+        running_bs = int(positions.shape[-1])  # rows; see the base contract
         attn_metadata = cast(
             AttentionMetaData_DSV4, get_forward_context().attn_metadata
         )
@@ -2371,7 +2371,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # `prepare_decode`.
         actual_swa = torch.clamp(positions + 1, max=win)
 
-        swa_indptr = var["v4_kv_indptr_swa"].gpu[: pad_bs + 1]
+        swa_indptr = var["v4_kv_indptr_swa"].gpu[: running_bs + 1]
         # positions/actual_swa are int64 (eagle's positions buffer); cast to
         # int32 inside cumsum to match swa_indptr's int32 storage.
         torch.cumsum(actual_swa, dim=0, dtype=torch.int32, out=swa_indptr[1:])
@@ -2393,9 +2393,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # Not a slice of `cu_seqlens_q` either: that one is also the q indptr,
         # and a sentinel in it would corrupt the other reader. `row_ids` is
         # the resident arange the real prefix is restored from.
-        batch_id_per_token = var["v4_batch_id_per_token"].gpu[:pad_bs]
+        batch_id_per_token = var["v4_batch_id_per_token"].gpu[:running_bs]
         batch_id_per_token[:bs].copy_(self.row_ids[:bs])
-        if pad_bs > bs:
+        if running_bs > bs:
             batch_id_per_token[bs:] = -1
 
         # ----- Kernel: write SWA prefix paged offsets -----
@@ -2406,7 +2406,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         swa_indices_buf = var["v4_kv_indices_swa"]
         dest_rows = self._dest_row_buffers()
         write_v4_paged_decode_indices(
-            state_slot_per_seq=attn_metadata.state_slot_out[:pad_bs],
+            state_slot_per_seq=attn_metadata.state_slot_out[:running_bs],
             batch_id_per_token=batch_id_per_token,
             positions=positions,
             swa_indptr=swa_indptr,
@@ -2416,7 +2416,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             csa_indices=None,
             hca_indices=None,
             dest_rows=dest_rows,
-            T=pad_bs,
+            T=running_bs,
             win=win,
             geometry=self.pool_geometry,
         )
@@ -2438,7 +2438,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # to that length via the same builder-staged path as the verify fwd.
         if self._kv_fp8:
             attn_metadata.qo_indptr = self._stage(
-                "v4_qo_indptr", self._v4_qo_indptr_np[: pad_bs + 1]
+                "v4_qo_indptr", self._v4_qo_indptr_np[: running_bs + 1]
             )
 
         # NOT rebuilt (unused by SWA-only MTP layer; would block a future
@@ -2572,7 +2572,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         compress_plans = self._build_compress_plans(
             extend_lens_np,
             context_lens_np,
-            graph_bs=bs,
+            running_bs=bs,
             max_q_len=max_seqlen_q,
         )
 
@@ -2613,14 +2613,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             )
             attn_metadata.dspark_full_q = int(full_q)
 
-        padded_bs = int(bs)
+        running_bs = int(bs)
         self._attach_v4_per_fwd_meta(
             attn_metadata,
             extend_lens_np,  # = np.full(scheduled_bs, max_seqlen_q) for decode
             state_slot_np,
             scheduled_bs,
             sum_scheduled_tokens,
-            padded_bs=padded_bs,
+            running_bs=running_bs,
             max_q_len=max_seqlen_q,
         )
         self._attach_v4_indexer_meta(
@@ -2690,7 +2690,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
             ctx = get_forward_context()
             padded_list = [
-                UBatchWrapper._decode_ub_padded_bs(ctx, i, N, bs) for i in range(N)
+                UBatchWrapper._decode_ub_running_bs(ctx, i, N, bs) for i in range(N)
             ]
             # Real-request ranges partition scheduled_bs; each ubatch owns up to
             # its padded capacity, the tail ubatch takes the remainder. Pad rows
@@ -2711,7 +2711,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         np.cumsum(extend_lens_np[:scheduled_bs], out=token_offsets[1:])
         for ub_idx, (req_start, req_end) in enumerate(ub_ranges):
             p = f"ub{ub_idx}_"
-            padded_bs = padded_list[ub_idx]
+            running_bs = padded_list[ub_idx]
             # Real requests that fall into this ubatch's [req_start, req_end),
             # clamped to scheduled_bs (cudagraph pad rows beyond scheduled_bs
             # carry sentinels, exercised only during capture's synthetic batch).
@@ -2724,53 +2724,53 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             # ---- per-seq slices into ub buffers ----
             ub_ctx_np = context_lens_np[req_start : req_start + ub_real_reqs]
             var[f"{p}context_lens"].np[:ub_real_reqs] = ub_ctx_np
-            var[f"{p}context_lens"].np[ub_real_reqs:padded_bs] = 0
+            var[f"{p}context_lens"].np[ub_real_reqs:running_bs] = 0
 
             ub_state_np = state_slot_np[req_start : req_start + ub_real_reqs]
             if len(ub_state_np) < ub_real_reqs:
                 ub_state_np = np.zeros(ub_real_reqs, dtype=np.int32)
             var[f"{p}v4_meta_state_slot_out"].np[:ub_real_reqs] = ub_state_np
-            var[f"{p}v4_meta_state_slot_out"].np[ub_real_reqs:padded_bs] = 0
-            state_slot_np_ub = var[f"{p}v4_meta_state_slot_out"].np[:padded_bs].copy()
+            var[f"{p}v4_meta_state_slot_out"].np[ub_real_reqs:running_bs] = 0
+            state_slot_np_ub = var[f"{p}v4_meta_state_slot_out"].np[:running_bs].copy()
             ub_state_in_np = state_slot_in_np[req_start : req_start + ub_real_reqs]
             if len(ub_state_in_np) < ub_real_reqs:
                 ub_state_in_np = np.zeros(ub_real_reqs, dtype=np.int32)
             var[f"{p}v4_meta_state_slot_in"].np[:ub_real_reqs] = ub_state_in_np
-            var[f"{p}v4_meta_state_slot_in"].np[ub_real_reqs:padded_bs] = 0
+            var[f"{p}v4_meta_state_slot_in"].np[ub_real_reqs:running_bs] = 0
 
             var[f"{p}block_tables"].np[:ub_real_reqs] = var["block_tables"].np[
                 req_start : req_start + ub_real_reqs
             ]
-            var[f"{p}block_tables"].np[ub_real_reqs:padded_bs] = 0
+            var[f"{p}block_tables"].np[ub_real_reqs:running_bs] = 0
 
             # positions: copy the ubatch's token slice (values match the global
             # positions slice the UBatchWrapper Context will expose).
             ub_positions_np = positions_np[tok_start : tok_start + ub_real_tokens]
             var[f"{p}positions"].np[:ub_real_tokens] = ub_positions_np
-            var[f"{p}positions"].np[ub_real_tokens : padded_bs * max_seqlen_q] = 0
+            var[f"{p}positions"].np[ub_real_tokens : running_bs * max_seqlen_q] = 0
 
             # cu_seqlens_q: exact per-request lengths, padded tail flat.
             cu = np.zeros(ub_real_reqs + 1, dtype=np.int32)
             np.cumsum(ub_extend_lens_np, out=cu[1:])
             var[f"{p}cu_seqlens_q"].np[: ub_real_reqs + 1] = cu
             var[f"{p}cu_seqlens_q"].np[
-                ub_real_reqs + 1 : padded_bs + 1
+                ub_real_reqs + 1 : running_bs + 1
             ] = ub_real_tokens
 
             # ---- H2D ----
             ub_sum_tokens = max(ub_real_tokens, 1)
-            positions_gpu = var[f"{p}positions"].copy_to_gpu(padded_bs * max_seqlen_q)
-            cu_seqlens_q_gpu = var[f"{p}cu_seqlens_q"].copy_to_gpu(padded_bs + 1)
-            context_lens_gpu = var[f"{p}context_lens"].copy_to_gpu(padded_bs)
-            block_tables_gpu = var[f"{p}block_tables"].copy_to_gpu(padded_bs)
-            state_slot_gpu = var[f"{p}v4_meta_state_slot_out"].copy_to_gpu(padded_bs)
+            positions_gpu = var[f"{p}positions"].copy_to_gpu(running_bs * max_seqlen_q)
+            cu_seqlens_q_gpu = var[f"{p}cu_seqlens_q"].copy_to_gpu(running_bs + 1)
+            context_lens_gpu = var[f"{p}context_lens"].copy_to_gpu(running_bs)
+            block_tables_gpu = var[f"{p}block_tables"].copy_to_gpu(running_bs)
+            state_slot_gpu = var[f"{p}v4_meta_state_slot_out"].copy_to_gpu(running_bs)
 
             # ---- compress plans (per ubatch buffer set) ----
             ctx_for_plan = context_lens_np[req_start : req_start + ub_real_reqs]
             compress_plans = self._build_compress_plans(
                 ub_extend_lens_np,
                 ctx_for_plan,
-                graph_bs=padded_bs,
+                running_bs=running_bs,
                 max_q_len=max_seqlen_q,
                 buf_prefix_ubatch=p,
             )
@@ -2791,12 +2791,12 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             )
             attn_metadata.state_slot_out = state_slot_gpu
             attn_metadata.state_slot_in = var[f"{p}v4_meta_state_slot_in"].copy_to_gpu(
-                padded_bs
+                running_bs
             )
             attn_metadata.state_slot_out_cpu = state_slot_np_ub
             attn_metadata.compress_plans = compress_plans
             if dspark_ragged:
-                ragged_lens_buf = np.zeros(padded_bs, dtype=np.int32)
+                ragged_lens_buf = np.zeros(running_bs, dtype=np.int32)
                 ragged_lens_buf[:ub_real_reqs] = ub_extend_lens_np
                 attn_metadata.dspark_ragged_lens_gpu = torch.as_tensor(
                     ragged_lens_buf, device=positions_gpu.device
@@ -2809,7 +2809,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 state_slot_np_ub,
                 ub_real_reqs,
                 ub_real_tokens,
-                padded_bs=padded_bs,
+                running_bs=running_bs,
                 max_q_len=max_seqlen_q,
                 buf_prefix_ubatch=p,
             )
@@ -2824,7 +2824,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         self._ubatch_decode_meta = metas
 
     def build_ubatch_metadata(
-        self, ubatch_idx: int, padded_bs: int
+        self, ubatch_idx: int, running_bs: int
     ) -> AttentionMetaData_DSV4:
         assert self._ubatch_decode_meta is not None, (
             "build_ubatch_metadata called but no ubatch decode metadata was "
@@ -3073,7 +3073,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         self,
         attn_metadata: AttentionMetaData,
         ub_slice,
-        padded_bs: int,
+        running_bs: int,
         ubatch_idx: int = 0,
     ) -> AttentionMetaData_DSV4:
         """Split prefill AttentionMetaData for V4 TBO micro-batches.
@@ -3082,9 +3082,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         - PCP+TBO request-boundary split: dispatches to
           `_build_ubatch_prefill_metadata_balanced(attn_metadata, ubatch_idx)`,
           which derives the group from `model_runner._pcp_bal_groups[ubatch_idx]`
-          and **ignores `ub_slice` / `padded_bs`** (the group's request/token
+          and **ignores `ub_slice` / `running_bs`** (the group's request/token
           ranges come from the PcpBalGroup, not the ub_slice).
-        - Token-split TBO (default, §11): uses `ub_slice` / `padded_bs`.
+        - Token-split TBO (default, §11): uses `ub_slice` / `running_bs`.
         """
         from atom.utils.tbo.ubatch_splitting import split_attn_metadata
 
@@ -3100,7 +3100,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 attn_metadata, ubatch_idx
             )
 
-        ub_attn = split_attn_metadata(attn_metadata, ub_slice, padded_bs)
+        ub_attn = split_attn_metadata(attn_metadata, ub_slice, running_bs)
         ub_attn.__class__ = AttentionMetaData_DSV4
 
         src = cast(AttentionMetaData_DSV4, attn_metadata)
@@ -3134,7 +3134,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             # Per-ubatch plan buffers — sharing the main pool would let
             # ubatch 1's CPU build overwrite ubatch 0's before ubatch 0
             # launches its compressor kernel. TBO prefill is eager-only,
-            # so leave graph_bs/max_q_len unset (tight n_compress/n_write).
+            # so leave running_bs/max_q_len unset (tight n_compress/n_write).
             ub_plan_buffers = self._get_ubatch_compress_plan_buffers(ubatch_idx)
             ub_attn.compress_plans = make_compress_plans(
                 np.ascontiguousarray(extend_lens_np, dtype=np.int32),
@@ -3378,7 +3378,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         scheduled_bs: int,
         total_tokens: int,
         *,
-        padded_bs: int | None = None,
+        running_bs: int | None = None,
         max_q_len: int | None = None,
         buf_prefix_ubatch: str = "",
     ) -> None:
@@ -3403,7 +3403,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         Caller contract: `scheduled_bs >= 1` and `total_tokens >= 1`.
         warmup_model + dummy_run paths both enforce these via min-1 fallbacks
         (model_runner.warmup_model:1003-1011, _populate_state_slot_mappings
-        zeros-fill); CG capture uses graph_bs >= 1 too.
+        zeros-fill); CG capture uses running_bs >= 1 too.
         """
         # state is set by the caller at AttentionMetaData_DSV4 construction
         # time (single source of truth — prepare_decode / prepare_prefill /
@@ -3412,18 +3412,18 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         is_pure_decode = attn_metadata.state is AttnState.DECODE
 
         # padded_total_tokens: CG-captured decode/MTP pads to the fixed
-        # bucket `padded_bs * (1+max_spec_steps)` so the per-token
+        # bucket `running_bs * (1+max_spec_steps)` so the per-token
         # `batch_id_per_token` buffer has a stable shape across captures.
         # Prefill states (PREFILL_NATIVE / PREFILL_PREFIX) are eager and
         # use `total_tokens` exactly — no wasted padding (a long prefill
         # chunk doesn't need to be padded up to a bucket that doesn't
         # exist for it).
         if is_pure_decode:
-            assert padded_bs is not None and max_q_len is not None, (
-                "DECODE state requires padded_bs + max_q_len from caller "
+            assert running_bs is not None and max_q_len is not None, (
+                "DECODE state requires running_bs + max_q_len from caller "
                 "(CG bucket size — fixed at capture)"
             )
-            padded_total_tokens = int(padded_bs) * int(max_q_len)
+            padded_total_tokens = int(running_bs) * int(max_q_len)
         else:
             padded_total_tokens = total_tokens
 
@@ -3463,11 +3463,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             f"{buf_prefix_ubatch}v4_batch_id_per_token", batch_id_per_token_np
         )
         # Stage n_committed to GPU. For CG-replay safety: aiter
-        # `top_k_per_row_decode` iterates the CAPTURED grid (= padded_bs *
+        # `top_k_per_row_decode` iterates the CAPTURED grid (= running_bs *
         # next_n rows) and reads `rowEnds[batch_id]` for every row. Its
         # per-row length formula is
         #   `row_len = rowEnds[bid] - next_n + (r % next_n) + 1`
-        # — for pad rows `bid ∈ [scheduled_bs, padded_bs)` the buffer slot
+        # — for pad rows `bid ∈ [scheduled_bs, running_bs)` the buffer slot
         # carries a stale value from a prior fwd; if that stale value is
         # `< next_n - 1` (easy with MTP3 next_n=4 if a prior fwd had a seq
         # in early prefill with ctx ≤ 11), row_len becomes negative and the
@@ -3477,9 +3477,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # to keep row_len non-negative. Use `index_topk` (≥ 1024 ≫ next_n).
         n_csa_buf = var[f"{buf_prefix_ubatch}v4_n_committed_csa_per_seq"]
         n_csa_buf.np[:scheduled_bs] = n_committed_csa_per_seq_np
-        if is_pure_decode and padded_bs is not None and padded_bs > scheduled_bs:
-            n_csa_buf.np[scheduled_bs:padded_bs] = self.index_topk
-            attn_metadata.n_committed_csa_per_seq = n_csa_buf.copy_to_gpu(padded_bs)
+        if is_pure_decode and running_bs is not None and running_bs > scheduled_bs:
+            n_csa_buf.np[scheduled_bs:running_bs] = self.index_topk
+            attn_metadata.n_committed_csa_per_seq = n_csa_buf.copy_to_gpu(running_bs)
         else:
             attn_metadata.n_committed_csa_per_seq = n_csa_buf.copy_to_gpu(scheduled_bs)
         self._attach_v4_paged_decode_meta(
@@ -4024,7 +4024,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         extend_lens_np,
         context_lens_np,
         *,
-        graph_bs: int | None = None,
+        running_bs: int | None = None,
         max_q_len: int | None = None,
         buf_prefix_ubatch: str = "",
     ):
@@ -4040,10 +4040,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         (fixed pointers for CUDAGraph capture); the kernels skip
         sentinel-marked tail rows.
 
-        `graph_bs` / `max_q_len`: set BOTH for decode runtime AND decode CG
+        `running_bs` / `max_q_len`: set BOTH for decode runtime AND decode CG
         capture — the returned compress/write plan_gpu are sliced to fixed
-        `graph_bs * per_seq_bound` capacities (per ratio) so capture/replay
-        shapes match, with `[bs, graph_bs)` padding rows sentinel-filled.
+        `running_bs * per_seq_bound` capacities (per ratio) so capture/replay
+        shapes match, with `[bs, running_bs)` padding rows sentinel-filled.
         Leave both None for eager prefill — the plan_gpu are sliced to the
         actual `n_compress` / `n_write` (smallest grid, no padding).
         """
@@ -4074,7 +4074,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             context_lens_np,
             self._unique_compress_ratios_overlap,
             plan_buffers=plan_buffers,
-            graph_bs=graph_bs,
+            running_bs=running_bs,
             max_q_len=max_q_len,
         )
 
@@ -4191,11 +4191,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         grid=(bs, write_per_batch) with bs baked at capture and write_per_batch a
         `constexpr`; rows past each seq's actual token count sentinel-skip.
         `update_compressor_states` launches grid=(write_plan.shape[0],) — the
-        decode-tight slice `graph_bs * min(qlen, K_pool)` baked at capture, NOT
+        decode-tight slice `running_bs * min(qlen, K_pool)` baked at capture, NOT
         the per-fwd num_write — and inactive rows carry `position=-1` and bail
         (see state_writes.py). So model.forward inside torch.cuda.graph does NOT
         hit a variable-grid launch here. (`fused_compress_attn` is likewise
-        CG-safe: launches at the decode-tight compress slice `graph_bs *
+        CG-safe: launches at the decode-tight compress slice `running_bs *
         ceil(qlen/ratio)` baked at capture and sentinel-skips inactive rows for
         both BF16 Main and FP8 Indexer paths.)
         """
@@ -4327,10 +4327,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         attn_metadata.compress_plans = self._build_compress_plans(
             extend_lens_np,
             context_lens_np,
-            graph_bs=bs,
+            running_bs=bs,
             max_q_len=max_q_len,
         )
-        # Capture: padded_bs == scheduled_bs == bs (synthetic batch is full).
+        # Capture: running_bs == scheduled_bs == bs (synthetic batch is full).
         # Must run BEFORE `_attach_v4_indexer_meta` so the indexer-side meta
         # builder can reuse the shared per-fwd GPU tensors.
         self._attach_v4_per_fwd_meta(
@@ -4339,7 +4339,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.state_slot_out_cpu,
             bs,
             total_tokens,
-            padded_bs=bs,
+            running_bs=bs,
             max_q_len=max_q_len,
         )
         self._attach_v4_indexer_meta(
@@ -4364,8 +4364,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         context = Context(
             positions=positions,
             is_prefill=False,
-            batch_size=bs,
-            graph_bs=bs,
+            scheduled_bs=bs,
+            running_bs=bs,
+            # `total_tokens` is this capture's row count already -- the ragged
+            # path's flat bucket, not bs*max_q_len.
+            # A capture runs a full synthetic batch: nothing is padded.
+            scheduled_tokens=total_tokens,
+            running_tokens=total_tokens,
         )
         return attn_metadata, context
 
@@ -4573,12 +4578,12 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # The decode CG path uses a much tighter capacity than the prefill
         # worst case — the kernel grid is dictated by the slice of this
         # buffer that we hand to the kernel, and decode only ever needs
-        # `graph_bs * ceil((1 + max_spec_steps) / ratio)` compress rows (vs
+        # `running_bs * ceil((1 + max_spec_steps) / ratio)` compress rows (vs
         # `mnbt // ratio + bs` for prefill, ~13× larger at typical config). We
         # still allocate the full prefill capacity (eager prefill needs it),
         # but decode capture/replay slice down via `make_compress_plans(
-        # graph_bs=, max_q_len=)`, which computes the per-graph-tight caps
-        # `graph_bs * per_seq_bound` internally (see compress_plan.py).
+        # running_bs=, max_q_len=)`, which computes the per-graph-tight caps
+        # `running_bs * per_seq_bound` internally (see compress_plan.py).
         for ratio, is_overlap in self._unique_compress_ratios_overlap:
             # NOTE: K_pool is the pool-window size (algorithm constant), NOT the
             # state ring buffer size. The ring buffer is K_pool + max_spec_steps

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -2383,12 +2383,12 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # draft costs nothing for the rows it invented instead of repeating a
         # real one's gather. At bs=65 padded to 128 that is half the batch.
         #
-        # THE buffer the verify fwd publishes on this field, not a private
-        # one: a captured draft graph baked that address, so a mid-step that
-        # republished a different tensor would leave the replay reading the
-        # verify map -- and the `-1` tail below is the only thing masking the
-        # pad rows out of the fused SWA write. Restaged by the verify fwd every
-        # step, so writing it here clobbers nothing.
+        # By its fixed name because a captured draft graph bakes this address:
+        # the tensor a mid-step installs has to be the same object every step,
+        # and under TBO `attn_metadata` alternates between ubatch-prefixed
+        # buffers. The draft is not ubatched, so the unprefixed one and a global
+        # arange are its map. `_attach_v4_per_fwd_meta` reassigns this field on
+        # every verify fwd, so writing it clobbers nothing.
         #
         # Not a slice of `cu_seqlens_q` either: that one is also the q indptr,
         # and a sentinel in it would corrupt the other reader. `row_ids` is

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -2353,6 +2353,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
 
         var = self.model_runner.forward_vars
+        pad_bs = int(positions.shape[-1])  # rows; see the base contract
         attn_metadata = cast(
             AttentionMetaData_DSV4, get_forward_context().attn_metadata
         )
@@ -2370,17 +2371,32 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # `prepare_decode`.
         actual_swa = torch.clamp(positions + 1, max=win)
 
-        swa_indptr = var["v4_kv_indptr_swa"].gpu[: bs + 1]
+        swa_indptr = var["v4_kv_indptr_swa"].gpu[: pad_bs + 1]
         # positions/actual_swa are int64 (eagle's positions buffer); cast to
         # int32 inside cumsum to match swa_indptr's int32 storage.
         torch.cumsum(actual_swa, dim=0, dtype=torch.int32, out=swa_indptr[1:])
 
-        # batch_id_per_token: 1-tok-per-seq → arange(bs). Eagle already
-        # populated cu_seqlens_q as arange(bs+1) (eagle.py:430), so its
-        # [:bs] slice IS [0,1,...,bs-1] — exactly the per-token batch id.
-        # No extra alloc / arange kernel.
-        assert attn_metadata.cu_seqlens_q is not None
-        batch_id_per_token = attn_metadata.cu_seqlens_q[:bs]
+        # batch_id_per_token: 1-tok-per-seq → arange(bs), with `-1` over the
+        # drafter's pad tail. That sentinel is the SAME one the verify fwd uses
+        # (`_attach_v4_per_fwd_meta` fills the padded tail with -1): the index
+        # writer and `csa_translate_pack` both skip those rows, so a padded
+        # draft costs nothing for the rows it invented instead of repeating a
+        # real one's gather. At bs=65 padded to 128 that is half the batch.
+        #
+        # THE buffer the verify fwd publishes on this field, not a private
+        # one: a captured draft graph baked that address, so a mid-step that
+        # republished a different tensor would leave the replay reading the
+        # verify map -- and the `-1` tail below is the only thing masking the
+        # pad rows out of the fused SWA write. Restaged by the verify fwd every
+        # step, so writing it here clobbers nothing.
+        #
+        # Not a slice of `cu_seqlens_q` either: that one is also the q indptr,
+        # and a sentinel in it would corrupt the other reader. `_v4_row_ids` is
+        # the resident arange the real prefix is restored from.
+        batch_id_per_token = var["v4_batch_id_per_token"].gpu[:pad_bs]
+        batch_id_per_token[:bs].copy_(self._v4_row_ids[:bs])
+        if pad_bs > bs:
+            batch_id_per_token[bs:] = -1
 
         # ----- Kernel: write SWA prefix paged offsets -----
         # MTP layers are dense, so only the dense class's buffer is asked for;
@@ -2390,7 +2406,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         swa_indices_buf = var["v4_kv_indices_swa"]
         dest_rows = self._dest_row_buffers()
         write_v4_paged_decode_indices(
-            state_slot_per_seq=attn_metadata.state_slot_out[:bs],
+            state_slot_per_seq=attn_metadata.state_slot_out[:pad_bs],
             batch_id_per_token=batch_id_per_token,
             positions=positions,
             swa_indptr=swa_indptr,
@@ -2400,7 +2416,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             csa_indices=None,
             hca_indices=None,
             dest_rows=dest_rows,
-            T=bs,
+            T=pad_bs,
             win=win,
             geometry=self.pool_geometry,
         )
@@ -2422,7 +2438,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # to that length via the same builder-staged path as the verify fwd.
         if self._kv_fp8:
             attn_metadata.qo_indptr = self._stage(
-                "v4_qo_indptr", self._v4_qo_indptr_np[: bs + 1]
+                "v4_qo_indptr", self._v4_qo_indptr_np[: pad_bs + 1]
             )
 
         # NOT rebuilt (unused by SWA-only MTP layer; would block a future
@@ -2523,6 +2539,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         si_buf.np[:scheduled_bs] = self._state_slot_in_np(
             batch, scheduled_bs, state_slot_np
         )
+        # Published at the PADDED `bs`, like the ubatch path below already does,
+        # so a consumer that runs the padded batch -- a speculative drafter -- can
+        # slice to it. Every reader either masks the pad tail out
+        # (`batch_id_per_token = -1`) or discards those rows, so 0 is as good a
+        # filler here as it is there.
+        ss_buf.np[scheduled_bs:bs] = 0
+        si_buf.np[scheduled_bs:bs] = 0
 
         # ---- fire H2D on prep_stream ----
         # NB: this runs inside attn_metadata_builder.build(), BEFORE
@@ -2535,8 +2558,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             cu_seqlens_q_gpu = var["cu_seqlens_q"].copy_to_gpu(bs + 1)
             context_lens_gpu = var["context_lens"].copy_to_gpu(scheduled_bs)
             block_tables_gpu = var["block_tables"].copy_to_gpu(scheduled_bs)
-            state_slot_gpu = ss_buf.copy_to_gpu(scheduled_bs)
-            state_slot_in_gpu = si_buf.copy_to_gpu(scheduled_bs)
+            state_slot_gpu = ss_buf.copy_to_gpu(bs)
+            state_slot_in_gpu = si_buf.copy_to_gpu(bs)
 
         # ---- CPU numpy work, overlapped with prep_stream H2D ----
         # RAGGED: per-seq extend lengths (else uniform max_seqlen_q). compress
@@ -4474,6 +4497,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # (re-copied into the captured buffer before graph.replay). The constant
         # numpy sources are precomputed once so the per-fwd cost is a slice + H2D.
         bufs["v4_qo_indptr"] = CpuGpuBuffer(T_dec + 1, **i32)
+        # The constant arange a mid-step restores the real prefix of
+        # `v4_batch_id_per_token` from, resident so no step rebuilds it.
+        self._v4_row_ids = torch.arange(bs, device=self.device, dtype=torch.int32)
         self._v4_qo_indptr_np = np.arange(T_dec + 1, dtype=np.int32)
         # Per-seq `ctx_len // 4` (raw, no clamp). Consumed by csa_translate_pack
         # (kernel masks `(k < n_committed) & (k < index_topk)`) AND by the

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -2391,10 +2391,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # step, so writing it here clobbers nothing.
         #
         # Not a slice of `cu_seqlens_q` either: that one is also the q indptr,
-        # and a sentinel in it would corrupt the other reader. `_v4_row_ids` is
+        # and a sentinel in it would corrupt the other reader. `row_ids` is
         # the resident arange the real prefix is restored from.
         batch_id_per_token = var["v4_batch_id_per_token"].gpu[:pad_bs]
-        batch_id_per_token[:bs].copy_(self._v4_row_ids[:bs])
+        batch_id_per_token[:bs].copy_(self.row_ids[:bs])
         if pad_bs > bs:
             batch_id_per_token[bs:] = -1
 
@@ -4497,9 +4497,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # (re-copied into the captured buffer before graph.replay). The constant
         # numpy sources are precomputed once so the per-fwd cost is a slice + H2D.
         bufs["v4_qo_indptr"] = CpuGpuBuffer(T_dec + 1, **i32)
-        # The constant arange a mid-step restores the real prefix of
-        # `v4_batch_id_per_token` from, resident so no step rebuilds it.
-        self._v4_row_ids = torch.arange(bs, device=self.device, dtype=torch.int32)
         self._v4_qo_indptr_np = np.arange(T_dec + 1, dtype=np.int32)
         # Per-seq `ctx_len // 4` (raw, no clamp). Consumed by csa_translate_pack
         # (kernel masks `(k < n_committed) & (k < index_topk)`) AND by the

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -2622,6 +2622,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             sum_scheduled_tokens,
             running_bs=running_bs,
             max_q_len=max_seqlen_q,
+            running_tokens=sum_scheduled_tokens_padded,
         )
         self._attach_v4_indexer_meta(
             attn_metadata,
@@ -3376,10 +3377,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         token_num_per_seq,
         state_slot_out_cpu,
         scheduled_bs: int,
-        total_tokens: int,
+        scheduled_tokens: int,
         *,
         running_bs: int | None = None,
         max_q_len: int | None = None,
+        running_tokens: int | None = None,
         buf_prefix_ubatch: str = "",
     ) -> None:
         """Hoist per-fwd, layer-invariant metadata used by every V4 layer.
@@ -3400,7 +3402,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             per-seq state cache slot (already set by prepare_*; passed
             through unchanged here).
 
-        Caller contract: `scheduled_bs >= 1` and `total_tokens >= 1`.
+        Caller contract: `scheduled_bs >= 1` and `scheduled_tokens >= 1`.
         warmup_model + dummy_run paths both enforce these via min-1 fallbacks
         (model_runner.warmup_model:1003-1011, _populate_state_slot_mappings
         zeros-fill); CG capture uses running_bs >= 1 too.
@@ -3415,7 +3417,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # bucket `running_bs * (1+max_spec_steps)` so the per-token
         # `batch_id_per_token` buffer has a stable shape across captures.
         # Prefill states (PREFILL_NATIVE / PREFILL_PREFIX) are eager and
-        # use `total_tokens` exactly — no wasted padding (a long prefill
+        # use `scheduled_tokens` exactly — no wasted padding (a long prefill
         # chunk doesn't need to be padded up to a bucket that doesn't
         # exist for it).
         if is_pure_decode:
@@ -3423,9 +3425,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 "DECODE state requires running_bs + max_q_len from caller "
                 "(CG bucket size — fixed at capture)"
             )
-            padded_total_tokens = int(running_bs) * int(max_q_len)
+            padded_total_tokens = (
+                int(running_tokens)
+                if running_tokens is not None
+                else int(running_bs) * int(max_q_len)
+            )
         else:
-            padded_total_tokens = total_tokens
+            padded_total_tokens = scheduled_tokens
 
         var = self.model_runner.forward_vars
 
@@ -3439,7 +3445,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             np.arange(scheduled_bs, dtype=np.int32), token_num_per_seq
         )
         batch_id_per_token_np = np.full(padded_total_tokens, -1, dtype=np.int32)
-        batch_id_per_token_np[:total_tokens] = batch_id_unpadded_np
+        batch_id_per_token_np[:scheduled_tokens] = batch_id_unpadded_np
         attn_metadata.batch_id_per_token_cpu = batch_id_unpadded_np
 
         # context_lens is int32 on the buffer; keep dtype through divide so
@@ -3487,7 +3493,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             token_num_per_seq=token_num_per_seq,
             state_slot_out_cpu=state_slot_out_cpu,
             scheduled_bs=scheduled_bs,
-            total_tokens=total_tokens,
+            total_tokens=scheduled_tokens,
             padded_total_tokens=padded_total_tokens,
             buf_prefix_ubatch=buf_prefix_ubatch,
         )

--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -595,6 +595,11 @@ class GDNStateMixin:
 class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
 
     reorder_batch_threshold: int = 1
+    # `prepare_mtp_decode` below regenerates kv_indices and nothing else, so it
+    # cannot absorb the position bump the fused path hands off to the backend.
+    # Inherited as True from the MHA builder, which made `EagleProposer` pass
+    # `update_context_lens` / `positions_out` into a signature that has neither.
+    fuse_mtp_decode_position_update = False
 
     def sub_pool_specs(self) -> list[SubPoolSpec]:
         """GDN hybrid: a paged KV pool holding ONLY the full-attention layer
@@ -727,7 +732,7 @@ class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
         only_update: bool = False,
         num_reject_tokens=None,
     ):
-        pad_bs = int(positions.shape[-1])  # rows; see the base contract
+        running_bs = int(positions.shape[-1])  # rows; see the base contract
         var = self.model_runner.forward_vars
 
         # GDN hybrid models use paged KV cache for full-attention layers.
@@ -737,9 +742,9 @@ class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
         # paged attention does not use persistent worker buffers that need
         # incremental updates (unlike MLA). The full kv_indices regeneration
         # is always correct regardless of the update mode.
-        kv_indptr = var["kv_indptr"].gpu[: pad_bs + 1]
+        kv_indptr = var["kv_indptr"].gpu[: running_bs + 1]
         kv_indices_generate_triton(
-            var["block_tables"].gpu[:pad_bs],
+            var["block_tables"].gpu[:running_bs],
             var["kv_indices"].gpu,
             kv_indptr,
             self.block_ratio,
@@ -748,7 +753,7 @@ class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
 
         result = {}
         if self.block_size == 1024:
-            result = self.set_aiter_persistent_worker_buffers(pad_bs)
+            result = self.set_aiter_persistent_worker_buffers(running_bs)
         return result
 
     def build_for_cudagraph_capture(self, bs: int):
@@ -772,8 +777,16 @@ class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
         attn_metadata.gdn_metadata = self._build_gdn_capture_metadata(bs)
 
         positions = var["positions"].copy_to_gpu(bs)
+        # A capture runs a full synthetic batch, so nothing is padded and the
+        # scheduled shape is the running one.
+        capture_tokens = bs * int(var["max_qlen"])
         context = Context(
-            positions=positions, is_prefill=False, batch_size=bs, graph_bs=bs
+            positions=positions,
+            is_prefill=False,
+            scheduled_bs=bs,
+            running_bs=bs,
+            scheduled_tokens=capture_tokens,
+            running_tokens=capture_tokens,
         )
         return attn_metadata, context
 

--- a/atom/model_ops/attentions/gdn_attn.py
+++ b/atom/model_ops/attentions/gdn_attn.py
@@ -727,6 +727,7 @@ class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
         only_update: bool = False,
         num_reject_tokens=None,
     ):
+        pad_bs = int(positions.shape[-1])  # rows; see the base contract
         var = self.model_runner.forward_vars
 
         # GDN hybrid models use paged KV cache for full-attention layers.
@@ -736,9 +737,9 @@ class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
         # paged attention does not use persistent worker buffers that need
         # incremental updates (unlike MLA). The full kv_indices regeneration
         # is always correct regardless of the update mode.
-        kv_indptr = var["kv_indptr"].gpu[: bs + 1]
+        kv_indptr = var["kv_indptr"].gpu[: pad_bs + 1]
         kv_indices_generate_triton(
-            var["block_tables"].gpu[:bs],
+            var["block_tables"].gpu[:pad_bs],
             var["kv_indices"].gpu,
             kv_indptr,
             self.block_ratio,
@@ -747,7 +748,7 @@ class GDNAttentionMetadataBuilder(GDNStateMixin, AiterAttentionMetadataBuilder):
 
         result = {}
         if self.block_size == 1024:
-            result = self.set_aiter_persistent_worker_buffers(bs)
+            result = self.set_aiter_persistent_worker_buffers(pad_bs)
         return result
 
     def build_for_cudagraph_capture(self, bs: int):

--- a/atom/model_ops/attentions/triton_mla.py
+++ b/atom/model_ops/attentions/triton_mla.py
@@ -69,27 +69,62 @@ class TritonMLAMetadataBuilder(AiterMLAMetadataBuilder):
         # Triton MLA does not use aiter persistent worker buffers
         return {}
 
+    def _cut_decode_buffers(
+        self,
+        rows: int,
+        max_seqlen_k: int,
+        kv_indices: torch.Tensor,
+        kv_indptr: torch.Tensor,
+    ) -> dict:
+        """The three buffers `attention_mla`'s Triton branch reads, cut to `rows`.
+
+        One implementation for both entry points, because the defect was that
+        only `prepare_decode` cut them: a mid-step then ran its own wider batch
+        against the verify forward's cut. Costs a zero plus a densify per
+        mid-step, which that path did not pay before.
+        """
+        var = self.model_runner.forward_vars
+        block_table = var["triton_block_table"][:rows, :max_seqlen_k]
+        block_table.zero_()
+        csr_to_dense_block_table(kv_indices, kv_indptr, block_table, max_seqlen_k, rows)
+        return {
+            "triton_block_table": block_table,
+            "triton_attn_logits": var["triton_attn_logits"][:rows],
+            "triton_lse": var["triton_lse"][:rows],
+        }
+
     def prepare_decode(self, batch: ScheduledBatch, bs: int):
         attn_metadata, positions = super().prepare_decode(batch, bs)
-
-        scheduled_bs = batch.total_seqs_num_decode
-        max_seqlen_k = attn_metadata.max_seqlen_k
-        var = self.model_runner.forward_vars
-
-        triton_bt = var["triton_block_table"][:scheduled_bs, :max_seqlen_k]
-        triton_bt.zero_()
-        csr_to_dense_block_table(
+        for name, buf in self._cut_decode_buffers(
+            batch.total_seqs_num_decode,
+            attn_metadata.max_seqlen_k,
             attn_metadata.kv_indices,
             attn_metadata.kv_indptr,
-            triton_bt,
-            max_seqlen_k,
-            scheduled_bs,
-        )
-        attn_metadata.triton_block_table = triton_bt
-        attn_metadata.triton_attn_logits = var["triton_attn_logits"][:scheduled_bs]
-        attn_metadata.triton_lse = var["triton_lse"][:scheduled_bs]
-
+        ).items():
+            setattr(attn_metadata, name, buf)
         return attn_metadata, positions
+
+    def prepare_mtp_decode(
+        self,
+        bs: int,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        positions: torch.Tensor,
+        only_update: bool = False,
+        num_reject_tokens: torch.Tensor | None = None,
+    ):
+        """Re-cut the Triton decode buffers off the `kv_indptr` the base rebuilt."""
+        result = super().prepare_mtp_decode(
+            bs, max_seqlen_q, max_seqlen_k, positions, only_update, num_reject_tokens
+        )
+        pad_bs = int(positions.shape[-1])  # rows; see the base contract
+        var = self.model_runner.forward_vars
+        return result | self._cut_decode_buffers(
+            pad_bs,
+            max_seqlen_k,
+            var["kv_indices"].gpu,
+            var["kv_indptr"].gpu[: pad_bs + 1],
+        )
 
     def prepare_prefill(self, batch: ScheduledBatch):
         attn_metadata, positions = super().prepare_prefill(batch)

--- a/atom/model_ops/attentions/triton_mla.py
+++ b/atom/model_ops/attentions/triton_mla.py
@@ -2,10 +2,10 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import logging
-from typing import List, Type
 
 import torch
 from aiter.ops.triton.attention.mla_decode import csr_to_dense_block_table
+
 from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_ops.attention_mla import MLAAttention
 from atom.utils import envs
@@ -23,11 +23,11 @@ class TritonMLABackend(AttentionBackend):
         return "ROCM_TRITON_MLA"
 
     @staticmethod
-    def get_builder_cls() -> Type["TritonMLAMetadataBuilder"]:
+    def get_builder_cls() -> type["TritonMLAMetadataBuilder"]:
         return TritonMLAMetadataBuilder
 
     @staticmethod
-    def get_impl_cls() -> Type["MLAAttention"]:
+    def get_impl_cls() -> type["MLAAttention"]:
         return MLAAttention
 
 
@@ -112,18 +112,31 @@ class TritonMLAMetadataBuilder(AiterMLAMetadataBuilder):
         positions: torch.Tensor,
         only_update: bool = False,
         num_reject_tokens: torch.Tensor | None = None,
+        **fused,
     ):
-        """Re-cut the Triton decode buffers off the `kv_indptr` the base rebuilt."""
+        """Re-cut the Triton decode buffers off the `kv_indptr` the base rebuilt.
+
+        `**fused` rather than the base's three keyword-only arguments spelled
+        out again: this class inherits `fuse_mtp_decode_position_update`, so
+        `EagleProposer` passes them, and an override that restated them could
+        fall behind the base without anything noticing until the call raised.
+        """
         result = super().prepare_mtp_decode(
-            bs, max_seqlen_q, max_seqlen_k, positions, only_update, num_reject_tokens
+            bs,
+            max_seqlen_q,
+            max_seqlen_k,
+            positions,
+            only_update,
+            num_reject_tokens,
+            **fused,
         )
-        pad_bs = int(positions.shape[-1])  # rows; see the base contract
+        running_bs = int(positions.shape[-1])  # rows; see the base contract
         var = self.model_runner.forward_vars
         return result | self._cut_decode_buffers(
-            pad_bs,
+            running_bs,
             max_seqlen_k,
             var["kv_indices"].gpu,
-            var["kv_indptr"].gpu[: pad_bs + 1],
+            var["kv_indptr"].gpu[: running_bs + 1],
         )
 
     def prepare_prefill(self, batch: ScheduledBatch):
@@ -203,11 +216,11 @@ class TritonMLAMetadataBuilder(AiterMLAMetadataBuilder):
         blk_offsets = torch.zeros(bs + 1, dtype=torch.int64, device=device)
         blk_offsets[1:] = torch.cumsum(per_seq_blocks, dim=0)
 
-        blk_indptr_list: List[torch.Tensor] = []
-        blk_indices_list: List[torch.Tensor] = []
-        cu_seqlens_k_list: List[torch.Tensor] = []
-        chunk_total_tokens: List[torch.Tensor] = []
-        chunk_max_seqlen_k: List[torch.Tensor] = []
+        blk_indptr_list: list[torch.Tensor] = []
+        blk_indices_list: list[torch.Tensor] = []
+        cu_seqlens_k_list: list[torch.Tensor] = []
+        chunk_total_tokens: list[torch.Tensor] = []
+        chunk_max_seqlen_k: list[torch.Tensor] = []
 
         for c in range(num_chunks):
             gb_start = c * chunk_blocks

--- a/atom/model_ops/fused_moe/flydsl_mega_experts.py
+++ b/atom/model_ops/fused_moe/flydsl_mega_experts.py
@@ -311,7 +311,7 @@ class MegaFusedExperts:
             experts=global_num_experts,
             # Infer top-k from the routing tensors, same as the standard kernels.
             topk=int(topk_ids.shape[1]),
-            # todo decode use graph_bs for perf
+            # todo decode use running_bs for perf
             mtpr=self._mtpr,
             swiglu_limit=getattr(self._layer, "swiglu_limit", 0.0),
             quant=self._quant,

--- a/atom/model_ops/fused_moe/modular_kernel.py
+++ b/atom/model_ops/fused_moe/modular_kernel.py
@@ -294,9 +294,9 @@ class FusedMoEModularKernel(torch.nn.Module):
         """Trim the mori dispatch buffer's dead tail before fused_moe.
 
         Default (native/sglang/rtp) policy: under a uniform all-ranks-decode
-        batch, trim to the static graph_bs*dp bound so the shape is
+        batch, trim to the static running_tokens*dp bound so the shape is
         consistent across cudagraph capture/replay. mori dispatch dedups per
-        destination rank, so a rank receives at most graph_bs tokens per source
+        destination rank, so a rank receives at most running_tokens per source
         rank -- the bound must not multiply by topk. atom-vllm needs a different,
         exact received-token trim for DP+EP mixed batches and overrides this
         method via a plugin patch -- keep this body frontend-agnostic.
@@ -306,8 +306,8 @@ class FusedMoEModularKernel(torch.nn.Module):
             return dispatch_a1, dispatch_scale, dispatch_ids, dispatch_weights
 
         dp_size = get_dp_group().world_size
-        # graph_bs keeps the trimmed shape consistent during capture/replay.
-        total_valid_tokens = context.graph_bs * dp_size
+        # running_tokens keeps the trimmed shape consistent capture-to-replay.
+        total_valid_tokens = context.running_tokens * dp_size
         all_ranks_decode = getattr(context, "dp_uniform_decode", not context.is_prefill)
         if total_valid_tokens < dispatch_a1.shape[0] and all_ranks_decode:
             dispatch_a1 = dispatch_a1[:total_valid_tokens]

--- a/atom/model_ops/fused_moe/mori_v2_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_v2_prepare_finalize.py
@@ -501,7 +501,7 @@ class MoriV2ModularKernel(mk.FusedMoEModularKernel):
     Both transports get the same grid shrink. The dispatch arena is padded to a
     huge static token_num (ws * max_num_inp_token_per_rank) while the received
     tokens occupy only the first ``total_recv`` rows, so under a uniform
-    all-ranks-decode batch it is capped at the static ``graph_bs * topk * dp``
+    all-ranks-decode batch it is capped at the static ``running_tokens*topk*dp``
     bound (the V1/base policy): the grid-bound aiter kernels (route-ksplit
     preshuffle, gather-reduce) then launch a grid sized to the decode bucket
     instead of the full arena, and the single-block route/psum kernels shrink too.
@@ -513,12 +513,12 @@ class MoriV2ModularKernel(mk.FusedMoEModularKernel):
         """Static recv-row bound for a uniform decode batch, else None (no shrink).
 
         Correctness / capture-safety:
-          * ``graph_bs`` is a python int, constant per captured cudagraph, so the
+          * ``running_tokens`` is a python int, fixed per captured graph, so the
             bound is static across capture/replay and no GPU->CPU sync is needed
             (unlike reading the device ``total_recv``).
-          * Under uniform decode each of ``dp`` ranks holds ``graph_bs`` tokens,
+          * Under uniform decode each of ``dp`` ranks holds ``running_tokens``,
             each routed to ``topk`` experts; worst case every route lands on this
-            rank, so ``total_recv <= graph_bs * topk * dp``. The bound therefore
+            rank, so ``total_recv <= running_tokens*topk*dp``. The bound therefore
             never drops a valid row, and the aiter kernels' device-side
             ``num_valid_routes`` guard still skips the exact within-buffer tail
             [total_recv, bound).
@@ -531,7 +531,7 @@ class MoriV2ModularKernel(mk.FusedMoEModularKernel):
         all_ranks_decode = getattr(context, "dp_uniform_decode", not context.is_prefill)
         if not all_ranks_decode:
             return None
-        bound = context.graph_bs * topk_ids.shape[1] * get_dp_group().world_size
+        bound = context.running_tokens * topk_ids.shape[1] * get_dp_group().world_size
         return bound if bound < arena_rows else None
 
     def _maybe_trim_dispatch_output(

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -347,50 +347,47 @@ def naive_multicast(
 
 
 def pad_for_all_gather(x: torch.Tensor) -> tuple[torch.Tensor, int]:
-    """Pad ``x`` along dim 0 up to the uniform all-gather batch size.
+    """Pad ``x`` up to the uniform all-gather height, and return both.
 
-    Every DP rank must contribute the same number of rows to the uniform
-    all-gather, so a short batch is padded up to ``graph_bs`` (scaled by the
-    per-sequence query length when decoding with MTP > 1).
+    The height comes off the context, never off ``x``: this pads for a
+    collective, so guessing it from the tensor turns a caller's mistake into a
+    DP-wide hang instead of a local failure. A decode forward arrives already
+    at ``running_tokens`` (the runner padded ``input_ids``), a prefill at
+    ``scheduled_tokens``; a draft states its own pair before it runs
+    (`Drafter._publish_draft_shape`), so it needs no case here.
 
-    Pad rows are left UNINITIALIZED. The expert GEMM is per-token and
-    ``reduce_scatter_with_unpadding`` drops the pad region, so garbage there
-    cannot reach a real token's output. It DOES reach the EPLB counter:
-    ``get_moe_input`` gathers ``router_logits`` with the same padding, so
-    ``record_eplb_expert_load`` counts pad rows into the expert-load histogram.
-    Fix that by excluding pad rows from the counter, not by zeroing here —
-    all-zero logits route deterministically and skew it just as much.
+    ATOM therefore never reaches the copy below -- it only runs uniform decode,
+    where the two are equal. The bridges can, on a prefill they call uniform.
 
-    (An earlier revision claimed the pad MUST be zeroed, citing a ~0.7pp GSM8K
-    drop. It was written while ``zero_()`` was already commented out, and
-    restoring the zeroing measures no difference on V4-Flash-DSpark tp8 + DPA —
-    though that is not the V4-Pro TBO config the original was bisected on.)
-
-    Returns the (possibly padded) tensor and the original row count so the
-    caller can unpad after reduce-scatter.
+    Pad rows are left UNINITIALIZED: the expert GEMM is per-token and
+    ``reduce_scatter_with_unpadding`` drops them. They DO reach the EPLB
+    counter, since ``get_moe_input`` gathers ``router_logits`` the same way --
+    exclude them there rather than zeroing here, which skews it just as much.
     """
-    ctx = get_forward_context()
-    max_batch_size = ctx.context.graph_bs
-    if not ctx.context.is_prefill and ctx.attn_metadata is not None:
-        max_batch_size *= ctx.attn_metadata.max_seqlen_q
-
-    original_batch_size = x.shape[0]
-    padding_size = max_batch_size - original_batch_size
-    if padding_size <= 0:
-        return x, original_batch_size
+    ctx = get_forward_context().context
+    running_tokens = ctx.running_tokens
+    local_tokens = ctx.scheduled_tokens if ctx.is_prefill else running_tokens
+    assert x.shape[0] == local_tokens, (
+        f"MoE was handed {x.shape[0]} rows on a "
+        f"{'prefill' if ctx.is_prefill else 'decode'} step expecting "
+        f"{local_tokens} (scheduled_tokens={ctx.scheduled_tokens}, "
+        f"running_tokens={running_tokens})"
+    )
+    if local_tokens >= running_tokens:
+        return x, local_tokens
 
     padding_shape = list(x.shape)
-    padding_shape[0] = max_batch_size
+    padding_shape[0] = running_tokens
     padded_x = torch.empty(padding_shape, device=x.device, dtype=x.dtype)
-    padded_x[:original_batch_size, :].copy_(x)
-    # padded_x[original_batch_size:, :].zero_() # keep for debug
-    return padded_x, original_batch_size
+    padded_x[:local_tokens, :].copy_(x)
+    # padded_x[local_tokens:, :].zero_() # keep for debug
+    return padded_x, local_tokens
 
 
 def all_gather_with_padding(
     x: torch.Tensor, use_cag: bool = True
 ) -> tuple[torch.Tensor, int]:
-    padded_x, original_batch_size = pad_for_all_gather(x)
+    padded_x, local_tokens = pad_for_all_gather(x)
     # use_custom=True routes through CA IPC (outplace_all_gather). Default
     # use_custom=False falls back to torch.distributed.all_gather_into_tensor
     # (NCCL), whose WorkNCCL end-event recorded inside CUDAGraph capture is
@@ -398,7 +395,7 @@ def all_gather_with_padding(
     gathered_hidden_states = get_dp_group().all_gather(
         padded_x, use_custom=use_cag, dim=0
     )
-    return gathered_hidden_states, original_batch_size
+    return gathered_hidden_states, local_tokens
 
 
 def repeat_rows(x: torch.Tensor, times: int) -> torch.Tensor:
@@ -416,16 +413,14 @@ def repeat_rows(x: torch.Tensor, times: int) -> torch.Tensor:
     return x.repeat(times, *([1] * (x.dim() - 1)))
 
 
-def reduce_scatter_with_unpadding(
-    x: torch.Tensor, original_batch_size: int
-) -> torch.Tensor:
+def reduce_scatter_with_unpadding(x: torch.Tensor, local_tokens: int) -> torch.Tensor:
     dp_group = get_dp_group()
     scattered_output = dp_group.reduce_scatter_tensor(x)
 
     # Drop the rows pad_for_all_gather appended (padding is on dim 0). Their
     # contents were never initialized, so they must not survive past here.
-    if scattered_output.shape[0] > original_batch_size:
-        scattered_output = scattered_output[:original_batch_size]
+    if scattered_output.shape[0] > local_tokens:
+        scattered_output = scattered_output[:local_tokens]
 
     return scattered_output
 
@@ -455,13 +450,21 @@ def dp_gather_hidden_and_router(
       same token count, so a plain padded ``all_gather`` per tensor is
       enough.
 
-    Returns ``(hidden_states, router_logits, original_hidden_size, sizes)``;
-    ``sizes`` is non-None only in eager mode (needed later for
-    ``reduce_scatterv``).
+    Returns ``(hidden_states, router_logits, local_tokens, sizes)``, where
+    ``local_tokens`` is this rank's own height -- what ``reduce_scatterv`` /
+    ``reduce_scatter_with_unpadding`` must trim back to. ``sizes`` is non-None
+    only in eager mode (needed later for ``reduce_scatterv``).
     """
     if dp_eager_mode:
         sizes = ctx.dp_metadata.get_sizes_across_dp()
-        original_hidden_size = hidden_states.shape[0]
+        # Eager means nothing was padded, so the context's two heights agree
+        # and either is the row count to unpad back to. Taken from the context
+        # rather than the tensor for the reason `pad_for_all_gather` gives.
+        local_tokens = ctx.context.scheduled_tokens
+        assert hidden_states.shape[0] == local_tokens, (
+            f"MoE was handed {hidden_states.shape[0]} rows on an eager step "
+            f"expecting {local_tokens}"
+        )
         h_dim = hidden_states.shape[-1]
         r_dim = router_logits.shape[-1]
         r_dtype = router_logits.dtype
@@ -480,11 +483,11 @@ def dp_gather_hidden_and_router(
             router_logits = router_logits.to(r_dtype)
         else:
             router_logits = router_logits.contiguous()
-        return hidden_states, router_logits, original_hidden_size, sizes
+        return hidden_states, router_logits, local_tokens, sizes
 
-    hidden_states, original_hidden_size = all_gather_with_padding(hidden_states)
+    hidden_states, local_tokens = all_gather_with_padding(hidden_states)
     router_logits, _ = all_gather_with_padding(router_logits)
-    return hidden_states, router_logits, original_hidden_size, None
+    return hidden_states, router_logits, local_tokens, None
 
 
 @torch_compile_guard()
@@ -4264,8 +4267,10 @@ class FusedMoE(torch.nn.Module):
         # 1. Pure DP mode: only DP is used
         # 2. DP attention + EP mori Moe
         # 3. DP attention + TP All_gahter/reduce Moe
-        original_hidden_size = None
-        sizes = None
+        # `local_tokens` / `sizes` are bound inside the gather block below and
+        # read only inside the scatter block, which tests the same unchanged
+        # condition -- pre-seeding them with None would make a state the code
+        # cannot reach look representable.
         # Use all_gather/reduce_scatter when DP > 1 but not using mori all2all kernels
         use_dp_gather_scatter = (
             self.dp_size > 1
@@ -4291,7 +4296,7 @@ class FusedMoE(torch.nn.Module):
             (
                 hidden_states,
                 router_logits,
-                original_hidden_size,
+                local_tokens,
                 sizes,
             ) = dp_gather_hidden_and_router(
                 hidden_states, router_logits, dp_eager_mode, ctx, dp_group
@@ -4342,7 +4347,7 @@ class FusedMoE(torch.nn.Module):
                 )
             else:
                 final_hidden_states = reduce_scatter_with_unpadding(
-                    final_hidden_states, original_hidden_size
+                    final_hidden_states, local_tokens
                 )
             if _tbo:
                 tbo_switch_to_compute_sync()

--- a/atom/model_ops/v4_kernels/compress_plan.py
+++ b/atom/model_ops/v4_kernels/compress_plan.py
@@ -33,8 +33,8 @@ Caller (per-seq loop) gets `cu_compress_cpu` for slicing the kernel's flat
 output `[num_compress, head_dim]` back to per-seq chunks.
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable, Tuple
 
 import numpy as np
 import torch
@@ -67,7 +67,7 @@ class CompressPlan:
 def make_compress_plans(
     extend_lens_cpu: np.ndarray,
     context_lens_cpu: np.ndarray,
-    unique_ratios_overlap: Iterable[Tuple[int, bool]],
+    unique_ratios_overlap: Iterable[tuple[int, bool]],
     *,
     plan_buffers: dict,
     running_bs: int | None = None,

--- a/atom/model_ops/v4_kernels/compress_plan.py
+++ b/atom/model_ops/v4_kernels/compress_plan.py
@@ -25,7 +25,7 @@ Two plan tensors are produced per `compress_ratio`:
                    per `update_compressor_states` kernel program.
 
 Each plan is sliced to a kernel-grid length that depends on the mode: tight
-`num_compress` / `num_write` for eager, or a fixed `graph_bs * per_seq_bound`
+`num_compress` / `num_write` for eager, or a fixed `running_bs * per_seq_bound`
 for the decode CUDAGraph path (padding rows sentinel-filled). See
 `make_compress_plans` for the exact per-mode capacities.
 
@@ -70,7 +70,7 @@ def make_compress_plans(
     unique_ratios_overlap: Iterable[Tuple[int, bool]],
     *,
     plan_buffers: dict,
-    graph_bs: int | None = None,
+    running_bs: int | None = None,
     max_q_len: int | None = None,
     decode_capacity_per_ratio: dict[int, int] | None = None,
 ) -> dict[int, CompressPlan]:
@@ -93,33 +93,33 @@ def make_compress_plans(
                     calls (CUDAGraph requirement). Fresh per-call alloc is
                     not supported — that pattern caused allocator-churn
                     races (see `write_v4_paged_decode_indices` docstring).
-      graph_bs: optional int — the CUDAGraph-padded batch size (>= bs). When
+      running_bs: optional int — the CUDAGraph-padded batch size (>= bs). When
                     PROVIDED this selects the DECODE CUDAGraph path: both
                     `compress_plan_gpu` and `write_plan_gpu` are sliced to a
-                    FIXED, content-independent capacity `graph_bs *
+                    FIXED, content-independent capacity `running_bs *
                     per_seq_bound` (compress bound = `ceil(max_q_len / ratio)`;
                     write bound = `min(max_q_len, K_pool)`), and rows
                     `[n_actual, cap)` are sentinel-filled. The cap depends only
-                    on `graph_bs` and `max_q_len` (both fixed at capture), so
+                    on `running_bs` and `max_q_len` (both fixed at capture), so
                     capture and replay dispatch identically-shaped kernels; the
-                    `[bs, graph_bs)` padding seqs land in the sentinel region.
-                    `max_q_len` is required when `graph_bs` is set. Because the
+                    `[bs, running_bs)` padding seqs land in the sentinel region.
+                    `max_q_len` is required when `running_bs` is set. Because the
                     decode write count is EXACTLY `bs * min(qlen, K_pool)`
                     (content-independent), no separate write-capacity dict is
-                    needed — the write cap is derived from `graph_bs`/`max_q_len`
+                    needed — the write cap is derived from `running_bs`/`max_q_len`
                     identically to compress.
       max_q_len: optional int — uniform per-seq query length of the padded
-                    decode batch (`1 + max_spec_steps`). Required iff `graph_bs`
+                    decode batch (`1 + max_spec_steps`). Required iff `running_bs`
                     is set; used to compute the per-seq compress/write bounds.
       decode_capacity_per_ratio: optional dict[ratio] -> int — explicit FIXED
                     COMPRESS slice length, for CUDAGraph paths whose per-fwd
-                    token count is not the uniform `graph_bs * max_q_len` shape
+                    token count is not the uniform `running_bs * max_q_len` shape
                     (the extend-shaped target-verify graph, whose buffers are
                     sized to a dynamic token count). Mutually exclusive with
-                    `graph_bs`. The write plan then keeps the full-buffer legacy
+                    `running_bs`. The write plan then keeps the full-buffer legacy
                     slice (fixed = buffer capacity, sentinel-filled) since that
                     path's write grid is bounded by its buffer sizing.
-                    When BOTH this and `graph_bs` are None (eager prefill /
+                    When BOTH this and `running_bs` are None (eager prefill /
                     eager plugin bridges): compress slice = `n_compress` (tight)
                     and write slice = full buffer (legacy). Slices are
                     contiguous-from-base so data pointers stay stable; only
@@ -137,11 +137,11 @@ def make_compress_plans(
     context_lens_cpu = np.ascontiguousarray(context_lens_cpu, dtype=np.int32)
     total = int(extend_lens_cpu.sum())
     out: dict[int, CompressPlan] = {}
-    if graph_bs is not None:
-        assert max_q_len is not None, "max_q_len is required when graph_bs is set"
+    if running_bs is not None:
+        assert max_q_len is not None, "max_q_len is required when running_bs is set"
         assert (
             decode_capacity_per_ratio is None
-        ), "graph_bs and decode_capacity_per_ratio are mutually exclusive"
+        ), "running_bs and decode_capacity_per_ratio are mutually exclusive"
 
     def _slices(
         ratio: int,
@@ -152,19 +152,19 @@ def make_compress_plans(
     ) -> tuple[int, int]:
         """(compress_slice, write_slice) — the fixed-or-tight kernel-grid lengths
         for this ratio. Three modes:
-          * graph_bs set (uniform decode CG): both = `graph_bs * per_seq_bound`
+          * running_bs set (uniform decode CG): both = `running_bs * per_seq_bound`
             (compress ceil(qlen/ratio); write min(qlen,K_pool)) — content-
             independent, so capture/replay dispatch identical shapes and the
-            `[n_actual, cap)` region is exactly the `[bs, graph_bs)` padding.
+            `[n_actual, cap)` region is exactly the `[bs, running_bs)` padding.
           * decode_capacity_per_ratio set (extend-shaped verify CG): compress =
             explicit cap; write = full buffer (fixed by buffer sizing).
           * neither (eager): compress = n_compress (tight); write = full buffer.
         """
-        if graph_bs is not None:
+        if running_bs is not None:
             k_pool = (2 if is_overlap else 1) * ratio
             return (
-                graph_bs * ((max_q_len + ratio - 1) // ratio),  # ceil(qlen/ratio)
-                graph_bs * min(max_q_len, k_pool),
+                running_bs * ((max_q_len + ratio - 1) // ratio),  # ceil(qlen/ratio)
+                running_bs * min(max_q_len, k_pool),
             )
         if decode_capacity_per_ratio is not None:
             return decode_capacity_per_ratio[ratio], full_wcap
@@ -254,19 +254,19 @@ def make_compress_plans(
         assert n_compress <= compress_slice <= full_ccap, (
             f"ratio={ratio} num_compress={n_compress}, slice={compress_slice}, "
             f"buffer={full_ccap}: invariant violated. CG path requires "
-            f"n_compress ≤ graph_bs·ceil(qlen/ratio) / decode_cap; eager uses "
+            f"n_compress ≤ running_bs·ceil(qlen/ratio) / decode_cap; eager uses "
             f"n_compress."
         )
         assert n_write <= write_slice <= full_wcap, (
             f"ratio={ratio} num_write={n_write}, slice={write_slice}, "
             f"buffer={full_wcap}: invariant violated. CG path requires "
-            f"n_write ≤ graph_bs·min(qlen,K_pool); else uses full buffer."
+            f"n_write ≤ running_bs·min(qlen,K_pool); else uses full buffer."
         )
         if n_compress > 0:
             cbuf.np[:n_compress] = compress_plan
         # Sentinel only within the slice we hand to the kernel; rows beyond
         # the slice are unreachable from this launch. For the CG path the
-        # `[n_*, cap)` region is exactly the `[bs, graph_bs)` padding seqs.
+        # `[n_*, cap)` region is exactly the `[bs, running_bs)` padding seqs.
         if compress_slice > n_compress:
             cbuf.np[n_compress:compress_slice].fill(-1)
         if n_write > 0:

--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -131,16 +131,17 @@ class DSparkIndexBuffers:
     entries of the max-batch buffer ARE the batch-`B` answer.
 
     `draft_width` / `draft_window` are the shape the buffers were cut for, kept
-    here so no caller can hand a slice a different one; `qo_indptr` and
-    `batch_ids` are constants filled at allocation and never written again.
-    `built_for` is the batch the other three currently hold.
+    here so no caller can hand a slice a different one; `qo_indptr` is a
+    constant filled at allocation and never written again. `built_for` is the
+    batch `kv_indices` / `kv_indptr` / `draft_rows` currently hold; `batch_ids`
+    additionally follows how much of that batch is real, via `mask_pad_tail`.
     """
 
     kv_indices: torch.Tensor  # [max_b*T*(W+T)] int32
     kv_indptr: torch.Tensor  # [max_b*T+1] int32
     draft_rows: torch.Tensor  # [max_b*T] int32
     qo_indptr: torch.Tensor  # [max_b*T+1] int32, constant ramp
-    batch_ids: torch.Tensor  # [max_b*T] int32, constant [0]*T ++ [1]*T ++ ...
+    batch_ids: torch.Tensor  # [max_b*T] int32, [0]*T ++ [1]*T ++ ..., -1 on pad
     max_batch: int
     draft_width: int  # T
     draft_window: int  # W
@@ -157,10 +158,9 @@ class DSparkIndexBuffers:
         for its own decode AND verify forwards (`deepseek_v4_attn.py:3727`).
 
         `batch_ids` is the token -> request map the fused SWA scatter gates on
-        (`bid >= 0`). It carries no CG-pad sentinels, and needs none: the draft runs
-        at `context.batch_size`, which is `scheduled_bs`, the REAL decode batch
-        (`model_runner.py:2609`) -- not the padded `effective_bs` the target's
-        metadata is built at. The target can alias `cu_seqlens_q[:bs]` for its own
+        (`bid >= 0`), and carries `-1` over a padded batch's fabricated rows; it
+        is `mask_pad_tail` that writes both halves, so this leaves it empty. The
+        target can alias `cu_seqlens_q[:bs]` for its own
         (`deepseek_v4_attn.py:2348`) because at one token per sequence that slice is
         already `arange(bs)`; DSpark runs T tokens per request and needs each id
         repeated T times, so there is nothing to alias.
@@ -172,15 +172,25 @@ class DSparkIndexBuffers:
             kv_indptr=torch.empty(n + 1, **i32),
             draft_rows=torch.empty(n, **i32),
             qo_indptr=torch.arange(n + 1, **i32),
-            batch_ids=torch.arange(max_batch, **i32)
-            .view(max_batch, 1)
-            .expand(max_batch, draft)
-            .reshape(-1)
-            .contiguous(),
+            batch_ids=torch.empty(n, **i32),
             max_batch=max_batch,
             draft_width=draft,
             draft_window=window,
         )
+
+    def mask_pad_tail(self, row_ids: torch.Tensor, real_batch: int, batch: int) -> None:
+        """Sentinel the rows past `real_batch`, so the fused SWA write skips them.
+
+        Restores the prefix as well as marking the tail: a sentinel left on a row
+        that has since become real would drop that request's draft KV silently.
+        `row_ids` is the builder's `arange`, broadcast one id across the row's T
+        tokens -- one strided copy, no repeated map to keep anywhere.
+        """
+        t = self.draft_width
+        self.batch_ids[: real_batch * t].view(real_batch, t).copy_(
+            row_ids[:real_batch].unsqueeze(1)
+        )
+        self.batch_ids[real_batch * t : batch * t].fill_(-1)
 
     def build(
         self,

--- a/atom/model_ops/v4_kernels/dspark_fp8_indices.py
+++ b/atom/model_ops/v4_kernels/dspark_fp8_indices.py
@@ -18,8 +18,9 @@ row ids rather than a materialised `[B, W+T, 512]` tensor.
 
 and `DSparkIndexBuffers.views` reads them back.
 
-`qo_indptr` and the scatter's `batch_ids` are constants that ride in the same
-`DSparkIndexBuffers` bundle. Everything is allocated once at `max_num_seqs` and
+`qo_indptr` is a constant riding in the same `DSparkIndexBuffers` bundle; the
+scatter's `batch_ids` is filled there too but follows how much of the batch is
+real, via `mask_pad_tail`. Everything is allocated once at `max_num_seqs` and
 only ever sliced, and shapes are statically known -- no `.item()`, no
 data-dependent allocation -- so a captured CUDA graph replays it.
 
@@ -158,12 +159,13 @@ class DSparkIndexBuffers:
         for its own decode AND verify forwards (`deepseek_v4_attn.py:3727`).
 
         `batch_ids` is the token -> request map the fused SWA scatter gates on
-        (`bid >= 0`), and carries `-1` over a padded batch's fabricated rows; it
-        is `mask_pad_tail` that writes both halves, so this leaves it empty. The
-        target can alias `cu_seqlens_q[:bs]` for its own
-        (`deepseek_v4_attn.py:2348`) because at one token per sequence that slice is
-        already `arange(bs)`; DSpark runs T tokens per request and needs each id
-        repeated T times, so there is nothing to alias.
+        (`bid >= 0`); `mask_pad_tail` rewrites it when a batch is padded. Filled
+        here rather than left ``empty`` because the startup sweep runs the block
+        first, and a buffer whose contract gives `-1` a meaning should not start
+        out undefined. The target can alias `cu_seqlens_q[:bs]` for its own
+        (`deepseek_v4_attn.py:2348`) because at one token per sequence that slice
+        is already `arange(bs)`; DSpark runs T tokens per request and needs each
+        id repeated T times, so there is nothing to alias.
         """
         n = max_batch * draft
         i32 = {"dtype": torch.int32, "device": device}
@@ -172,7 +174,7 @@ class DSparkIndexBuffers:
             kv_indptr=torch.empty(n + 1, **i32),
             draft_rows=torch.empty(n, **i32),
             qo_indptr=torch.arange(n + 1, **i32),
-            batch_ids=torch.empty(n, **i32),
+            batch_ids=torch.arange(n, **i32) // draft,
             max_batch=max_batch,
             draft_width=draft,
             draft_window=window,

--- a/atom/model_ops/v4_kernels/fused_compress.py
+++ b/atom/model_ops/v4_kernels/fused_compress.py
@@ -10,7 +10,7 @@ SGLang plan-style batched dispatch (vs. the earlier per-seq launcher):
   Each compression boundary across the entire fwd is one row in
   `compress_plan_gpu` — a packed `[num_compress, 4] int32` tensor where each
   row is `[ragged_id, batch_id, position, window_len]`. The kernel grid is
-  the caller-supplied slice length (decode CG: `graph_bs * ceil(qlen/ratio)`
+  the caller-supplied slice length (decode CG: `running_bs * ceil(qlen/ratio)`
   / eager prefill: `n_compress`); inactive plan rows are sentinel-marked
   (`position == -1`) and bail at the top of the kernel. Each program does
   ONE 4×i32 load to get all the metadata it needs:
@@ -141,7 +141,7 @@ def _fused_compress_attn_kernel(
     FP8_MAX: tl.constexpr = 1.0,
 ):
     """One program per boundary in the plan. Grid = caller-supplied slice
-    length (decode CG: `graph_bs * ceil(qlen/ratio)` for capture/replay
+    length (decode CG: `running_bs * ceil(qlen/ratio)` for capture/replay
     address stability; eager prefill: tight `n_compress`). Inactive rows
     are sentinel-marked (position == -1) and bail before any load /
     store / scatter."""

--- a/atom/model_ops/v4_kernels/state_writes.py
+++ b/atom/model_ops/v4_kernels/state_writes.py
@@ -597,7 +597,7 @@ def update_compressor_states(
       write_plan:   [grid, 4] int32 — packed (ragged_id, batch_id, position, _);
                     each active row = one token to write. `grid` (== shape[0])
                     is the caller-supplied slice length: the decode-tight
-                    `graph_bs * min(qlen, K_pool)` on the CUDAGraph path, tight
+                    `running_bs * min(qlen, K_pool)` on the CUDAGraph path, tight
                     `num_write` on the eager path, or the full buffer capacity
                     for the extend-shaped verify path. Inactive tail rows carry
                     sentinel `position=-1` and are skipped.

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1577,7 +1577,9 @@ def sparse_attn_indexer(
         return torch.zeros_like(weights, dtype=torch.float32)
     # For MTP verify decode, max_seqlen_q > 1 so total decode tokens = batch_size * max_seqlen_q
     num_decode_tokens = (
-        context.batch_size * attn_metadata.max_seqlen_q if not context.is_prefill else 0
+        context.scheduled_bs * attn_metadata.max_seqlen_q
+        if not context.is_prefill
+        else 0
     )
     runner_block_size = get_current_atom_config().kv_cache_block_size
     cp_kv_cache_interleave_size = get_current_atom_config().dcp_config.interleave_size
@@ -1642,7 +1644,7 @@ def sparse_attn_indexer(
         if attn_metadata.max_seqlen_k <= topk_tokens:
             return weights
         prefill_metadata = attn_metadata
-        num_prefills = context.batch_size
+        num_prefills = context.scheduled_bs
         # Size the gathered-KV buffer off the KEY length, not the hidden/query
         # length. Under PCP the query side (hidden_states) is 1/pcp while `k` is
         # the full all-gathered key set, so `k.shape[0]` is the correct full
@@ -1785,12 +1787,12 @@ def sparse_attn_indexer(
         # we only have [num_block, block_size, head_dim],
         kv_cache = kv_cache.unsqueeze(-2)
         padded_q_fp8_decode_tokens = q_fp8[:num_decode_tokens].reshape(
-            context.batch_size, -1, *q_fp8.shape[1:]
+            context.scheduled_bs, -1, *q_fp8.shape[1:]
         )
         # TODO: move and optimize below logic with triton kernels
         batch_size = padded_q_fp8_decode_tokens.shape[0]
         next_n = padded_q_fp8_decode_tokens.shape[1]
-        assert batch_size == context.batch_size
+        assert batch_size == context.scheduled_bs
         num_padded_tokens = batch_size * next_n
         batch_size, next_n, _heads, _ = padded_q_fp8_decode_tokens.shape
         num_rows = batch_size * next_n

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -2150,7 +2150,7 @@ class Indexer(nn.Module):
         exercised eagerly under PIECEWISE (the paged core is an eager splitting op).
 
         `--cudagraph-mode FULL` works too: `graph_key` is only
-        `(graph_bs, max_q_len)`, so a rectangular step (DP-sync dummy, boundary,
+        `(running_bs, max_q_len)`, so a rectangular step (DP-sync dummy, boundary,
         no-shrink) can replay a ragged-captured graph. The attn builder therefore
         refreshes these windows on EVERY decode fwd — rectangular ones included —
         so a replay never reads the previous step's stale windows (which faulted

--- a/atom/models/deepseek_v4_dspark.py
+++ b/atom/models/deepseek_v4_dspark.py
@@ -704,7 +704,7 @@ class DSparkLayer(Block):  # type: ignore[misc]
 
         fc = get_forward_context()
         attn_md = fc.attn_metadata
-        B = fc.context.batch_size
+        B = fc.context.scheduled_bs
         cu_seqlens_q = attn_md.cu_seqlens_q[: B + 1]
         a = self.attn
         # An fp8 window is the planes' own 2buff layout, so the verified target

--- a/atom/plugin/register.py
+++ b/atom/plugin/register.py
@@ -427,10 +427,10 @@ def _patch_sglang_dsv4_spec_cuda_graph() -> None:
 
                     original_batch_size = forward_batch.batch_size
                     original_out_cache_loc = forward_batch.out_cache_loc
-                    graph_bs = int(self.bs)
-                    forward_batch.batch_size = graph_bs
+                    running_bs = int(self.bs)
+                    forward_batch.batch_size = running_bs
                     forward_batch.out_cache_loc = self.buffers.out_cache_loc[
-                        : graph_bs * self.topk * self.speculative_num_steps
+                        : running_bs * self.topk * self.speculative_num_steps
                     ]
                     try:
                         stage_glm52_draft_decode_graph_metadata(

--- a/atom/plugin/rtpllm/attention_backend/rtp_sparse_mla_backend.py
+++ b/atom/plugin/rtpllm/attention_backend/rtp_sparse_mla_backend.py
@@ -1715,10 +1715,10 @@ def _run_rtp_sparse_attn_indexer_topk_only(
         return weights
 
     max_seqlen_q = int(getattr(attn_metadata, "max_seqlen_q", 1) or 1)
-    num_decode_tokens = int(context.batch_size) * max_seqlen_q
+    num_decode_tokens = int(context.scheduled_bs) * max_seqlen_q
     kv_cache_for_logits = kv_cache.unsqueeze(-2)
     padded_q_fp8_decode_tokens = q_fp8[:num_decode_tokens].reshape(
-        int(context.batch_size), -1, *q_fp8.shape[1:]
+        int(context.scheduled_bs), -1, *q_fp8.shape[1:]
     )
     batch_size, next_n, _heads, _dim = padded_q_fp8_decode_tokens.shape
     logits = torch.empty(

--- a/atom/plugin/rtpllm/utils/forward_context.py
+++ b/atom/plugin/rtpllm/utils/forward_context.py
@@ -38,6 +38,7 @@ from atom.utils.forward_context import (
     Context,
     _forward_kv_cache_context,
     reset_forward_context,
+    running_tokens_from_bs,
     set_forward_context,
     set_kv_cache_data,
 )
@@ -1635,11 +1636,17 @@ class RTPForwardContext:
             batch_size = int(attn_metadata.plugin_metadata.num_decodes)
         if batch_size <= 0:
             raise ValueError("RTP plugin failed to derive non-zero batch size.")
+        is_prefill = bool(getattr(attn_inputs, "is_prefill", False))
         context = Context(
             positions=positions,
-            is_prefill=bool(getattr(attn_inputs, "is_prefill", False)),
-            batch_size=batch_size,
-            graph_bs=batch_size,
+            is_prefill=is_prefill,
+            scheduled_bs=batch_size,
+            # The rows this forward really runs; MRoPE keeps the token axis last.
+            scheduled_tokens=int(positions.shape[-1]),
+            running_bs=batch_size,
+            running_tokens=running_tokens_from_bs(
+                batch_size, is_prefill=is_prefill, attn_metadata=attn_metadata
+            ),
         )
         return cls(
             gdn_metadata=gdn_metadata,

--- a/atom/plugin/sglang/attention_backend/attention_gdn.py
+++ b/atom/plugin/sglang/attention_backend/attention_gdn.py
@@ -462,8 +462,12 @@ class SGLangGDNForwardContext:
                 positions=forward_batch.positions,
                 is_prefill=is_prefill,
                 is_dummy_run=mode.is_idle(),
-                batch_size=forward_batch.batch_size,
-                graph_bs=forward_batch.batch_size,
+                scheduled_bs=forward_batch.batch_size,
+                running_bs=forward_batch.batch_size,
+                # `num_tokens` is already this step's flat row count, so no
+                # per-request multiplier is needed (nor available here).
+                scheduled_tokens=num_tokens,
+                running_tokens=num_tokens,
                 dp_uniform_decode=dp_uniform_decode,
             ),
             num_tokens,

--- a/atom/plugin/sglang/deepseek_v4_bridge.py
+++ b/atom/plugin/sglang/deepseek_v4_bridge.py
@@ -955,7 +955,7 @@ def _make_compress_plans(extend_lens_cpu, context_lens_cpu, device):
         [(4, True), (128, False)],
         plan_buffers=plan_buffers,
     )
-    # Eager path (graph_bs unset): full-buffer write slice; the eager bridge
+    # Eager path (running_bs unset): full-buffer write slice; the eager bridge
     # launches update_compressor_states with exactly num_write rows.
     for plan in plans.values():
         plan.write_plan_gpu = plan.write_plan_gpu[: plan.num_write]
@@ -1016,12 +1016,12 @@ class _V4SGLangDecodeGraphBuffers:
         self.idx_csa = i32(t * max(1, win + topk))
         self.idx_hca = i32(t * max(1, win + hca))
 
-        # Decode CG plan slicing is `graph_bs * per_seq_bound` (computed inside
-        # make_compress_plans). graph_bs == num_slots (padded decode batch);
+        # Decode CG plan slicing is `running_bs * per_seq_bound` (computed inside
+        # make_compress_plans). running_bs == num_slots (padded decode batch);
         # max_q_len == 1 + max_spec_steps (== max_decode_tokens // num_slots).
-        self.decode_graph_bs = s
+        self.decode_running_bs = s
         self.decode_q_len = max(1, t // s)
-        # Compress buffer sized to the graph_bs compress cap `s*ceil(qlen/ratio)`
+        # Compress buffer sized to the running_bs compress cap `s*ceil(qlen/ratio)`
         # (matches make_compress_plans' slice); write buffer to `s*K_pool`. Sizing
         # flat `s` would undersize the compress plan once ceil(qlen/ratio)>1 (mtp_k
         # >= 4). Mirrors the vllm bridge's `S*per_seq` sizing.
@@ -1137,7 +1137,7 @@ def _make_decode_graph_compress_plans(extend_lens_cpu, context_lens_cpu, bufs):
         np.ascontiguousarray(context_lens_cpu, dtype=np.int32),
         [(4, True), (128, False)],
         plan_buffers=bufs.plan_buffers,
-        graph_bs=bufs.decode_graph_bs,
+        running_bs=bufs.decode_running_bs,
         max_q_len=bufs.decode_q_len,
     )
 

--- a/atom/plugin/sglang/models/deepseek_v4_attention.py
+++ b/atom/plugin/sglang/models/deepseek_v4_attention.py
@@ -302,7 +302,7 @@ def patch_deepseek_v4_attention_for_sglang(attn: nn.Module) -> None:
                 num_reqs = (
                     int(state_slots.shape[0])
                     if torch.is_tensor(state_slots)
-                    else int(getattr(fc.context, "batch_size", 1))
+                    else int(getattr(fc.context, "scheduled_bs", 1))
                 )
                 num_real = int(getattr(attn_md, "max_seqlen_q", 1)) * num_reqs
             else:

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -780,23 +780,31 @@ def _set_atom_forward_context(
         else positions.shape[0]
     )
 
+    max_q = int(getattr(attn_metadata, "max_seqlen_q", 1) or 1)
     enable_dp_attention = bool(atom_config.enable_dp_attention)
     if enable_dp_attention:
         num_tokens_across_dp = _resolve_num_tokens_across_dp(
             atom_config, forward_batch, num_tokens
         )
-        graph_bs = int(torch.max(num_tokens_across_dp).item())
+        # Already TOKENS, and already the group max -- what MoE pads to.
+        running_tokens = int(torch.max(num_tokens_across_dp).item())
     else:
         num_tokens_across_dp = None
-        graph_bs = num_tokens if is_prefill else batch_size
+        running_tokens = num_tokens if is_prefill else batch_size * max_q
+    # Sequences, per the field's contract -- the TBO split divides this into
+    # per-ubatch request counts, so handing it a token count would make each
+    # ubatch `max_seqlen_q` times too wide. Prefill's value is unread there.
+    running_bs = batch_size if is_prefill else max(1, running_tokens // max_q)
 
     dp_uniform_decode = _resolve_dp_uniform_decode(atom_config, forward_batch)
     context = Context(
         positions=positions,
         is_prefill=is_prefill,
         is_dummy_run=is_dummy_run,
-        batch_size=batch_size,
-        graph_bs=graph_bs,
+        scheduled_bs=batch_size,
+        scheduled_tokens=num_tokens,
+        running_bs=running_bs,
+        running_tokens=running_tokens,
         dp_uniform_decode=dp_uniform_decode,
     )
     set_forward_context(

--- a/atom/plugin/sglang/tbo/adapter.py
+++ b/atom/plugin/sglang/tbo/adapter.py
@@ -36,8 +36,8 @@ class AdaptedSGLangUBatch:
     positions: torch.Tensor
     num_reqs: int
     num_tokens: int
-    padded_bs: int
-    graph_bs: int | None
+    running_bs: int
+    running_tokens: int | None
 
 
 def normalize_child_forward_batches(
@@ -93,7 +93,7 @@ def prepare_sglang_ubatch(
     child_forward_batch: ForwardBatch,
     *,
     is_prefill: bool,
-    full_graph_bs: int,
+    full_running_bs: int,
     ubatch_idx: int,
     num_ubatches: int,
     ub_max_tokens_across_dp: tuple[int, int] | None,
@@ -105,7 +105,7 @@ def prepare_sglang_ubatch(
     attention TP/CP alignment, or a CUDA Graph bucket, so use those tensors
     directly instead of slicing the parent and recreating the same padding.
     The merged output still uses the logical token count. Prefill also uses the
-    cross-DP maximum token count as graph_bs so every MORI rank allocates
+    cross-DP maximum token count as running_tokens so every MORI rank allocates
     matching communication buffers.
     """
 
@@ -137,27 +137,31 @@ def prepare_sglang_ubatch(
         )
 
     if is_prefill:
-        padded_bs = ub_num_reqs
+        running_bs = ub_num_reqs
     elif ubatch_idx < num_ubatches - 1:
-        padded_bs = full_graph_bs // num_ubatches
+        running_bs = full_running_bs // num_ubatches
     else:
-        padded_bs = full_graph_bs - (full_graph_bs // num_ubatches) * (num_ubatches - 1)
+        running_bs = full_running_bs - (full_running_bs // num_ubatches) * (
+            num_ubatches - 1
+        )
 
-    ub_graph_bs = child_padded_len
+    ub_running_tokens = child_padded_len
     if (
         is_prefill
         and ub_max_tokens_across_dp is not None
         and len(ub_max_tokens_across_dp) == num_ubatches
     ):
-        ub_graph_bs = max(ub_graph_bs, int(ub_max_tokens_across_dp[ubatch_idx]))
+        ub_running_tokens = max(
+            ub_running_tokens, int(ub_max_tokens_across_dp[ubatch_idx])
+        )
 
     return AdaptedSGLangUBatch(
         input_ids=ub_input_ids,
         positions=ub_positions,
         num_reqs=ub_num_reqs,
         num_tokens=ub_num_tokens,
-        padded_bs=padded_bs,
-        graph_bs=ub_graph_bs if is_prefill else None,
+        running_bs=running_bs,
+        running_tokens=ub_running_tokens if is_prefill else None,
     )
 
 

--- a/atom/plugin/sglang/tbo/ubatch_wrapper.py
+++ b/atom/plugin/sglang/tbo/ubatch_wrapper.py
@@ -28,24 +28,33 @@ class SGLangPluginUBatchWrapper(UBatchWrapper):
         ub_slice,
         positions: torch.Tensor,
         input_ids: torch.Tensor,
-        padded_bs: int,
+        running_bs: int,
         *,
-        ub_graph_bs: int | None,
+        ub_running_tokens: int | None,
         dp_metadata,
     ) -> ForwardContext:
         ub_num_reqs = ub_slice.request_slice.stop - ub_slice.request_slice.start
         ub_num_tokens = ub_slice.token_slice.stop - ub_slice.token_slice.start
-        graph_bs = (
-            ub_graph_bs
-            if ub_graph_bs is not None
-            else ub_num_tokens if ctx.context.is_prefill else padded_bs
+        # The adapter hands rows on prefill and None on decode, where the
+        # per-ubatch request count still needs its max_seqlen_q multiplier.
+        running_tokens = (
+            ub_running_tokens
+            if ub_running_tokens is not None
+            else (
+                ub_num_tokens
+                if ctx.context.is_prefill
+                else running_bs * int(ctx.attn_metadata.max_seqlen_q)
+            )
         )
         ub_context = Context(
             positions=positions,
             is_prefill=ctx.context.is_prefill,
             is_dummy_run=ctx.context.is_dummy_run,
-            batch_size=ub_num_reqs,
-            graph_bs=graph_bs,
+            scheduled_bs=ub_num_reqs,
+            scheduled_tokens=ub_num_tokens,
+            # `running_bs` already IS `ub_num_reqs` on prefill (see the adapter).
+            running_bs=running_bs,
+            running_tokens=running_tokens,
             is_draft=ctx.context.is_draft,
             dp_uniform_decode=ctx.context.dp_uniform_decode,
             forward_mode=ctx.context.forward_mode,
@@ -130,7 +139,7 @@ class SGLangPluginUBatchWrapper(UBatchWrapper):
                 ub_slice,
                 child_forward_batches[idx],
                 is_prefill=ctx.context.is_prefill,
-                full_graph_bs=ctx.context.graph_bs,
+                full_running_bs=ctx.context.running_bs,
                 ubatch_idx=idx,
                 num_ubatches=num_ubatches,
                 ub_max_tokens_across_dp=ctx.ub_max_tokens_across_dp,
@@ -140,8 +149,8 @@ class SGLangPluginUBatchWrapper(UBatchWrapper):
                 ub_slice,
                 adapted.positions,
                 adapted.input_ids,
-                adapted.padded_bs,
-                ub_graph_bs=adapted.graph_bs,
+                adapted.running_bs,
+                ub_running_tokens=adapted.running_tokens,
                 dp_metadata=(
                     ub_dp_metadata[idx] if ub_dp_metadata is not None else None
                 ),

--- a/atom/plugin/vllm/deepseek_v4_bridge.py
+++ b/atom/plugin/vllm/deepseek_v4_bridge.py
@@ -837,10 +837,10 @@ class _V4DecodeMetaBuffers:
             make_compress_plans as _mcp,
         )
 
-        # Decode CG plan slicing is `graph_bs * per_seq_bound` (computed inside
-        # make_compress_plans from these two scalars). graph_bs == num_slots
+        # Decode CG plan slicing is `running_bs * per_seq_bound` (computed inside
+        # make_compress_plans from these two scalars). running_bs == num_slots
         # (padded decode batch); max_q_len == 1 + max_spec_steps.
-        self.decode_graph_bs = S
+        self.decode_running_bs = S
         self.decode_q_len = max(1, T // S)
         self.plan_buffers: dict[int, dict] = {}
         for ratio, is_overlap in ratios_overlap:
@@ -1174,10 +1174,10 @@ def _make_compress_plans(
         ratios,
         plan_buffers=plan_buffers,
     )
-    # Eager path (graph_bs unset): make_compress_plans returns a full-buffer
+    # Eager path (running_bs unset): make_compress_plans returns a full-buffer
     # write slice (sentinel-padded). The eager bridge launches
     # update_compressor_states with exactly num_write rows, so re-slice down.
-    # Graph decode uses _make_decode_compress_plans (fixed graph_bs slice).
+    # Graph decode uses _make_decode_compress_plans (fixed running_bs slice).
     for plan in plans.values():
         plan.write_plan_gpu = plan.write_plan_gpu[: plan.num_write]
     return plans
@@ -1649,7 +1649,7 @@ def _make_decode_compress_plans(extend_lens_cpu, context_lens_cpu, bufs):
         np.ascontiguousarray(context_lens_cpu, dtype=np.int32),
         ratios_overlap,
         plan_buffers=bufs.plan_buffers,
-        graph_bs=bufs.decode_graph_bs,
+        running_bs=bufs.decode_running_bs,
         max_q_len=bufs.decode_q_len,
     )
 
@@ -2090,6 +2090,7 @@ def atom_deepseek_v4_forward_context(
     from atom.utils.forward_context import (
         Context,
         reset_forward_context,
+        running_tokens_from_bs,
         set_forward_context,
     )
 
@@ -2156,8 +2157,13 @@ def atom_deepseek_v4_forward_context(
         positions=positions,
         is_prefill=is_prefill,
         is_dummy_run=force_dummy or common_attn_metadata is None,
-        batch_size=batch_size,
-        graph_bs=batch_size,
+        scheduled_bs=batch_size,
+        # The rows this forward really runs -- what MoE will be handed.
+        scheduled_tokens=int(input_ids.shape[0]) if input_ids is not None else 0,
+        running_bs=batch_size,
+        running_tokens=running_tokens_from_bs(
+            batch_size, is_prefill=is_prefill, attn_metadata=attn_metadata
+        ),
         input_ids=input_ids,
     )
     set_forward_context(

--- a/atom/plugin/vllm/mori_patch.py
+++ b/atom/plugin/vllm/mori_patch.py
@@ -10,7 +10,7 @@ overridable methods and injected here, so native files stay clean:
   token-count threshold instead.
 * ``FusedMoEModularKernel._maybe_trim_dispatch_output`` (dispatch-buffer trim)
   -- vLLM DP+EP mixed batches need an exact received-token trim; the native
-  graph_bs bound under-counts recv on a decoding rank and reads past the
+  running_tokens bound under-counts recv on a decoding rank and reads past
   buffer -> illegal memory access.
 """
 

--- a/atom/spec_decode/draft_graph.py
+++ b/atom/spec_decode/draft_graph.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: MIT
+"""One draft forward, warmed and optionally captured per ``graph_bs``.
+
+Kept out of ``drafter.py`` so it stays importable without a GPU AITER build:
+the invariants below -- rounding to a captured batch, staging with a padded
+tail, the pad contract -- are pure torch, and CI has no aiter. A flavor's own
+passes still live with the flavor; only the machine is here.
+"""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from atom.utils import envs
+
+if TYPE_CHECKING:
+    from atom.config import Config
+
+
+@dataclass(frozen=True)
+class StagedInput:
+    """One staged input's type: everything but the leading batch axis."""
+
+    shape: tuple[int, ...] = ()
+    dtype: torch.dtype = torch.int32
+
+
+@dataclass
+class DraftGraph:
+    """One draft forward: declared by the flavor, bound to storage here.
+
+    Named for what it is FOR, not for what it always holds -- a pass that
+    declines to pad holds no graph at all (EPLB, eager, the separate-draft
+    flavor), because a graph is one shape and only padding pins the shape.
+
+    Three capabilities, each needing strictly more than the last:
+
+    * **warmup** -- run it once per ``graph_bs`` at startup, paying its
+      per-shape JIT there rather than mid-serve. Needs nothing.
+    * **pad** -- round the runtime batch up to a ``graph_bs``, so serving only
+      ever asks for a warmed one. Needs ``inputs`` (fixed addresses to pad into)
+      and ``pads`` (an assertion that the fabricated rows reach nothing).
+    * **capture** -- record it. Needs pad.
+
+    The pass is ``epilogue ∘ forward``. Warmup always runs both, so nothing
+    serving runs is left cold -- narrowing the warmup to the capturable part is
+    how the LM head silently stopped being warmed once. Capture takes ``forward``
+    alone, or both when ``capture_epilogue``; either way there is exactly one
+    place a graph is replayed, so a flavor cannot put the seam in the wrong spot.
+
+    ``warmup_inputs`` makes that startup batch plausible, since warming on zeros
+    compiles a shape no real batch draws.
+
+    Everything here counts SEQUENCES, in the same three words the target uses:
+    ``bs`` is real, ``pad_bs`` is what actually runs, ``graph_bs`` is the
+    captured set.
+    """
+
+    forward: Callable[..., Any]  # (pad_bs, **staged) -> Any
+    epilogue: Callable[..., Any] | None = None  # (fwd_out, pad_bs, **staged)
+    capture_epilogue: bool = False
+    inputs: "Mapping[str, StagedInput]" = field(default_factory=dict)
+    pads: bool = False
+    warmup_inputs: Callable[..., None] | None = None
+
+    _runner: Any = field(init=False, default=None)
+    _buffers: dict[str, torch.Tensor] = field(init=False, default_factory=dict)
+    _cuda_graphs: dict[int, tuple] = field(init=False, default_factory=dict)
+
+    @property
+    def name(self) -> str:
+        """Which pass this is, for the assertions below.
+
+        Taken from the forward rather than declared, so it cannot drift and it
+        points at the exact function. A declared one would have to be unique
+        across the repo on its own, and the words available -- "block", "step"
+        -- are the three most overloaded in it.
+        """
+        return self.forward.__qualname__
+
+    def bind(self, config: "Config", device, runner) -> "DraftGraph":
+        """Give the declared pass its storage. Once, at drafter init.
+
+        Buffers are allocated now rather than on first use: a capture bakes
+        their addresses, and one born on the capture step would come out of the
+        graph's own private pool.
+        """
+        assert not self.pads or self.inputs, (
+            f"{self.name} says it may pad but stages nothing, so there is no "
+            f"buffer for the fabricated rows to land in"
+        )
+        self._runner = runner
+        self._buffers = {
+            role: torch.zeros(
+                (config.max_num_seqs, *staged.shape),
+                dtype=staged.dtype,
+                device=device,
+            )
+            for role, staged in self.inputs.items()
+        }
+        return self
+
+    @property
+    def will_capture(self) -> bool:
+        """Whether warmup also captures. One gate for every flavor, since the
+        graph is made by the shared ``warmup``."""
+        return self.pads and envs.ATOM_DRAFT_CUDAGRAPH
+
+    def graph_bs_for(self, bs: int) -> int:
+        """Round ``bs`` up to a warmed ``graph_bs``, or leave it alone.
+
+        Monotone and idempotent by construction, so padding can never truncate,
+        and "warmed at startup" and "reachable at serve time" stay one set
+        rather than two lists that drift.
+
+        An empty batch is never rounded up -- a pad row is a copy of a real one.
+        Declining the padding rather than the pass is deliberate: under DP every
+        rank has to reach the draft's collectives.
+        """
+        if not bs or not self.pads:
+            return bs
+        return min((g for g in self._runner.graph_bs if g >= bs), default=bs)
+
+    def stage(
+        self, pad_bs: int, srcs: "Mapping[str, torch.Tensor]"
+    ) -> dict[str, torch.Tensor]:
+        """Copy every input into its fixed buffer, widening the batch to ``pad_bs``.
+
+        The only way in, because ``pads`` is the part of the contract nothing
+        else can check: a pass that lies about it still runs and still returns
+        the right shape -- its fabricated rows just land in another sequence's
+        KV.
+
+        How many rows are real comes from the sources, not from the caller: a
+        count that cannot disagree with the tensor it describes.
+        """
+        staged = {
+            role: self._stage_one(role, pad_bs, src) for role, src in srcs.items()
+        }
+        counts = {t.shape[0] for t in srcs.values() if t is not None}
+        assert len(counts) <= 1, (
+            f"{self.name} was handed batches of {sorted(counts)}; they "
+            f"describe one step, so one of them is not this step's"
+        )
+        bs = counts.pop() if counts else pad_bs
+        assert pad_bs == bs or self.pads, (
+            f"{self.name} was asked for {pad_bs} rows against {bs} real ones, "
+            f"but never said its fabricated rows are inert"
+        )
+        return staged
+
+    def _stage_one(self, role: str, pad_bs: int, src: torch.Tensor | None):
+        """Copy ``src`` into this input's fixed buffer, tail-repeating its last row.
+
+        Every input repeats the same last index, so a pad row is a coherent copy
+        of the last real one and only redoes work that row already does. Zeros
+        instead faulted 8/8 ranks at the first padded decode step, and repeating
+        one input alone -- an incoherent pair -- faulted too.
+
+        ``src=None`` hands back the view unwritten: warmup wants a well-formed
+        batch, not a particular one.
+        """
+        buf = self._buffers[role]
+        out = buf[:pad_bs]
+        if src is None:
+            return out
+        assert src.dtype == buf.dtype, (
+            f"draft input '{role}' of {self.name} arrived as {src.dtype}, but "
+            f"its storage is {buf.dtype}; a capture has that address baked"
+        )
+        assert src.ndim == buf.ndim, (
+            f"draft input '{role}' of {self.name} arrived as {tuple(src.shape)}, "
+            f"whose leading axis is not the batch; this pass stages "
+            f"{tuple(buf.shape[1:])} per sequence. MRoPE positions ([3, N]) are "
+            f"the case that reaches here"
+        )
+        bs = src.shape[0]
+        out[:bs].copy_(src)
+        if pad_bs > bs:
+            out[bs:].copy_(src[-1])  # copy_ broadcasts; no expand needed
+        return out
+
+    def is_captured(self, pad_bs: int) -> bool:
+        return pad_bs in self._cuda_graphs
+
+    @property
+    def _to_capture(self) -> Callable[..., Any]:
+        """What a graph holds -- and so what a replay stands in for."""
+        return self._forward_and_epilogue if self.capture_epilogue else self.forward
+
+    def run(self, pad_bs: int, **staged) -> Any:
+        """Replay this batch size's graph, then whatever it did not cover."""
+        captured = self._cuda_graphs.get(pad_bs)
+        if captured is None:
+            out = self._to_capture(pad_bs, **staged)
+        else:
+            graph, out = captured
+            graph.replay()
+        return (
+            out if self.capture_epilogue else self._run_epilogue(out, pad_bs, **staged)
+        )
+
+    def _forward_and_epilogue(self, pad_bs: int, **staged) -> Any:
+        return self._run_epilogue(self.forward(pad_bs, **staged), pad_bs, **staged)
+
+    def _run_epilogue(self, out: Any, pad_bs: int, **staged) -> Any:
+        return out if self.epilogue is None else self.epilogue(out, pad_bs, **staged)
+
+    @torch.inference_mode()
+    def warmup(self, pad_bs: int, *, pool=None, stream=None):
+        """Run the pass once at one ``graph_bs``, paying its per-shape JIT here."""
+        staged = {role: self._stage_one(role, pad_bs, None) for role in self.inputs}
+        if self.warmup_inputs is not None:
+            self.warmup_inputs(pad_bs, **staged)
+        # forward AND epilogue, so nothing serving runs is left cold.
+        self._forward_and_epilogue(pad_bs, **staged)
+        if not self.will_capture:
+            return pool
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, pool, stream=stream):
+            out = self._to_capture(pad_bs, **staged)
+        self._cuda_graphs[pad_bs] = (graph, out)
+        return pool or graph.pool()

--- a/atom/spec_decode/draft_graph.py
+++ b/atom/spec_decode/draft_graph.py
@@ -2,7 +2,7 @@
 """One draft forward, warmed and optionally captured per ``graph_bs``.
 
 Kept out of ``drafter.py`` so it stays importable without a GPU AITER build:
-the invariants below -- rounding to a captured batch, staging with a padded
+the invariants below -- which batch a pass may run at, staging with a padded
 tail, the pad contract -- are pure torch, and CI has no aiter. A flavor's own
 passes still live with the flavor; only the machine is here.
 """
@@ -39,9 +39,10 @@ class DraftGraph:
 
     * **warmup** -- run it once per ``graph_bs`` at startup, paying its
       per-shape JIT there rather than mid-serve. Needs nothing.
-    * **pad** -- round the runtime batch up to a ``graph_bs``, so serving only
-      ever asks for a warmed one. Needs ``inputs`` (fixed addresses to pad into)
-      and ``pads`` (an assertion that the fabricated rows reach nothing).
+    * **pad** -- run at the batch the target just ran, which the startup sweep
+      warmed, rather than at whatever this step's batch happens to be. Needs
+      ``inputs`` (fixed addresses to pad into) and ``pads`` (an assertion that
+      the fabricated rows reach nothing).
     * **capture** -- record it. Needs pad.
 
     The pass is ``epilogue ∘ forward``. Warmup always runs both, so nothing
@@ -65,7 +66,6 @@ class DraftGraph:
     pads: bool = False
     warmup_inputs: Callable[..., None] | None = None
 
-    _runner: Any = field(init=False, default=None)
     _buffers: dict[str, torch.Tensor] = field(init=False, default_factory=dict)
     _cuda_graphs: dict[int, tuple] = field(init=False, default_factory=dict)
 
@@ -80,7 +80,7 @@ class DraftGraph:
         """
         return self.forward.__qualname__
 
-    def bind(self, config: "Config", device, runner) -> "DraftGraph":
+    def bind(self, config: "Config", device) -> "DraftGraph":
         """Give the declared pass its storage. Once, at drafter init.
 
         Buffers are allocated now rather than on first use: a capture bakes
@@ -91,7 +91,6 @@ class DraftGraph:
             f"{self.name} says it may pad but stages nothing, so there is no "
             f"buffer for the fabricated rows to land in"
         )
-        self._runner = runner
         self._buffers = {
             role: torch.zeros(
                 (config.max_num_seqs, *staged.shape),
@@ -108,20 +107,45 @@ class DraftGraph:
         graph is made by the shared ``warmup``."""
         return self.pads and envs.ATOM_DRAFT_CUDAGRAPH
 
-    def graph_bs_for(self, bs: int) -> int:
-        """Round ``bs`` up to a warmed ``graph_bs``, or leave it alone.
+    def target_pad_bs(self, bs: int, context) -> int:
+        """The batch the target just ran at, or ``bs`` when it pinned none.
 
-        Monotone and idempotent by construction, so padding can never truncate,
-        and "warmed at startup" and "reachable at serve time" stay one set
-        rather than two lists that drift.
+        Never a batch the drafter picks. ``forward_mode.effective_bs`` IS what
+        the target ran: ``model_runner`` builds the attention metadata with it,
+        so every per-sequence buffer already reaches that far -- ``slot_mapping``
+        -1, ``context_lens`` 0, ring slots published -- and a pad row fabricates
+        nothing the backend has not already accounted for, on any backend and
+        without the drafter knowing each one's convention. It is a warmed shape
+        by construction too: on the cudagraph path ``ForwardMode.decide`` picks
+        it out of ``graph_bs``, which is the list the startup sweep warms.
 
-        An empty batch is never rounded up -- a pad row is a copy of a real one.
+        Not ``context.graph_bs``, which agrees except where DSpark's ragged path
+        overwrites it with a token-derived count (``_dspark_ragged_moe_graph_bs``)
+        that is neither captured nor the batch the metadata was built at.
+
+        Off the cudagraph path every eager branch of ``decide`` returns
+        ``effective_bs == scheduled_bs``, so this answers ``bs`` and nothing is
+        padded -- which is the only safe answer, since nobody sized the target's
+        metadata past the real batch there.
+
         Declining the padding rather than the pass is deliberate: under DP every
-        rank has to reach the draft's collectives.
+        rank still has to reach the draft's collectives.
         """
-        if not bs or not self.pads:
+        mode = context.forward_mode
+        if not self.pads or context.is_dummy_run:
             return bs
-        return min((g for g in self._runner.graph_bs if g >= bs), default=bs)
+        if mode is None or not mode.use_cudagraph:
+            return bs
+        return max(bs, int(mode.effective_bs))
+
+    def label(self, real_bs: int, pad_bs: int) -> str:
+        """``bs=<real>/<pad>`` plus a trailing ``graph`` on a replay.
+
+        One convention, one implementation: "did the draft get into a graph" is
+        then a single grep across every flavor, rather than each flavor writing
+        the same string and the answer holding by coincidence.
+        """
+        return f"bs={real_bs}/{pad_bs}" + (" graph" if self.is_captured(pad_bs) else "")
 
     def stage(
         self, pad_bs: int, srcs: "Mapping[str, torch.Tensor]"
@@ -136,10 +160,7 @@ class DraftGraph:
         How many rows are real comes from the sources, not from the caller: a
         count that cannot disagree with the tensor it describes.
         """
-        staged = {
-            role: self._stage_one(role, pad_bs, src) for role, src in srcs.items()
-        }
-        counts = {t.shape[0] for t in srcs.values() if t is not None}
+        counts = {t.shape[0] for t in srcs.values()}
         assert len(counts) <= 1, (
             f"{self.name} was handed batches of {sorted(counts)}; they "
             f"describe one step, so one of them is not this step's"
@@ -149,7 +170,7 @@ class DraftGraph:
             f"{self.name} was asked for {pad_bs} rows against {bs} real ones, "
             f"but never said its fabricated rows are inert"
         )
-        return staged
+        return {role: self._stage_one(role, pad_bs, src) for role, src in srcs.items()}
 
     def _stage_one(self, role: str, pad_bs: int, src: torch.Tensor | None):
         """Copy ``src`` into this input's fixed buffer, tail-repeating its last row.
@@ -157,7 +178,7 @@ class DraftGraph:
         Every input repeats the same last index, so a pad row is a coherent copy
         of the last real one and only redoes work that row already does. Zeros
         instead faulted 8/8 ranks at the first padded decode step, and repeating
-        one input alone -- an incoherent pair -- faulted too.
+        one input alone -- an incoherent mix -- faulted too.
 
         ``src=None`` hands back the view unwritten: warmup wants a well-formed
         batch, not a particular one.

--- a/atom/spec_decode/draft_graph.py
+++ b/atom/spec_decode/draft_graph.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-"""One draft forward, warmed and optionally captured per ``graph_bs``.
+"""One draft forward, warmed and optionally captured per captured size.
 
 Kept out of ``drafter.py`` so it stays importable without a GPU AITER build:
 the invariants below -- which batch a pass may run at, staging with a padded
@@ -37,7 +37,7 @@ class DraftGraph:
 
     Three capabilities, each needing strictly more than the last:
 
-    * **warmup** -- run it once per ``graph_bs`` at startup, paying its
+    * **warmup** -- run it once per ``capture_sizes`` entry at startup, paying its
       per-shape JIT there rather than mid-serve. Needs nothing.
     * **pad** -- run at the batch the target just ran, which the startup sweep
       warmed, rather than at whatever this step's batch happens to be. Needs
@@ -54,13 +54,13 @@ class DraftGraph:
     ``warmup_inputs`` makes that startup batch plausible, since warming on zeros
     compiles a shape no real batch draws.
 
-    Everything here counts SEQUENCES, in the same three words the target uses:
-    ``bs`` is real, ``pad_bs`` is what actually runs, ``graph_bs`` is the
-    captured set.
+    Everything here counts SEQUENCES, in the target's own words: ``bs`` is the
+    scheduled batch, ``running_bs`` is what it actually runs at, and
+    ``capture_sizes`` is the ladder the startup sweep warms.
     """
 
-    forward: Callable[..., Any]  # (pad_bs, **staged) -> Any
-    epilogue: Callable[..., Any] | None = None  # (fwd_out, pad_bs, **staged)
+    forward: Callable[..., Any]  # (running_bs, **staged) -> Any
+    epilogue: Callable[..., Any] | None = None  # (fwd_out, running_bs, **staged)
     capture_epilogue: bool = False
     inputs: "Mapping[str, StagedInput]" = field(default_factory=dict)
     pads: bool = False
@@ -107,52 +107,57 @@ class DraftGraph:
         graph is made by the shared ``warmup``."""
         return self.pads and envs.ATOM_DRAFT_CUDAGRAPH
 
-    def target_pad_bs(self, bs: int, context) -> int:
+    def target_running_bs(self, bs: int, context) -> int:
         """The batch the target just ran at, or ``bs`` when it pinned none.
 
-        Never a batch the drafter picks. ``forward_mode.effective_bs`` IS what
-        the target ran: ``model_runner`` builds the attention metadata with it,
-        so every per-sequence buffer already reaches that far -- ``slot_mapping``
+        Never a batch the drafter picks. ``context.running_bs`` IS what the
+        target ran: ``model_runner`` builds the attention metadata with it, so
+        every per-sequence buffer already reaches that far -- ``slot_mapping``
         -1, ``context_lens`` 0, ring slots published -- and a pad row fabricates
         nothing the backend has not already accounted for, on any backend and
         without the drafter knowing each one's convention. It is a warmed shape
         by construction too: on the cudagraph path ``ForwardMode.decide`` picks
-        it out of ``graph_bs``, which is the list the startup sweep warms.
+        it out of ``capture_sizes``, the list the startup sweep warms. And it is
+        DP-unified, which is what lets the draft's own collectives line up.
 
-        Not ``context.graph_bs``, which agrees except where DSpark's ragged path
-        overwrites it with a token-derived count (``_dspark_ragged_moe_graph_bs``)
-        that is neither captured nor the batch the metadata was built at.
-
-        Off the cudagraph path every eager branch of ``decide`` returns
-        ``effective_bs == scheduled_bs``, so this answers ``bs`` and nothing is
-        padded -- which is the only safe answer, since nobody sized the target's
-        metadata past the real batch there.
+        Off the cudagraph path nothing is padded -- ``running_bs`` is then the
+        scheduled batch, and that is the only safe answer anyway, since nobody
+        sized the target's metadata past the real batch there.
 
         An empty batch is never widened: a pad row is a copy of the last real
         one, and there is no last real one to copy. Declining the padding rather
         than the pass is deliberate -- under DP every rank still has to reach the
         draft's collectives.
+
+        ``is_dummy_run`` is deliberately NOT read, for the reason spelled out in
+        :meth:`_replays`: it is per-rank, so any term keyed on it splits the DP
+        group into two shapes.
+
         """
         mode = context.forward_mode
-        if not bs or not self.pads or context.is_dummy_run:
+        if not bs or not self.pads:
             return bs
         if mode is None or not mode.use_cudagraph:
             return bs
-        return max(bs, int(mode.effective_bs))
+        return max(bs, int(context.running_bs))
 
-    def label(self, real_bs: int, pad_bs: int) -> str:
-        """``bs=<real>/<pad>`` plus a trailing ``graph`` on a replay.
+    def label(self, real_bs: int, running_bs: int, context) -> str:
+        """``bs=<real>/<pad>`` plus a trailing ``graph`` when this step replays.
 
         One convention, one implementation: "did the draft get into a graph" is
         then a single grep across every flavor, rather than each flavor writing
-        the same string and the answer holding by coincidence.
+        the same string and the answer holding by coincidence. Reads the same
+        predicate `run` does, so the mark cannot claim a replay that did not
+        happen.
         """
-        return f"bs={real_bs}/{pad_bs}" + (" graph" if self.is_captured(pad_bs) else "")
+        return f"bs={real_bs}/{running_bs}" + (
+            " graph" if self._replays(running_bs, context) else ""
+        )
 
     def stage(
-        self, pad_bs: int, srcs: "Mapping[str, torch.Tensor]"
+        self, running_bs: int, srcs: "Mapping[str, torch.Tensor]"
     ) -> dict[str, torch.Tensor]:
-        """Copy every input into its fixed buffer, widening the batch to ``pad_bs``.
+        """Copy every input into its fixed buffer, widening the batch to ``running_bs``.
 
         The only way in, because ``pads`` is the part of the contract nothing
         else can check: a pass that lies about it still runs and still returns
@@ -167,14 +172,16 @@ class DraftGraph:
             f"{self.name} was handed batches of {sorted(counts)}; they "
             f"describe one step, so one of them is not this step's"
         )
-        bs = counts.pop() if counts else pad_bs
-        assert pad_bs == bs or self.pads, (
-            f"{self.name} was asked for {pad_bs} rows against {bs} real ones, "
+        bs = counts.pop() if counts else running_bs
+        assert running_bs == bs or self.pads, (
+            f"{self.name} was asked for {running_bs} rows against {bs} real ones, "
             f"but never said its fabricated rows are inert"
         )
-        return {role: self._stage_one(role, pad_bs, src) for role, src in srcs.items()}
+        return {
+            role: self._stage_one(role, running_bs, src) for role, src in srcs.items()
+        }
 
-    def _stage_one(self, role: str, pad_bs: int, src: torch.Tensor | None):
+    def _stage_one(self, role: str, running_bs: int, src: torch.Tensor | None):
         """Copy ``src`` into this input's fixed buffer, tail-repeating its last row.
 
         Every input repeats the same last index, so a pad row is a coherent copy
@@ -186,7 +193,7 @@ class DraftGraph:
         batch, not a particular one.
         """
         buf = self._buffers[role]
-        out = buf[:pad_bs]
+        out = buf[:running_bs]
         if src is None:
             return out
         assert src.dtype == buf.dtype, (
@@ -201,44 +208,76 @@ class DraftGraph:
         )
         bs = src.shape[0]
         out[:bs].copy_(src)
-        if pad_bs > bs:
+        if running_bs > bs:
             out[bs:].copy_(src[-1])  # copy_ broadcasts; no expand needed
         return out
 
-    def is_captured(self, pad_bs: int) -> bool:
-        return pad_bs in self._cuda_graphs
+    def is_captured(self, running_bs: int) -> bool:
+        """Whether a recording exists at this shape. Not whether it may be used."""
+        return running_bs in self._cuda_graphs
+
+    def _replays(self, running_bs: int, context) -> bool:
+        """Whether THIS step stands in for a recording.
+
+        A recording holds the collective at the width it was made for, so every
+        term here must be one the whole DP group agrees on -- which is why
+        `is_dummy_run` may not enter. A DP-sync dummy is per-rank, so gating on
+        it makes the rank with work replay while the rest issue eagerly, and
+        all of them wait forever (measured: V4-Flash-DSpark tp8 + DPA hung 8/8
+        on the first real decode). Replaying is safe on a dummy anyway --
+        `warmup` asserts the recording was made on a REAL context.
+        """
+        mode = context.forward_mode
+        return mode is not None and mode.use_cudagraph and self.is_captured(running_bs)
 
     @property
     def _to_capture(self) -> Callable[..., Any]:
         """What a graph holds -- and so what a replay stands in for."""
         return self._forward_and_epilogue if self.capture_epilogue else self.forward
 
-    def run(self, pad_bs: int, **staged) -> Any:
-        """Replay this batch size's graph, then whatever it did not cover."""
-        captured = self._cuda_graphs.get(pad_bs)
+    def run(self, running_bs: int, context, **staged) -> Any:
+        """Replay this batch size's graph, then whatever it did not cover.
+
+        Takes the step, not just its shape: a recording stands in for the branch
+        the flavor took while it was made, and a dummy took a different one --
+        ``warmup`` asserts it ran on a real context precisely so the recording
+        holds the real branch. Refusing the padding is not enough, because a
+        dummy's own batch can be a captured size on its own.
+        """
+        captured = (
+            self._cuda_graphs.get(running_bs)
+            if self._replays(running_bs, context)
+            else None
+        )
         if captured is None:
-            out = self._to_capture(pad_bs, **staged)
+            out = self._to_capture(running_bs, **staged)
         else:
             graph, out = captured
             graph.replay()
         return (
-            out if self.capture_epilogue else self._run_epilogue(out, pad_bs, **staged)
+            out
+            if self.capture_epilogue
+            else self._run_epilogue(out, running_bs, **staged)
         )
 
-    def _forward_and_epilogue(self, pad_bs: int, **staged) -> Any:
-        return self._run_epilogue(self.forward(pad_bs, **staged), pad_bs, **staged)
+    def _forward_and_epilogue(self, running_bs: int, **staged) -> Any:
+        return self._run_epilogue(
+            self.forward(running_bs, **staged), running_bs, **staged
+        )
 
-    def _run_epilogue(self, out: Any, pad_bs: int, **staged) -> Any:
-        return out if self.epilogue is None else self.epilogue(out, pad_bs, **staged)
+    def _run_epilogue(self, out: Any, running_bs: int, **staged) -> Any:
+        return (
+            out if self.epilogue is None else self.epilogue(out, running_bs, **staged)
+        )
 
     @torch.inference_mode()
-    def warmup(self, pad_bs: int, *, pool=None, stream=None):
-        """Run the pass once at one ``graph_bs``, paying its per-shape JIT here."""
-        staged = {role: self._stage_one(role, pad_bs, None) for role in self.inputs}
+    def warmup(self, running_bs: int, *, pool=None, stream=None):
+        """Run the pass once at one captured size, paying its per-shape JIT here."""
+        staged = {role: self._stage_one(role, running_bs, None) for role in self.inputs}
         if self.warmup_inputs is not None:
-            self.warmup_inputs(pad_bs, **staged)
+            self.warmup_inputs(running_bs, **staged)
         # forward AND epilogue, so nothing serving runs is left cold.
-        self._forward_and_epilogue(pad_bs, **staged)
+        self._forward_and_epilogue(running_bs, **staged)
         if not self.will_capture:
             return pool
         torch.cuda.synchronize()
@@ -249,6 +288,6 @@ class DraftGraph:
         with torch.cuda.graph(
             graph, pool, stream=stream, capture_error_mode="thread_local"
         ):
-            out = self._to_capture(pad_bs, **staged)
-        self._cuda_graphs[pad_bs] = (graph, out)
+            out = self._to_capture(running_bs, **staged)
+        self._cuda_graphs[running_bs] = (graph, out)
         return pool or graph.pool()

--- a/atom/spec_decode/draft_graph.py
+++ b/atom/spec_decode/draft_graph.py
@@ -128,11 +128,13 @@ class DraftGraph:
         padded -- which is the only safe answer, since nobody sized the target's
         metadata past the real batch there.
 
-        Declining the padding rather than the pass is deliberate: under DP every
-        rank still has to reach the draft's collectives.
+        An empty batch is never widened: a pad row is a copy of the last real
+        one, and there is no last real one to copy. Declining the padding rather
+        than the pass is deliberate -- under DP every rank still has to reach the
+        draft's collectives.
         """
         mode = context.forward_mode
-        if not self.pads or context.is_dummy_run:
+        if not bs or not self.pads or context.is_dummy_run:
             return bs
         if mode is None or not mode.use_cudagraph:
             return bs
@@ -241,7 +243,12 @@ class DraftGraph:
             return pool
         torch.cuda.synchronize()
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, pool, stream=stream):
+        # thread_local, not the "global" default: global invalidates a capture
+        # when ANY thread makes an unsafe HIP call, and the NCCL watchdog polls
+        # `hipEventQuery` every ~100ms. Same reasoning as `cuda_graph.py`'s.
+        with torch.cuda.graph(
+            graph, pool, stream=stream, capture_error_mode="thread_local"
+        ):
             out = self._to_capture(pad_bs, **staged)
         self._cuda_graphs[pad_bs] = (graph, out)
         return pool or graph.pool()

--- a/atom/spec_decode/drafter.py
+++ b/atom/spec_decode/drafter.py
@@ -11,6 +11,7 @@ from torch import nn
 
 from atom.config import Config
 from atom.model_loader.loader import load_model
+from atom.spec_decode.draft_graph import DraftGraph
 from atom.utils import CpuGpuBuffer, resolve_obj_by_qualname
 from atom.utils.forward_context import (
     DPMetadata,
@@ -171,6 +172,24 @@ class Drafter(abc.ABC):
         self.target_logits_indices = CpuGpuBuffer(max_bs * self.mtp_k, **i64_kwargs)
         self.bonus_logits_indices = CpuGpuBuffer(max_bs, **i64_kwargs)
 
+        self._build_draft_graphs()
+
+    # ---- draft passes ----
+    def _declare_draft_graphs(self) -> tuple[DraftGraph, ...]:
+        """Declare this drafter's warmable forwards. Opt-in.
+
+        A flavor whose model cannot answer the warmup/forward/epilogue must
+        declare nothing rather than merely decline to pad: warmup runs before
+        the pad and capture gates.
+        """
+        return ()
+
+    def _build_draft_graphs(self) -> None:
+        self.draft_graphs: tuple[DraftGraph, ...] = tuple(
+            pass_.bind(self.config, self.device, self.runner)
+            for pass_ in self._declare_draft_graphs()
+        )
+
     # ---- flavor hooks ----
     @abc.abstractmethod
     def _resolve_mtp_k(self) -> int:
@@ -226,8 +245,8 @@ class Drafter(abc.ABC):
         return None
 
     @property
-    def precompute_duplicates_propose(self) -> bool:
-        """Is `precompute_context_kv` the pass propose's first draft step redoes?
+    def draft_kv_duplicates_propose(self) -> bool:
+        """Is `compute_draft_kv` the pass propose's first draft step redoes?
 
         True (EAGLE) means the two must never both run: the second is a
         collective the peers on `dummy_execution` do not mirror. False (DSpark)
@@ -328,7 +347,7 @@ class Drafter(abc.ABC):
         buf.np[:n] = anchors
         return buf.copy_to_gpu(n)
 
-    def precompute_context_kv(
+    def compute_draft_kv(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,

--- a/atom/spec_decode/drafter.py
+++ b/atom/spec_decode/drafter.py
@@ -1,5 +1,6 @@
 import abc
 import logging
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -17,6 +18,7 @@ from atom.utils.forward_context import (
     DPMetadata,
     SpecDecodeMetadata,
     get_forward_context,
+    set_forward_context,
 )
 
 logger = logging.getLogger("atom")
@@ -167,7 +169,6 @@ class Drafter(abc.ABC):
         i32_kwargs = {"dtype": torch.int32, "device": self.device}
         i64_kwargs = {"dtype": torch.int64, "device": self.device}
         max_bs = self.config.max_num_seqs
-        self.arrange_bs = torch.arange(max_bs + 1, **i32_kwargs)
         self.cu_num_draft_tokens = CpuGpuBuffer(max_bs, **i32_kwargs)
         self.target_logits_indices = CpuGpuBuffer(max_bs * self.mtp_k, **i64_kwargs)
         self.bonus_logits_indices = CpuGpuBuffer(max_bs, **i64_kwargs)
@@ -186,9 +187,55 @@ class Drafter(abc.ABC):
 
     def _build_draft_graphs(self) -> None:
         self.draft_graphs: tuple[DraftGraph, ...] = tuple(
-            pass_.bind(self.config, self.device, self.runner)
+            pass_.bind(self.config, self.device)
             for pass_ in self._declare_draft_graphs()
         )
+
+    @torch.inference_mode()
+    def warmup_draft_graphs(self, build_context, max_q_len: int, stream) -> None:
+        """Run every declared pass once per `graph_bs`, paying its JIT here.
+
+        aiter's flydsl hgemm builds a kernel per tile config, in-process, so a
+        batch first seen mid-serve stalls that step and every restart pays
+        again: `hipModuleLoadData` per rank went 6 -> 0 on the 16k/20/50c
+        reproducer, with this and `propose`'s padding.
+
+        Warming `runner.graph_bs` is the point -- `propose` runs at the batch
+        the target ran, which `ForwardMode.decide` picks out of that same list,
+        so warmed and reachable are one set by construction rather than two
+        that drift.
+
+        `build_context(bs=...)` synthesizes one decode batch. The runner passes
+        it already bound, because which backends take a `max_q_len` is the
+        runner's to know. Call INSIDE `graph_capture()` (it arms the custom
+        all-reduce for the optional capture) and after `allocate_kv_cache`, so
+        that context has real ring slots and `is_dummy_run=False`.
+        """
+        if not self.draft_graphs:
+            return
+        runner = self.runner
+        graph_bs = sorted(runner.graph_bs)  # capture leaves it descending
+        pool = runner.graph_pool
+        start = time.time()
+        for pass_ in self.draft_graphs:
+            for bs in graph_bs:
+                attn_metadata, context = build_context(bs=bs)
+                set_forward_context(
+                    attn_metadata=attn_metadata,
+                    atom_config=self.config,
+                    context=context,
+                    num_tokens=bs * max_q_len,
+                )
+                pool = pass_.warmup(bs, pool=pool, stream=stream)
+        runner.graph_pool = pool
+        torch.cuda.synchronize()
+        if runner.rank == 0:
+            logger.info(
+                "Draft passes warmed at %s in %.2fs: %s",
+                graph_bs,
+                time.time() - start,
+                [g.name for g in self.draft_graphs],
+            )
 
     # ---- flavor hooks ----
     @abc.abstractmethod

--- a/atom/spec_decode/drafter.py
+++ b/atom/spec_decode/drafter.py
@@ -192,15 +192,15 @@ class Drafter(abc.ABC):
         )
 
     @torch.inference_mode()
-    def warmup_draft_graphs(self, build_context, max_q_len: int, stream) -> None:
-        """Run every declared pass once per `graph_bs`, paying its JIT here.
+    def warmup_draft_graphs(self, build_context, stream) -> None:
+        """Run every declared pass once per captured size, paying its JIT here.
 
         aiter's flydsl hgemm builds a kernel per tile config, in-process, so a
         batch first seen mid-serve stalls that step and every restart pays
         again: `hipModuleLoadData` per rank went 6 -> 0 on the 16k/20/50c
         reproducer, with this and `propose`'s padding.
 
-        Warming `runner.graph_bs` is the point -- `propose` runs at the batch
+        Warming `runner.capture_sizes` is the point -- `propose` runs at the batch
         the target ran, which `ForwardMode.decide` picks out of that same list,
         so warmed and reachable are one set by construction rather than two
         that drift.
@@ -210,21 +210,36 @@ class Drafter(abc.ABC):
         runner's to know. Call INSIDE `graph_capture()` (it arms the custom
         all-reduce for the optional capture) and after `allocate_kv_cache`, so
         that context has real ring slots and `is_dummy_run=False`.
+
+        Whatever `propose` sets on the context, this must set too. A capture
+        bakes every Python branch taken while it is made, so a guard that reads
+        the context is decided once, here, for every replay -- `is_draft` gates
+        the aux-capture hook away from the draft's own forward, and warming
+        without it records that hook clobbering the buffer it protects. The
+        row counts are the same rule and the sharper case: they size the MoE
+        all_gather that goes INTO the recording, so a synthetic context left
+        describing the target bakes a collective the pass never runs at.
         """
         if not self.draft_graphs:
             return
         runner = self.runner
-        graph_bs = sorted(runner.graph_bs)  # capture leaves it descending
+        capture_sizes = sorted(runner.capture_sizes)  # capture leaves it descending
         pool = runner.graph_pool
         start = time.time()
         for pass_ in self.draft_graphs:
-            for bs in graph_bs:
+            for bs in capture_sizes:
                 attn_metadata, context = build_context(bs=bs)
+                context.is_draft = True
+                # The synthetic batch is full, so the pass's scheduled and
+                # running counts are the same number.
+                local_tokens = bs * self.draft_tokens_per_seq
+                context.scheduled_tokens = local_tokens
+                context.running_tokens = local_tokens
                 set_forward_context(
                     attn_metadata=attn_metadata,
                     atom_config=self.config,
                     context=context,
-                    num_tokens=bs * max_q_len,
+                    num_tokens=local_tokens,
                 )
                 pool = pass_.warmup(bs, pool=pool, stream=stream)
         runner.graph_pool = pool
@@ -232,12 +247,23 @@ class Drafter(abc.ABC):
         if runner.rank == 0:
             logger.info(
                 "Draft passes warmed at %s in %.2fs: %s",
-                graph_bs,
+                capture_sizes,
                 time.time() - start,
                 [g.name for g in self.draft_graphs],
             )
 
     # ---- flavor hooks ----
+    @property
+    def draft_tokens_per_seq(self) -> int:
+        """Tokens one sequence contributes to a DECLARED pass.
+
+        1 for a serial flavor, whose declared pass is the mid-step; a block
+        flavor drafts its whole width in one pass and overrides. Read by
+        `warmup_draft_graphs`, which must state the shape on a synthetic
+        context and cannot ask `propose`.
+        """
+        return 1
+
     @abc.abstractmethod
     def _resolve_mtp_k(self) -> int:
         """Return the per-request verify horizon (drafted tokens per step).
@@ -524,14 +550,28 @@ class Drafter(abc.ABC):
             "lm_head",
         )
 
-    def _refresh_dp_metadata(self, forward_context, num_local_tokens: int) -> None:
+    def _publish_draft_shape(
+        self, forward_context, scheduled_tokens: int, running_tokens: int
+    ) -> None:
+        """Re-point the forward context at the pass about to run.
+
+        A draft reuses the target's context, whose counts are the verified
+        tokens -- not the draft's own width. Anything sizing a collective off
+        the context (MoE's `pad_for_all_gather` above all) would then use the
+        wrong height, so the draft states its shape here rather than letting
+        each consumer special-case `is_draft`. Both units: DP's variable-length
+        gather takes `running_tokens`, the pad needs to know how much is real.
+        """
+        context = forward_context.context
+        context.scheduled_tokens = scheduled_tokens
+        context.running_tokens = running_tokens
         parallel_config = self.config.parallel_config
         if parallel_config.data_parallel_size <= 1:
             return
-        forward_context.context.dp_uniform_decode = False
+        context.dp_uniform_decode = False
         forward_context.dp_metadata = DPMetadata.make(
             parallel_config,
-            num_local_tokens,
+            running_tokens,
         )
 
     def prepare_inputs(

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -134,52 +134,6 @@ class DSparkProposer(Drafter):
         num_draft = min(self.mtp_k, int(self.model.window_size))
         return self.model.model(anchor_ids, anchor_positions, num_draft)
 
-    def _block_graph_bs(self, bs: int, context) -> int:
-        """The batch the block runs at, or ``bs`` when nothing pins a wider one.
-
-        On the target's cudagraph path it must come from
-        ``context.graph_bs``, which the target set to the DP-unified
-        ``moe_pad_bs`` precisely because MoE's ``pad_for_all_gather`` pads
-        hidden_states to it before a cross-DP all_gather (model_runner.py:2611).
-        ``runner.graph_bs`` is the unnegotiated list, and is ``[0]`` until
-        capture runs. Off that path, see ``_self_chosen_graph_bs``.
-        """
-        mode = context.forward_mode
-        if context.is_dummy_run:
-            return bs  # no bound ring slots to pad against
-        if mode is None or not mode.use_cudagraph:
-            return self._self_chosen_graph_bs(bs)
-        graph_bs = int(context.graph_bs)
-        if graph_bs <= bs:
-            return bs
-        # A SEQUENCE count only on the rectangular decode path: under PIECEWISE
-        # + ragged, `_dspark_ragged_moe_graph_bs` swaps in a token-derived count
-        # (flat_bucket // q) that need not be a captured size. Round through the
-        # base so the answer is a warmed batch or nothing -- padding to an
-        # unwarmed shape is the stall this exists to fix.
-        return graph_bs if self.block.graph_bs_for(bs) == graph_bs else bs
-
-    def _self_chosen_graph_bs(self, bs: int) -> int:
-        """A batch the drafter picks itself, when the target negotiated none.
-
-        A prefill step's ``graph_bs`` is a token count, so there is nothing to
-        pad a SEQUENCE batch to -- and that used to end the matter, leaving the
-        first draft after every prefill eager. It need not: the block's own
-        capture at ``graph_bs_for(bs)`` is self-evidencing, since a graph exists
-        at that batch only if the startup sweep both warmed and captured it.
-        With no capture this returns ``bs`` and nothing changes.
-
-        DP needs no special case. ``_refresh_dp_metadata`` forces
-        ``dp_uniform_decode = False`` for every draft, which routes MoE to the
-        variable-length ``all_gatherv`` (moe.py ``dp_eager_mode``), so ranks
-        already run different widths here; padding changes the numbers, not the
-        structure. There was a ``dp > 1`` bail-out, and it was removed: nothing
-        was ever measured to need it, and it silently kept the whole prefill-side
-        win off the configuration that most wants it.
-        """
-        pad_bs = self.block.graph_bs_for(bs)
-        return pad_bs if self.block.is_captured(pad_bs) else bs
-
     def _init_draft_block_buffers(self) -> None:
         """Preallocate the block-pass metadata the separate-draft path rebinds."""
         max_bs = self.config.max_num_seqs
@@ -605,21 +559,30 @@ class DSparkProposer(Drafter):
         # forward_spec sizes the block off anchor_ids. context.batch_size counts
         # only one half of a mixed prefill+decode step, so it is not that B.
         real_bs = anchor_ids.shape[0]
-        pad_bs = self._block_graph_bs(real_bs, context)
+        pad_bs = self.block.target_pad_bs(real_bs, context)
         # The target already replayed a padded graph, but none of that padding
         # reaches here: its pad rows end at the graph boundary. `anchor_ids`
         # comes from the sampler, which runs after the graph and only over real
         # rows. So the block pads its own inputs. The target's `state_slot_out`
-        # needs no help: `prepare_decode` publishes it at the padded batch.
+        # needs no help, and by an identity rather than an agreement:
+        # `prepare_decode` publishes it at the `bs` it was built with, which is
+        # `forward_mode.effective_bs` -- the same number `target_pad_bs` just
+        # returned.
         staged = self.block.stage(
             pad_bs,
             {"anchor_ids": anchor_ids, "anchor_positions": anchor_positions},
         )
+        # ...and the fabricated rows must not scatter their draft KV. Their ring
+        # slot is the 0 `prepare_decode` fills that tail with, which is a real
+        # position, so the write would land in another request's window. Here
+        # and not inside the block: `run` may REPLAY, and then nothing in the
+        # block's Python runs at all.
+        self.model.model.index_buffers(num_draft, window, self.device).mask_pad_tail(
+            self.runner.attn_metadata_builder.row_ids, real_bs, pad_bs
+        )
         self._refresh_dp_metadata(forward_context, pad_bs * num_draft)
-        replayed = " graph" if self.block.is_captured(pad_bs) else ""
-        with record_function(
-            f"propose_dspark[bs={real_bs}/{pad_bs} T={num_draft}{replayed}]"
-        ):
+        label = self.block.label(real_bs, pad_bs)
+        with record_function(f"propose_dspark[{label} T={num_draft}]"):
             draft_token_ids, confidence = self.block.run(pad_bs, **staged)
         draft_token_ids = draft_token_ids[:real_bs, : self.mtp_k]
         if confidence is not None:

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -5,6 +5,7 @@ from torch import nn
 from torch.profiler import record_function
 
 from atom.distributed.dcp_utils import get_dcp_rank, get_dcp_world_size
+from atom.spec_decode.draft_graph import DraftGraph, StagedInput
 from atom.spec_decode.drafter import AuxCaptureSpec, Drafter
 from atom.spec_decode.dspark_verify import VerifyScheduler
 from atom.utils import envs
@@ -44,6 +45,140 @@ class DSparkProposer(Drafter):
         self.dcp_rank = get_dcp_rank()
         if self._with_draft:
             self._init_draft_block_buffers()
+
+    def _declare_draft_graphs(self):
+        """The block pass.
+
+        ``block`` is the only pure pass either drafter has: it gathers the
+        rolling window and writes nothing back. The KV write is a separate call
+        (``compute_draft_kv``), which is exactly why the block can be padded
+        at all -- purity is a property of what a pass does, not of DSpark.
+
+        That KV write is per-token, not per-sequence, and is NOT declared:
+        warming it needs a prefill-shaped synthetic forward context, which the
+        capture builder cannot produce. Declaring it with a stub forward would
+        create a pass that claims to be warmable and is not.
+
+        The separate-draft flavor declares nothing for the same reason: it drafts
+        through ``_propose_with_draft``, and the warmup/forward/epilogue below
+        reach for ``model.window_size`` and ``model.model.head_and_sample``,
+        which its checkpoint does not carry. Declining to pad is not enough --
+        warmup runs before that gate.
+
+        No ``mtp_k`` floor, unlike eagle's: the block drafts its whole width in
+        ONE pass, so there is no step 1+ to be absent at ``mtp_k == 1``.
+        """
+        self.block = None
+        if self._with_draft:
+            return ()
+        self.block = DraftGraph(
+            forward=self._block_backbone,
+            epilogue=self._block_head,
+            capture_epilogue=True,
+            inputs={
+                "anchor_ids": StagedInput(dtype=torch.int32),
+                "anchor_positions": StagedInput(dtype=torch.int64),
+            },
+            pads=self._block_may_pad,
+            warmup_inputs=self._block_warmup_inputs,
+        )
+        return (self.block,)
+
+    def _block_warmup_inputs(self, pad_bs, *, anchor_positions, **_):
+        """A plausible warmup batch: anchors past the window, real ring slots.
+
+        Anchors at position ``window`` leave every window slot valid, which is
+        what a steady-state decode draws. Warming at position 0 would mask all
+        but the last slot and compile a shape serving never asks for.
+        """
+        fc = get_forward_context()
+        assert not fc.context.is_dummy_run, (
+            "warmup needs a real forward context; a dummy one bakes the "
+            "all-zero rolling window and only shows up as lost acceptance"
+        )
+        anchor_positions.fill_(int(self.model.window_size))
+
+    @property
+    def _block_may_pad(self) -> bool:
+        """Whether the block may take fabricated rows.
+
+        Off under EPLB: pad rows carry fabricated tokens through the draft's full
+        MoE, and ``select_experts_with_record`` counts every row it routes into
+        the expert-load histogram that drives online expert migration.
+        """
+        return not self.config.eplb_enable
+
+    def _block_head(self, out, pad_bs, *, anchor_ids, **_):
+        """The block's epilogue: LM head, then the sequential Markov sampler.
+
+        Nothing here resists capture -- the sampler is a fixed-trip loop over
+        the draft width, and the LM head's one data-dependent step (its
+        prefill last-token slice) is already suppressed for a draft. Under TP
+        it does all_gather the vocab shard; ``capture_epilogue`` says whether
+        that one collective is captured with the rest.
+
+        It must be WARMED regardless: the head has its own per-shape flydsl
+        builder, and leaving it out of the warm is exactly how
+        `hipModuleLoadData` went 0 -> 4 on the reproducer once.
+        """
+        normed, hc_hidden = out
+        return self.model.model.head_and_sample(normed, hc_hidden, anchor_ids)
+
+    def _block_backbone(self, pad_bs, *, anchor_ids, anchor_positions):
+        """The block's forward: the parallel backbone over the whole draft width.
+
+        Nothing of the target's metadata is installed. The ring slots the model
+        reads off the forward context are already this length: `prepare_decode`
+        publishes them at the padded batch, which is the batch this runs at.
+        """
+        num_draft = min(self.mtp_k, int(self.model.window_size))
+        return self.model.model(anchor_ids, anchor_positions, num_draft)
+
+    def _block_graph_bs(self, bs: int, context) -> int:
+        """The batch the block runs at, or ``bs`` when nothing pins a wider one.
+
+        On the target's cudagraph path it must come from
+        ``context.graph_bs``, which the target set to the DP-unified
+        ``moe_pad_bs`` precisely because MoE's ``pad_for_all_gather`` pads
+        hidden_states to it before a cross-DP all_gather (model_runner.py:2611).
+        ``runner.graph_bs`` is the unnegotiated list, and is ``[0]`` until
+        capture runs. Off that path, see ``_self_chosen_graph_bs``.
+        """
+        mode = context.forward_mode
+        if context.is_dummy_run:
+            return bs  # no bound ring slots to pad against
+        if mode is None or not mode.use_cudagraph:
+            return self._self_chosen_graph_bs(bs)
+        graph_bs = int(context.graph_bs)
+        if graph_bs <= bs:
+            return bs
+        # A SEQUENCE count only on the rectangular decode path: under PIECEWISE
+        # + ragged, `_dspark_ragged_moe_graph_bs` swaps in a token-derived count
+        # (flat_bucket // q) that need not be a captured size. Round through the
+        # base so the answer is a warmed batch or nothing -- padding to an
+        # unwarmed shape is the stall this exists to fix.
+        return graph_bs if self.block.graph_bs_for(bs) == graph_bs else bs
+
+    def _self_chosen_graph_bs(self, bs: int) -> int:
+        """A batch the drafter picks itself, when the target negotiated none.
+
+        A prefill step's ``graph_bs`` is a token count, so there is nothing to
+        pad a SEQUENCE batch to -- and that used to end the matter, leaving the
+        first draft after every prefill eager. It need not: the block's own
+        capture at ``graph_bs_for(bs)`` is self-evidencing, since a graph exists
+        at that batch only if the startup sweep both warmed and captured it.
+        With no capture this returns ``bs`` and nothing changes.
+
+        DP needs no special case. ``_refresh_dp_metadata`` forces
+        ``dp_uniform_decode = False`` for every draft, which routes MoE to the
+        variable-length ``all_gatherv`` (moe.py ``dp_eager_mode``), so ranks
+        already run different widths here; padding changes the numbers, not the
+        structure. There was a ``dp > 1`` bail-out, and it was removed: nothing
+        was ever measured to need it, and it silently kept the whole prefill-side
+        win off the configuration that most wants it.
+        """
+        pad_bs = self.block.graph_bs_for(bs)
+        return pad_bs if self.block.is_captured(pad_bs) else bs
 
     def _init_draft_block_buffers(self) -> None:
         """Preallocate the block-pass metadata the separate-draft path rebinds."""
@@ -358,7 +493,7 @@ class DSparkProposer(Drafter):
         # Plain residual stream (no special bookkeeping).
         return output
 
-    def precompute_context_kv(
+    def compute_draft_kv(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
@@ -391,7 +526,7 @@ class DSparkProposer(Drafter):
         forward_context = get_forward_context()
         bs = forward_context.context.batch_size
         main_hidden_all = torch.cat(aux_hidden_states, dim=-1)
-        with record_function(f"dspark_ctx_kv[bs={bs} tok={main_hidden_all.shape[0]}]"):
+        with record_function(f"draft_kv[bs={bs} tok={main_hidden_all.shape[0]}]"):
             self.model.write_context_kv(main_hidden_all, positions)
 
     def propose(
@@ -434,7 +569,7 @@ class DSparkProposer(Drafter):
                 "dspark_target_layer_ids; none were captured."
             )
         # aux is validated here (drafting requires it) but the target context is
-        # already in the draft's KV: `precompute_context_kv` absorbed it right
+        # already in the draft's KV: `compute_draft_kv` absorbed it right
         # after the target forward, uniformly for every flavor. propose() only
         # needs the anchor to seed the block.
 
@@ -453,7 +588,7 @@ class DSparkProposer(Drafter):
                 anchor_positions,
             )
 
-        # The rolling target-KV window is filled by `precompute_context_kv`,
+        # The rolling target-KV window is filled by `compute_draft_kv`,
         # which the runner calls after every target forward.
         #
         # Draft width = the verify horizon mtp_k (num_speculative_tokens). This
@@ -467,14 +602,30 @@ class DSparkProposer(Drafter):
         # confidence calibration are not comparable across K.
         window = int(self.model.window_size)
         num_draft = min(self.mtp_k, window)
-        self._refresh_dp_metadata(forward_context, bs * num_draft)
-        with record_function(f"dspark[bs={bs} T={num_draft}]"):
-            draft_token_ids, confidence = self.model.forward_spec(
-                anchor_ids,
-                anchor_positions,
-                num_draft=num_draft,
-            )
-        draft_token_ids = draft_token_ids[:, : self.mtp_k]
+        # forward_spec sizes the block off anchor_ids. context.batch_size counts
+        # only one half of a mixed prefill+decode step, so it is not that B.
+        real_bs = anchor_ids.shape[0]
+        pad_bs = self._block_graph_bs(real_bs, context)
+        # The target already replayed a padded graph, but none of that padding
+        # reaches here: its pad rows end at the graph boundary. `anchor_ids`
+        # comes from the sampler, which runs after the graph and only over real
+        # rows. So the block pads its own inputs. The target's `state_slot_out`
+        # needs no help: `prepare_decode` publishes it at the padded batch.
+        staged = self.block.stage(
+            pad_bs,
+            {"anchor_ids": anchor_ids, "anchor_positions": anchor_positions},
+        )
+        self._refresh_dp_metadata(forward_context, pad_bs * num_draft)
+        replayed = " graph" if self.block.is_captured(pad_bs) else ""
+        with record_function(
+            f"propose_dspark[bs={real_bs}/{pad_bs} T={num_draft}{replayed}]"
+        ):
+            draft_token_ids, confidence = self.block.run(pad_bs, **staged)
+        draft_token_ids = draft_token_ids[:real_bs, : self.mtp_k]
+        if confidence is not None:
+            # compute_ell takes its batch size from confidence.shape and zips the
+            # resulting ell against batch.req_ids by position.
+            confidence = confidence[:real_bs]
         # Confidence-scheduled verification. The hardware-aware prefix scheduler
         # consumes the confidence head to pick a per-request verify length
         # ell_r. We compute ell here and stash it; the actual variable-length
@@ -482,7 +633,7 @@ class DSparkProposer(Drafter):
         # request's scheduled spec tokens to ell_r, which frees batch capacity
         # instead of the no-op in-block masking of Level A.
         if self.verify_scheduler is not None and confidence is not None:
-            with record_function(f"dspark_sched[bs={bs}]"):
+            with record_function(f"dspark_sched[bs={real_bs}]"):
                 self.verify_scheduler.set_last_ell(
                     self.verify_scheduler.compute_ell(confidence[:, : self.mtp_k])
                 )
@@ -503,7 +654,7 @@ class DSparkProposer(Drafter):
         """Kimi-K3 DSpark: one non-causal block pass over the paged latent cache.
 
         The target context is already in the draft's latent cache (absorbed by
-        `precompute_context_kv`); this only builds the draft block's own metadata
+        `compute_draft_kv`); this only builds the draft block's own metadata
         (addressed by slot mapping) and runs the block. Same shape as the V4
         block pass -- T queries per request against a paged KV cache.
         """
@@ -674,7 +825,7 @@ class DSparkProposer(Drafter):
         forward_context.attn_metadata.dtype_q = dtype_q
 
         # ---- 3. Block pass + Markov sampling ---------------------------------
-        with record_function(f"dspark[bs={bs} T={T}]"):
+        with record_function(f"propose_dspark[bs={bs} T={T}]"):
             draft_token_ids, confidence = self.model.forward_spec(
                 anchor_ids,
                 block_positions.view(-1),

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -84,7 +84,7 @@ class DSparkProposer(Drafter):
         )
         return (self.block,)
 
-    def _block_warmup_inputs(self, pad_bs, *, anchor_positions, **_):
+    def _block_warmup_inputs(self, running_bs, *, anchor_positions, **_):
         """A plausible warmup batch: anchors past the window, real ring slots.
 
         Anchors at position ``window`` leave every window slot valid, which is
@@ -108,7 +108,7 @@ class DSparkProposer(Drafter):
         """
         return not self.config.eplb_enable
 
-    def _block_head(self, out, pad_bs, *, anchor_ids, **_):
+    def _block_head(self, out, running_bs, *, anchor_ids, **_):
         """The block's epilogue: LM head, then the sequential Markov sampler.
 
         Nothing here resists capture -- the sampler is a fixed-trip loop over
@@ -124,15 +124,14 @@ class DSparkProposer(Drafter):
         normed, hc_hidden = out
         return self.model.model.head_and_sample(normed, hc_hidden, anchor_ids)
 
-    def _block_backbone(self, pad_bs, *, anchor_ids, anchor_positions):
+    def _block_backbone(self, running_bs, *, anchor_ids, anchor_positions):
         """The block's forward: the parallel backbone over the whole draft width.
 
         Nothing of the target's metadata is installed. The ring slots the model
         reads off the forward context are already this length: `prepare_decode`
         publishes them at the padded batch, which is the batch this runs at.
         """
-        num_draft = min(self.mtp_k, int(self.model.window_size))
-        return self.model.model(anchor_ids, anchor_positions, num_draft)
+        return self.model.model(anchor_ids, anchor_positions, self.draft_tokens_per_seq)
 
     def _init_draft_block_buffers(self) -> None:
         """Preallocate the block-pass metadata the separate-draft path rebinds."""
@@ -297,6 +296,12 @@ class DSparkProposer(Drafter):
             # off the presence of this attribute.
             self.runner.eagle3_draft_builder = Eagle3DraftBuilder(self.runner, draft_hf)
         return model
+
+    @property
+    def draft_tokens_per_seq(self) -> int:
+        """The whole block, in one pass -- capped at the rolling window so the
+        `[window ++ draft]` KV the block attends to stays bounded."""
+        return min(self.mtp_k, int(self.model.window_size))
 
     def _resolve_mtp_k(self) -> int:
         draft_cfg = self.speculative_config.draft_model_hf_config
@@ -478,7 +483,7 @@ class DSparkProposer(Drafter):
         if aux_hidden_states is None:
             return
         forward_context = get_forward_context()
-        bs = forward_context.context.batch_size
+        bs = forward_context.context.scheduled_bs
         main_hidden_all = torch.cat(aux_hidden_states, dim=-1)
         with record_function(f"draft_kv[bs={bs} tok={main_hidden_all.shape[0]}]"):
             self.model.write_context_kv(main_hidden_all, positions)
@@ -512,7 +517,7 @@ class DSparkProposer(Drafter):
         context = forward_context.context
         attn_metadata = forward_context.attn_metadata
         context.is_draft = True
-        bs = context.batch_size
+        bs = context.scheduled_bs
 
         # Drafter-owned aux: our own forward-hook capture buffers, row-aligned to
         # the target hidden states.
@@ -555,21 +560,27 @@ class DSparkProposer(Drafter):
         # bidirectional, so every draft token depends on T. Acceptance rates and
         # confidence calibration are not comparable across K.
         window = int(self.model.window_size)
-        num_draft = min(self.mtp_k, window)
-        # forward_spec sizes the block off anchor_ids. context.batch_size counts
+        num_draft = self.draft_tokens_per_seq
+        # forward_spec sizes the block off anchor_ids. context.scheduled_bs counts
         # only one half of a mixed prefill+decode step, so it is not that B.
         real_bs = anchor_ids.shape[0]
-        pad_bs = self.block.target_pad_bs(real_bs, context)
+        # Agreed first, and on EVERY step. The batch a pass runs at has to be
+        # one number for the whole DP group, or half of it replays a recorded
+        # collective while the rest issue a differently sized one. Not
+        # conditioned on prefill-vs-decode either: which of the two a rank is
+        # doing is its own business, so a rank that skipped this would leave
+        # the others waiting in the exchange.
+        running_bs = self.block.target_running_bs(real_bs, context)
         # The target already replayed a padded graph, but none of that padding
         # reaches here: its pad rows end at the graph boundary. `anchor_ids`
         # comes from the sampler, which runs after the graph and only over real
         # rows. So the block pads its own inputs. The target's `state_slot_out`
         # needs no help, and by an identity rather than an agreement:
         # `prepare_decode` publishes it at the `bs` it was built with, which is
-        # `forward_mode.effective_bs` -- the same number `target_pad_bs` just
+        # `context.running_bs` -- the same number `target_running_bs` just
         # returned.
         staged = self.block.stage(
-            pad_bs,
+            running_bs,
             {"anchor_ids": anchor_ids, "anchor_positions": anchor_positions},
         )
         # ...and the fabricated rows must not scatter their draft KV. Their ring
@@ -578,12 +589,16 @@ class DSparkProposer(Drafter):
         # and not inside the block: `run` may REPLAY, and then nothing in the
         # block's Python runs at all.
         self.model.model.index_buffers(num_draft, window, self.device).mask_pad_tail(
-            self.runner.attn_metadata_builder.row_ids, real_bs, pad_bs
+            self.runner.attn_metadata_builder.row_ids, real_bs, running_bs
         )
-        self._refresh_dp_metadata(forward_context, pad_bs * num_draft)
-        label = self.block.label(real_bs, pad_bs)
+        self._publish_draft_shape(
+            forward_context,
+            scheduled_tokens=real_bs * num_draft,
+            running_tokens=running_bs * num_draft,
+        )
+        label = self.block.label(real_bs, running_bs, context)
         with record_function(f"propose_dspark[{label} T={num_draft}]"):
-            draft_token_ids, confidence = self.block.run(pad_bs, **staged)
+            draft_token_ids, confidence = self.block.run(running_bs, context, **staged)
         draft_token_ids = draft_token_ids[:real_bs, : self.mtp_k]
         if confidence is not None:
             # compute_ell takes its batch size from confidence.shape and zips the
@@ -762,7 +777,10 @@ class DSparkProposer(Drafter):
             attn_metadata.reduce_final_map = ps["reduce_final_map"]
             attn_metadata.reduce_partial_map = ps["reduce_partial_map"]
 
-        self._refresh_dp_metadata(forward_context, bs * T)
+        # The separate-draft path pads nothing, so both heights are `bs * T`.
+        self._publish_draft_shape(
+            forward_context, scheduled_tokens=bs * T, running_tokens=bs * T
+        )
 
         # The block pass is ALWAYS decode-shaped -- T queries per request against
         # a paged KV cache -- even on a step where the target just prefilled. But

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -123,8 +123,8 @@ class EagleProposer(Drafter):
         )
         return (self.step,)
 
-    def _step_forward(self, pad_bs, *, input_ids, positions, hidden_states):
-        """One mid-step draft forward at ``pad_bs`` rows.
+    def _step_forward(self, running_bs, *, input_ids, positions, hidden_states):
+        """One mid-step draft forward at ``running_bs`` rows.
 
         PCP does not appear here: only step 0 is a prefill and only a prefill is
         query-sharded, so steps 1+ run full on every rank.
@@ -270,7 +270,7 @@ class EagleProposer(Drafter):
             return
         forward_context = get_forward_context()
         context = forward_context.context
-        bs = context.batch_size
+        bs = context.scheduled_bs
         anchors = next_token_ids[:bs]
         if any(t < 0 for t in anchors):
             return
@@ -306,37 +306,45 @@ class EagleProposer(Drafter):
         finally:
             context.is_draft = was_draft
 
-    def _stage_step_inputs(self, pad_bs, input_ids, positions, hidden_states):
+    def _stage_step_inputs(self, running_bs, input_ids, positions, hidden_states):
         """Stage one mid-step's inputs."""
         return {
             **self.step.stage(
-                pad_bs, {"input_ids": input_ids, "hidden_states": hidden_states}
+                running_bs, {"input_ids": input_ids, "hidden_states": hidden_states}
             ),
             # Already the pass's buffer: it had to be padded before the metadata
             # rebuild read it, which is a step earlier than the rest.
             "positions": positions,
         }
 
-    def _step_warmup_inputs(self, pad_bs, **staged):
+    def _step_warmup_inputs(self, running_bs, **staged):
         """Put the warmup context into the shape a mid-step sees.
 
         The capture builder hands a decode batch at the target's query width;
         steps 1+ run one row per sequence, and every kernel they compile is
         chosen from that shape. Replaying the same rewrite serving uses is the
         point -- a warmup that built its own would warm a shape nobody asks for.
+
+        The same goes for state the model carries: `skip_topk` is read as a
+        Python branch inside the draft's attention, and `propose` turns it on
+        only after step 0. Warming without it records the branch that recomputes
+        the index, which a replay then repeats every step -- the sharing this
+        flavor logs as enabled would be dead, silently.
         """
+        if self._share_mtp_indices:
+            self.model.model.set_skip_topk(True)
         fc = get_forward_context()
         # Where each synthetic sequence actually is. Warming at position 0 would
         # compile a masked, near-empty window -- a shape steady-state decode
         # never draws.
-        staged["positions"].copy_(fc.attn_metadata.context_lens[:pad_bs])
-        zeros = torch.zeros(pad_bs, dtype=torch.int32, device=self.device)
+        staged["positions"].copy_(fc.attn_metadata.context_lens[:running_bs])
+        zeros = torch.zeros(running_bs, dtype=torch.int32, device=self.device)
         self._enter_decode_metadata(
-            pad_bs, pad_bs, staged["positions"], zeros.to(torch.int64), zeros
+            running_bs, running_bs, staged["positions"], zeros.to(torch.int64), zeros
         )
 
     def _enter_decode_metadata(
-        self, bs, pad_bs, positions, last_token_indices, num_reject_tokens
+        self, bs, running_bs, positions, last_token_indices, num_reject_tokens
     ):
         """Rewrite the target's attn_metadata to one row per sequence.
 
@@ -358,17 +366,17 @@ class EagleProposer(Drafter):
         has_flat_kv = "kv_indices" in var
         i0_max_seqlen_q = attn_metadata.max_seqlen_q
         attn_metadata.max_seqlen_q = 1
-        slot_mapping = var["slot_mapping"].gpu[:pad_bs]  # max_seqlen_q is 1 here
-        cu_seqlens_q = var["cu_seqlens_q"].gpu[: pad_bs + 1]
+        slot_mapping = var["slot_mapping"].gpu[:running_bs]  # max_seqlen_q is 1 here
+        cu_seqlens_q = var["cu_seqlens_q"].gpu[: running_bs + 1]
         attn_metadata.cu_seqlens_q = cu_seqlens_q
         attn_metadata.slot_mapping = slot_mapping
         if has_flat_kv:
-            kv_indptr = var["kv_indptr"].gpu[: pad_bs + 1]
+            kv_indptr = var["kv_indptr"].gpu[: running_bs + 1]
             kv_indices = var["kv_indices"].gpu
             attn_metadata.kv_indptr = kv_indptr
             attn_metadata.kv_indices = kv_indices
         if target_uses_mla:
-            kv_last_page_lens = var["kv_last_page_lens"].gpu[:pad_bs]
+            kv_last_page_lens = var["kv_last_page_lens"].gpu[:running_bs]
             attn_metadata.kv_last_page_lens = kv_last_page_lens
             # Sparse (DSA) MLA decode packs KV per token at
             # page_size=1, so it reads the all-1s
@@ -381,14 +389,16 @@ class EagleProposer(Drafter):
             if "sparse_kv_last_page_lens" in var:
                 attn_metadata.sparse_kv_last_page_lens = var[
                     "sparse_kv_last_page_lens"
-                ].gpu[:pad_bs]
+                ].gpu[:running_bs]
         # block_tables, context_lens, and sparse_kv_indptr are
         # needed by both MHA and MLA+sparse attention
-        attn_metadata.block_tables = var["block_tables"].gpu[:pad_bs]
-        attn_metadata.context_lens = var["context_lens"].gpu[:pad_bs]
+        attn_metadata.block_tables = var["block_tables"].gpu[:running_bs]
+        attn_metadata.context_lens = var["context_lens"].gpu[:running_bs]
         if "sparse_kv_indptr" in var:
-            attn_metadata.sparse_kv_indptr = var["sparse_kv_indptr"].gpu[: pad_bs + 1]
-        cu_seqlens_q[: pad_bs + 1] = builder.row_ids[: pad_bs + 1]
+            attn_metadata.sparse_kv_indptr = var["sparse_kv_indptr"].gpu[
+                : running_bs + 1
+            ]
+        cu_seqlens_q[: running_bs + 1] = builder.row_ids[: running_bs + 1]
         if target_uses_mla and has_flat_kv:
             # MLA: block_size=1, kv_indptr tracks tokens
             # Per REAL request: `num_reject_tokens` is bs-long and a pad row
@@ -425,11 +435,11 @@ class EagleProposer(Drafter):
         forward_context = get_forward_context()
         context = forward_context.context
         attn_metadata = forward_context.attn_metadata
-        bs = context.batch_size
+        bs = context.scheduled_bs
         # Steps 1+ run at the row count the target just replayed, so every
         # mid-step lands on a shape the startup sweep already warmed. No pass
         # declared (MRoPE) means the loop runs the model directly, at `bs`.
-        pad_bs = self.step.target_pad_bs(bs, context) if self.step else bs
+        running_bs = self.step.target_running_bs(bs, context) if self.step else bs
         context.is_draft = True
 
         assert self.runner is not None
@@ -483,7 +493,9 @@ class EagleProposer(Drafter):
         # Mid-steps run padded and may replay; step 0 does neither, so it is
         # labelled as the plain batch it is.
         step0_label = f"bs={bs}"
-        mid_label = self.step.label(bs, pad_bs) if self.step else step0_label
+        mid_label = (
+            self.step.label(bs, running_bs, context) if self.step else step0_label
+        )
         for i in range(self.mtp_k):
             # `tok` is this step's real row count, which is NOT `bs`: step 0 runs
             # over the target's whole token stream (a prefill chunk, or
@@ -499,10 +511,15 @@ class EagleProposer(Drafter):
                 # Re-sync DP token
                 # The count the forward RUNS, which at i>=1 is the padded one
                 # -- DP sizes its all_gatherv from this, and aiter asserts the
-                # tensor matches. DSpark reports `pad_bs * num_draft` for the
+                # tensor matches. DSpark reports `running_bs * num_draft` for the
                 # same reason.
-                self._refresh_dp_metadata(
-                    forward_context, pad_bs if i else input_ids.shape[0]
+                # Step 0 carries the target's whole token stream and pads
+                # nothing; steps 1+ run the padded row count, of which `bs`
+                # rows are real.
+                self._publish_draft_shape(
+                    forward_context,
+                    scheduled_tokens=bs if i else input_ids.shape[0],
+                    running_tokens=running_bs if i else input_ids.shape[0],
                 )
                 # ---- Prefill Context Parallel (draft i==0 prefill) --------
                 # The draft's first pass is a prefill that reuses the target's
@@ -542,9 +559,10 @@ class EagleProposer(Drafter):
                     # Steps 1+ are the declared pass: one row per sequence, at
                     # a batch the startup sweep already warmed.
                     ret_hidden_states = self.step.run(
-                        pad_bs,
+                        running_bs,
+                        context,
                         **self._stage_step_inputs(
-                            pad_bs, d_input_ids, d_positions, d_hidden
+                            running_bs, d_input_ids, d_positions, d_hidden
                         ),
                     )
                 else:
@@ -588,11 +606,15 @@ class EagleProposer(Drafter):
                     )
                     if i == 0:
                         i0_max_seqlen_q, positions = self._enter_decode_metadata(
-                            bs, pad_bs, positions, last_token_indices, num_reject_tokens
+                            bs,
+                            running_bs,
+                            positions,
+                            last_token_indices,
+                            num_reject_tokens,
                         )
                         # From here the loop owns the pass's positions buffer.
                         # `prepare_mtp_decode` derives each step's SWA extents
-                        # from it, so it has to be `pad_bs` long before THAT --
+                        # from it, so it has to be `running_bs` long before THAT --
                         # padding it with the other rows, just before the
                         # forward, is a step too late.
                         #
@@ -601,7 +623,7 @@ class EagleProposer(Drafter):
                         # None and these stay the target's own 2-D positions.
                         if self.step is not None:
                             positions = self.step.stage(
-                                pad_bs, {"positions": positions}
+                                running_bs, {"positions": positions}
                             )["positions"]
 
                     # update metadata
@@ -617,12 +639,12 @@ class EagleProposer(Drafter):
                             "positions_out": positions,
                         }
                     else:
-                        attn_metadata.context_lens[:pad_bs] += 1
+                        attn_metadata.context_lens[:running_bs] += 1
                         positions += 1
                         mtp_decode_kwargs = {}
                     # `bs` stays the REAL sequence count; the builder reads
                     # the padded row count off `positions`, which is the
-                    # pass's own buffer and therefore already `pad_bs` long.
+                    # pass's own buffer and therefore already `running_bs` long.
                     workinfos = self.runner.attn_metadata_builder.prepare_mtp_decode(
                         bs,
                         (
@@ -645,7 +667,7 @@ class EagleProposer(Drafter):
                         # returns them, so this branch is exactly the case where
                         # `attn_metadata` still holds them.
                         raw_slots = attn_metadata.kv_indices[
-                            attn_metadata.kv_indptr[1 : pad_bs + 1] - 1
+                            attn_metadata.kv_indptr[1 : running_bs + 1] - 1
                         ]
                         builder = self.runner.attn_metadata_builder
                         if getattr(builder, "dcp_world_size", 1) > 1:
@@ -654,7 +676,7 @@ class EagleProposer(Drafter):
                             # raw_slots would point at a stale slot. Emit -1. S=1 is
                             # the original round-robin ``(ctx-1) % W``.
                             S = getattr(builder, "cp_kv_cache_interleave_size", 1)
-                            ctx = attn_metadata.context_lens[:pad_bs]
+                            ctx = attn_metadata.context_lens[:running_bs]
                             owned = (
                                 ((ctx - 1) // S) % builder.dcp_world_size
                             ) == builder.dcp_rank
@@ -669,9 +691,9 @@ class EagleProposer(Drafter):
                     # cache kernels honour it.
                     #
                     # Outside the branch above: a backend that RETURNS a
-                    # slot_mapping computed it over `pad_bs` rows too, so leaving
+                    # slot_mapping computed it over `running_bs` rows too, so leaving
                     # this inside was how those pad rows kept a live slot.
-                    if pad_bs > bs:
+                    if running_bs > bs:
                         attn_metadata.slot_mapping[bs:] = -1
 
                     input_ids = new_draft_ids

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -98,7 +98,7 @@ class EagleProposer(Drafter):
         # DeepSeek-V4 carries the mHC residual, so its hidden is [N, hc, dim]
         # rather than [N, dim]. `hc_mult` is absent on every architecture that
         # does not, which is exactly the two-dimensional case.
-        hc = getattr(draft_hf, "hc_mult", 0)
+        hc = getattr(draft_hf, "hc_mult", None)
         inputs = {
             # int64, not the int32 of the token buffer step 0 reads: a mid-step's
             # ids come from `compute_draft_ids`, which is an argmax. The loop
@@ -107,7 +107,11 @@ class EagleProposer(Drafter):
             "input_ids": StagedInput(dtype=torch.int64),
             "positions": StagedInput(dtype=torch.int64),
             "hidden_states": StagedInput(
-                shape=(hc, draft_hf.hidden_size) if hc else (draft_hf.hidden_size,),
+                shape=(
+                    (hc, draft_hf.hidden_size)
+                    if hc is not None
+                    else (draft_hf.hidden_size,)
+                ),
                 dtype=self.dtype,
             ),
         }
@@ -302,27 +306,6 @@ class EagleProposer(Drafter):
         finally:
             context.is_draft = was_draft
 
-    def _step_pad_bs(self, bs: int, context) -> int:
-        """The batch steps 1+ run at: the one the target just replayed.
-
-        Not a ``graph_bs`` the drafter picks. ``context.graph_bs`` is the count the
-        target already padded its own metadata to (``slot_mapping`` -1,
-        ``context_lens`` 0), so drafting there fabricates no row the backend has
-        not already accounted for -- on any backend, and without the drafter
-        knowing each one's convention.
-
-        Off the cudagraph path there is no such count, so the batch runs as it
-        is; nothing is padded, and nothing needed a warmed shape. Same answer
-        when there is no declared pass at all (MRoPE): the loop then runs the
-        model directly, at the real batch.
-        """
-        mode = context.forward_mode
-        if self.step is None or context.is_dummy_run:
-            return bs
-        if mode is None or not mode.use_cudagraph:
-            return bs
-        return max(bs, int(context.graph_bs))
-
     def _stage_step_inputs(self, pad_bs, input_ids, positions, hidden_states):
         """Stage one mid-step's inputs."""
         return {
@@ -359,16 +342,20 @@ class EagleProposer(Drafter):
 
         Run once, at the tail of draft step 0, and replayed by
         ``warmup_inputs`` so warmup compiles the shapes serving asks for rather
-        than a copy of them. Returns the buffers the loop keeps rebinding, the target's
-        original ``max_seqlen_q`` (``prepare_mtp_decode`` still wants it), and
-        the per-sequence positions.
+        than a copy of them.
+
+        Returns only what is not reachable through ``attn_metadata`` afterwards:
+        the target's original ``max_seqlen_q`` (which this overwrites, and
+        ``prepare_mtp_decode`` still wants) and the per-sequence positions. Every
+        buffer below is installed, so the loop reads it back from there rather
+        than holding a second name for it.
         """
         fc = get_forward_context()
         attn_metadata, context = fc.attn_metadata, fc.context
         var = self.runner.forward_vars
+        builder = self.runner.attn_metadata_builder
         target_uses_mla = self.runner.use_mla
         has_flat_kv = "kv_indices" in var
-        kv_indptr = kv_indices = None
         i0_max_seqlen_q = attn_metadata.max_seqlen_q
         attn_metadata.max_seqlen_q = 1
         slot_mapping = var["slot_mapping"].gpu[:pad_bs]  # max_seqlen_q is 1 here
@@ -401,7 +388,7 @@ class EagleProposer(Drafter):
         attn_metadata.context_lens = var["context_lens"].gpu[:pad_bs]
         if "sparse_kv_indptr" in var:
             attn_metadata.sparse_kv_indptr = var["sparse_kv_indptr"].gpu[: pad_bs + 1]
-        cu_seqlens_q[: pad_bs + 1] = self.arrange_bs[: pad_bs + 1]
+        cu_seqlens_q[: pad_bs + 1] = builder.row_ids[: pad_bs + 1]
         if target_uses_mla and has_flat_kv:
             # MLA: block_size=1, kv_indptr tracks tokens
             # Per REAL request: `num_reject_tokens` is bs-long and a pad row
@@ -419,13 +406,7 @@ class EagleProposer(Drafter):
                 positions, positions.ndim - 1, last_token_indices
             )
         context.is_prefill = False
-        return (
-            i0_max_seqlen_q,
-            positions,
-            slot_mapping,
-            kv_indptr,
-            kv_indices,
-        )
+        return i0_max_seqlen_q, positions
 
     def propose(
         self,
@@ -445,9 +426,10 @@ class EagleProposer(Drafter):
         context = forward_context.context
         attn_metadata = forward_context.attn_metadata
         bs = context.batch_size
-        # Steps 1+ run at the row count the target just replayed, so every mid-step
-        # forward lands on a shape the startup sweep already warmed.
-        pad_bs = self._step_pad_bs(bs, context)
+        # Steps 1+ run at the row count the target just replayed, so every
+        # mid-step lands on a shape the startup sweep already warmed. No pass
+        # declared (MRoPE) means the loop runs the model directly, at `bs`.
+        pad_bs = self.step.target_pad_bs(bs, context) if self.step else bs
         context.is_draft = True
 
         assert self.runner is not None
@@ -498,16 +480,10 @@ class EagleProposer(Drafter):
         # every iteration (used at i>=1 too, even though i==0 sets it).
         has_flat_kv = "kv_indices" in var
 
-        # Mid-steps run padded and may replay; step 0 does neither, so it carries
-        # neither mark. Same `bs/pad_bs` + ` graph` convention the block
-        # drafter's label uses, so one grep answers "did the draft get into a
-        # graph" for both flavors.
-        if self.step is None:
-            steps_tag = ""  # nothing declared: every step runs like step 0
-        elif self.step.is_captured(pad_bs):
-            steps_tag = f"/{pad_bs} graph"
-        else:
-            steps_tag = f"/{pad_bs}"
+        # Mid-steps run padded and may replay; step 0 does neither, so it is
+        # labelled as the plain batch it is.
+        step0_label = f"bs={bs}"
+        mid_label = self.step.label(bs, pad_bs) if self.step else step0_label
         for i in range(self.mtp_k):
             # `tok` is this step's real row count, which is NOT `bs`: step 0 runs
             # over the target's whole token stream (a prefill chunk, or
@@ -517,8 +493,8 @@ class EagleProposer(Drafter):
             # rank-local detail, and this is the count `_refresh_dp_metadata`
             # reports.
             with record_function(
-                f"propose_eagle[{i}/{self.mtp_k} tok={input_ids.shape[0]}"
-                f" bs={bs}{steps_tag if i else ''}]"
+                f"propose_eagle[{i}/{self.mtp_k} tok={input_ids.shape[0]} "
+                f"{mid_label if i else step0_label}]"
             ):
                 # Re-sync DP token
                 # The count the forward RUNS, which at i>=1 is the padded one
@@ -611,13 +587,7 @@ class EagleProposer(Drafter):
                         and self.runner.attn_metadata_builder.num_attention_heads != 32
                     )
                     if i == 0:
-                        (
-                            i0_max_seqlen_q,
-                            positions,
-                            slot_mapping,
-                            kv_indptr,
-                            kv_indices,
-                        ) = self._enter_decode_metadata(
+                        i0_max_seqlen_q, positions = self._enter_decode_metadata(
                             bs, pad_bs, positions, last_token_indices, num_reject_tokens
                         )
                         # From here the loop owns the pass's positions buffer.
@@ -669,8 +639,14 @@ class EagleProposer(Drafter):
                     for k, v in workinfos.items():
                         attn_metadata.__dict__[k] = v
                     if has_flat_kv and "slot_mapping" not in workinfos:
-                        # MLA/MHA path: slot derived from flat kv_indices.
-                        raw_slots = kv_indices[kv_indptr[1 : pad_bs + 1] - 1]
+                        # MLA/MHA path: slot derived from flat kv_indices. Both,
+                        # and the slot_mapping written below, are the ones
+                        # `_enter_decode_metadata` installed -- no backend
+                        # returns them, so this branch is exactly the case where
+                        # `attn_metadata` still holds them.
+                        raw_slots = attn_metadata.kv_indices[
+                            attn_metadata.kv_indptr[1 : pad_bs + 1] - 1
+                        ]
                         builder = self.runner.attn_metadata_builder
                         if getattr(builder, "dcp_world_size", 1) > 1:
                             # DCP interleave-S: only rank ((ctx-1)//S) % W owns this
@@ -682,9 +658,11 @@ class EagleProposer(Drafter):
                             owned = (
                                 ((ctx - 1) // S) % builder.dcp_world_size
                             ) == builder.dcp_rank
-                            slot_mapping[:] = torch.where(owned, raw_slots, -1)
+                            attn_metadata.slot_mapping[:] = torch.where(
+                                owned, raw_slots, -1
+                            )
                         else:
-                            slot_mapping[:] = raw_slots
+                            attn_metadata.slot_mapping[:] = raw_slots
                     # A pad row's slot is some real sequence's, and the draft
                     # writes KV through it. -1 is this path's existing "skip"
                     # sentinel (the DCP branch above emits it too), and the aiter

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -13,6 +13,7 @@ from atom.distributed.pcp_utils import (
     pcp_pad_len,
     pcp_round_robin_split,
 )
+from atom.spec_decode.draft_graph import DraftGraph, StagedInput
 from atom.spec_decode.drafter import Drafter
 from atom.spec_decode.eagle3_kv_builder import Eagle3DraftBuilder
 from atom.utils import envs
@@ -68,6 +69,70 @@ class EagleProposer(Drafter):
 
     def _resolve_mtp_k(self) -> int:
         return self.speculative_config.num_speculative_tokens or 0
+
+    def _declare_draft_graphs(self):
+        """The mid-step pass: draft steps 1..k-1, one row per sequence.
+
+        Step 0 counts tokens, not sequences -- it runs the target's whole token
+        stream -- and is NOT declared: warming it needs a prefill-shaped
+        synthetic forward context, which the capture builder cannot produce. A
+        stub would claim to be warmable and not be.
+
+        Unlike DSpark's block, this pass does not carry its own metadata; it
+        reads the target's, which ``_enter_decode_metadata`` rewrites to one row
+        per sequence. That rewrite is what ``warmup_inputs`` replays, so the two
+        go through the same code rather than a copy that can drift.
+
+        MRoPE declares nothing, by the same rule Kimi-K3 does: its positions are
+        ``[3, N]``, so there is no leading batch axis to stage, hence nothing to
+        pad and nothing a graph could pin. Declaring anyway used to warm and
+        capture a ONE-dimensional-positions shape that serving never runs --
+        graphs nobody replays, paid for at every startup.
+        """
+        self.step = None
+        if self.runner.use_mrope or self.mtp_k < 2:
+            # mtp_k == 1 has no step 1+, so warming one would capture a graph
+            # `propose` can never reach.
+            return ()
+        draft_hf = self.speculative_config.draft_model_hf_config
+        # DeepSeek-V4 carries the mHC residual, so its hidden is [N, hc, dim]
+        # rather than [N, dim]. `hc_mult` is absent on every architecture that
+        # does not, which is exactly the two-dimensional case.
+        hc = getattr(draft_hf, "hc_mult", 0)
+        inputs = {
+            # int64, not the int32 of the token buffer step 0 reads: a mid-step's
+            # ids come from `compute_draft_ids`, which is an argmax. The loop
+            # rebinds `input_ids` from one to the other, so the two halves
+            # genuinely differ.
+            "input_ids": StagedInput(dtype=torch.int64),
+            "positions": StagedInput(dtype=torch.int64),
+            "hidden_states": StagedInput(
+                shape=(hc, draft_hf.hidden_size) if hc else (draft_hf.hidden_size,),
+                dtype=self.dtype,
+            ),
+        }
+        self.step = DraftGraph(
+            forward=self._step_forward,
+            inputs=inputs,
+            pads=True,
+            warmup_inputs=self._step_warmup_inputs,
+        )
+        return (self.step,)
+
+    def _step_forward(self, pad_bs, *, input_ids, positions, hidden_states):
+        """One mid-step draft forward at ``pad_bs`` rows.
+
+        PCP does not appear here: only step 0 is a prefill and only a prefill is
+        query-sharded, so steps 1+ run full on every rank.
+
+        Nothing of the target's metadata is installed here. The pad rows are
+        already masked where it matters: `prepare_mtp_decode` writes `-1` into
+        `batch_id_per_token`, and the index kernel returns on `bid < 0` before it
+        ever loads a ring slot.
+        """
+        return self.model(
+            input_ids=input_ids, positions=positions, hidden_states=hidden_states
+        )
 
     def _build_draft_model(self, model_class) -> nn.Module:
         draft_model_hf_config = self.speculative_config.draft_model_hf_config
@@ -167,11 +232,11 @@ class EagleProposer(Drafter):
         return hidden
 
     @property
-    def precompute_duplicates_propose(self) -> bool:
+    def draft_kv_duplicates_propose(self) -> bool:
         # The pass below is propose's i==0 step: same rows, same anchors.
         return True
 
-    def precompute_context_kv(
+    def compute_draft_kv(
         self,
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
@@ -191,7 +256,7 @@ class EagleProposer(Drafter):
 
         The all-middle batch (no -1) is the remaining case; under DP it runs
         `propose(align_only=True)` for its collectives -- the same redo -- so
-        `precompute_duplicates_propose` has the runner skip this call there.
+        `draft_kv_duplicates_propose` has the runner skip this call there.
 
         NOTE: unverified against real weights. `build_drafter` routes anything
         carrying `dspark_block_size` to `DSparkProposer`, and every model on
@@ -237,6 +302,131 @@ class EagleProposer(Drafter):
         finally:
             context.is_draft = was_draft
 
+    def _step_pad_bs(self, bs: int, context) -> int:
+        """The batch steps 1+ run at: the one the target just replayed.
+
+        Not a ``graph_bs`` the drafter picks. ``context.graph_bs`` is the count the
+        target already padded its own metadata to (``slot_mapping`` -1,
+        ``context_lens`` 0), so drafting there fabricates no row the backend has
+        not already accounted for -- on any backend, and without the drafter
+        knowing each one's convention.
+
+        Off the cudagraph path there is no such count, so the batch runs as it
+        is; nothing is padded, and nothing needed a warmed shape. Same answer
+        when there is no declared pass at all (MRoPE): the loop then runs the
+        model directly, at the real batch.
+        """
+        mode = context.forward_mode
+        if self.step is None or context.is_dummy_run:
+            return bs
+        if mode is None or not mode.use_cudagraph:
+            return bs
+        return max(bs, int(context.graph_bs))
+
+    def _stage_step_inputs(self, pad_bs, input_ids, positions, hidden_states):
+        """Stage one mid-step's inputs."""
+        return {
+            **self.step.stage(
+                pad_bs, {"input_ids": input_ids, "hidden_states": hidden_states}
+            ),
+            # Already the pass's buffer: it had to be padded before the metadata
+            # rebuild read it, which is a step earlier than the rest.
+            "positions": positions,
+        }
+
+    def _step_warmup_inputs(self, pad_bs, **staged):
+        """Put the warmup context into the shape a mid-step sees.
+
+        The capture builder hands a decode batch at the target's query width;
+        steps 1+ run one row per sequence, and every kernel they compile is
+        chosen from that shape. Replaying the same rewrite serving uses is the
+        point -- a warmup that built its own would warm a shape nobody asks for.
+        """
+        fc = get_forward_context()
+        # Where each synthetic sequence actually is. Warming at position 0 would
+        # compile a masked, near-empty window -- a shape steady-state decode
+        # never draws.
+        staged["positions"].copy_(fc.attn_metadata.context_lens[:pad_bs])
+        zeros = torch.zeros(pad_bs, dtype=torch.int32, device=self.device)
+        self._enter_decode_metadata(
+            pad_bs, pad_bs, staged["positions"], zeros.to(torch.int64), zeros
+        )
+
+    def _enter_decode_metadata(
+        self, bs, pad_bs, positions, last_token_indices, num_reject_tokens
+    ):
+        """Rewrite the target's attn_metadata to one row per sequence.
+
+        Run once, at the tail of draft step 0, and replayed by
+        ``warmup_inputs`` so warmup compiles the shapes serving asks for rather
+        than a copy of them. Returns the buffers the loop keeps rebinding, the target's
+        original ``max_seqlen_q`` (``prepare_mtp_decode`` still wants it), and
+        the per-sequence positions.
+        """
+        fc = get_forward_context()
+        attn_metadata, context = fc.attn_metadata, fc.context
+        var = self.runner.forward_vars
+        target_uses_mla = self.runner.use_mla
+        has_flat_kv = "kv_indices" in var
+        kv_indptr = kv_indices = None
+        i0_max_seqlen_q = attn_metadata.max_seqlen_q
+        attn_metadata.max_seqlen_q = 1
+        slot_mapping = var["slot_mapping"].gpu[:pad_bs]  # max_seqlen_q is 1 here
+        cu_seqlens_q = var["cu_seqlens_q"].gpu[: pad_bs + 1]
+        attn_metadata.cu_seqlens_q = cu_seqlens_q
+        attn_metadata.slot_mapping = slot_mapping
+        if has_flat_kv:
+            kv_indptr = var["kv_indptr"].gpu[: pad_bs + 1]
+            kv_indices = var["kv_indices"].gpu
+            attn_metadata.kv_indptr = kv_indptr
+            attn_metadata.kv_indices = kv_indices
+        if target_uses_mla:
+            kv_last_page_lens = var["kv_last_page_lens"].gpu[:pad_bs]
+            attn_metadata.kv_last_page_lens = kv_last_page_lens
+            # Sparse (DSA) MLA decode packs KV per token at
+            # page_size=1, so it reads the all-1s
+            # sparse_kv_last_page_lens (NOT the dense per-block
+            # buffer, which makes the asm kernel over-read past
+            # the written sparse-index region -> illegal access).
+            # The draft reuses the target's attn_metadata but
+            # drops to max_seqlen_q=1, so it must re-point this to
+            # the per-seq all-1s slice itself.
+            if "sparse_kv_last_page_lens" in var:
+                attn_metadata.sparse_kv_last_page_lens = var[
+                    "sparse_kv_last_page_lens"
+                ].gpu[:pad_bs]
+        # block_tables, context_lens, and sparse_kv_indptr are
+        # needed by both MHA and MLA+sparse attention
+        attn_metadata.block_tables = var["block_tables"].gpu[:pad_bs]
+        attn_metadata.context_lens = var["context_lens"].gpu[:pad_bs]
+        if "sparse_kv_indptr" in var:
+            attn_metadata.sparse_kv_indptr = var["sparse_kv_indptr"].gpu[: pad_bs + 1]
+        cu_seqlens_q[: pad_bs + 1] = self.arrange_bs[: pad_bs + 1]
+        if target_uses_mla and has_flat_kv:
+            # MLA: block_size=1, kv_indptr tracks tokens
+            # Per REAL request: `num_reject_tokens` is bs-long and a pad row
+            # rejected nothing. Their `kv_indptr` keeps what the target left,
+            # which is one of its own valid ranges, so their reads stay in
+            # bounds; their WRITES are what has to be neutralized, below.
+            kv_indptr[1 : bs + 1] -= torch.cumsum(num_reject_tokens, dim=0)
+        if positions.ndim == 1:
+            positions = torch.index_select(positions, 0, last_token_indices)
+        else:
+            # MRoPE positions keep the token axis last (e.g.
+            # [3, num_tokens] for Qwen3.5), so select columns
+            # instead of indexing dim 0.
+            positions = torch.index_select(
+                positions, positions.ndim - 1, last_token_indices
+            )
+        context.is_prefill = False
+        return (
+            i0_max_seqlen_q,
+            positions,
+            slot_mapping,
+            kv_indptr,
+            kv_indices,
+        )
+
     def propose(
         self,
         # [num_tokens]
@@ -255,6 +445,9 @@ class EagleProposer(Drafter):
         context = forward_context.context
         attn_metadata = forward_context.attn_metadata
         bs = context.batch_size
+        # Steps 1+ run at the row count the target just replayed, so every mid-step
+        # forward lands on a shape the startup sweep already warmed.
+        pad_bs = self._step_pad_bs(bs, context)
         context.is_draft = True
 
         assert self.runner is not None
@@ -281,7 +474,6 @@ class EagleProposer(Drafter):
         if envs.ATOM_DEBUG_FORCE_SKIP_DRAFT_MODEL:
             draft_token_ids.fill_(-1)
         var = self.runner.forward_vars
-        target_uses_mla = self.runner.use_mla
         # Eaale3 only support mha currently
         draft_uses_mha = hasattr(self.runner, "eagle3_draft_builder")
 
@@ -306,10 +498,36 @@ class EagleProposer(Drafter):
         # every iteration (used at i>=1 too, even though i==0 sets it).
         has_flat_kv = "kv_indices" in var
 
+        # Mid-steps run padded and may replay; step 0 does neither, so it carries
+        # neither mark. Same `bs/pad_bs` + ` graph` convention the block
+        # drafter's label uses, so one grep answers "did the draft get into a
+        # graph" for both flavors.
+        if self.step is None:
+            steps_tag = ""  # nothing declared: every step runs like step 0
+        elif self.step.is_captured(pad_bs):
+            steps_tag = f"/{pad_bs} graph"
+        else:
+            steps_tag = f"/{pad_bs}"
         for i in range(self.mtp_k):
-            with record_function(f"draft[{i}/{self.mtp_k} bs={bs}]"):
+            # `tok` is this step's real row count, which is NOT `bs`: step 0 runs
+            # over the target's whole token stream (a prefill chunk, or
+            # bs*(mtp_k+1) on decode) and only steps 1+ run one row per sequence.
+            # Labelling both as `bs` collapsed the draft's two shape axes into
+            # one. Taken pre-PCP-split on purpose -- the sharded count is a
+            # rank-local detail, and this is the count `_refresh_dp_metadata`
+            # reports.
+            with record_function(
+                f"propose_eagle[{i}/{self.mtp_k} tok={input_ids.shape[0]}"
+                f" bs={bs}{steps_tag if i else ''}]"
+            ):
                 # Re-sync DP token
-                self._refresh_dp_metadata(forward_context, input_ids.shape[0])
+                # The count the forward RUNS, which at i>=1 is the padded one
+                # -- DP sizes its all_gatherv from this, and aiter asserts the
+                # tensor matches. DSpark reports `pad_bs * num_draft` for the
+                # same reason.
+                self._refresh_dp_metadata(
+                    forward_context, pad_bs if i else input_ids.shape[0]
+                )
                 # ---- Prefill Context Parallel (draft i==0 prefill) --------
                 # The draft's first pass is a prefill that reuses the target's
                 # 1/pcp-reindexed attn_metadata, so it must run on this rank's
@@ -344,11 +562,21 @@ class EagleProposer(Drafter):
                 # steps 1+ skip it and read the compacted sparse_kv buffer.
                 if self._share_mtp_indices and i == 0:
                     self.model.model.set_skip_topk(False)
-                ret_hidden_states = self.model(
-                    input_ids=d_input_ids,
-                    positions=d_positions,
-                    hidden_states=d_hidden,
-                )
+                if i and self.step is not None:
+                    # Steps 1+ are the declared pass: one row per sequence, at
+                    # a batch the startup sweep already warmed.
+                    ret_hidden_states = self.step.run(
+                        pad_bs,
+                        **self._stage_step_inputs(
+                            pad_bs, d_input_ids, d_positions, d_hidden
+                        ),
+                    )
+                else:
+                    ret_hidden_states = self.model(
+                        input_ids=d_input_ids,
+                        positions=d_positions,
+                        hidden_states=d_hidden,
+                    )
                 if pcp_draft_prefill:
                     ret_hidden_states = pcp_allgather_rerange(
                         ret_hidden_states, pcp_ws
@@ -357,10 +585,13 @@ class EagleProposer(Drafter):
                     self.model.model.set_skip_topk(True)
                     self.model.model.compact_topk_indices(last_token_indices)
 
+                # Step 0 gathers one row per sequence out of the token stream;
+                # steps 1+ already are one row per sequence -- sliced back off
+                # the padded batch, so nothing downstream sees a pad row.
                 sample_hidden_states = (
                     torch.index_select(ret_hidden_states, 0, last_token_indices)
                     if i == 0
-                    else ret_hidden_states
+                    else ret_hidden_states[:bs]
                 )
                 # Every draft model EagleProposer can build implements this --
                 # the DSpark archs in support_draft_model_arch_dict do not, but
@@ -380,60 +611,28 @@ class EagleProposer(Drafter):
                         and self.runner.attn_metadata_builder.num_attention_heads != 32
                     )
                     if i == 0:
-                        i0_max_seqlen_q = attn_metadata.max_seqlen_q
-                        attn_metadata.max_seqlen_q = 1
-                        slot_mapping = var["slot_mapping"].gpu[
-                            : bs * attn_metadata.max_seqlen_q
-                        ]
-                        cu_seqlens_q = var["cu_seqlens_q"].gpu[: bs + 1]
-                        attn_metadata.cu_seqlens_q = cu_seqlens_q
-                        attn_metadata.slot_mapping = slot_mapping
-                        if has_flat_kv:
-                            kv_indptr = var["kv_indptr"].gpu[: bs + 1]
-                            kv_indices = var["kv_indices"].gpu
-                            attn_metadata.kv_indptr = kv_indptr
-                            attn_metadata.kv_indices = kv_indices
-                        if target_uses_mla:
-                            kv_last_page_lens = var["kv_last_page_lens"].gpu[:bs]
-                            attn_metadata.kv_last_page_lens = kv_last_page_lens
-                            # Sparse (DSA) MLA decode packs KV per token at
-                            # page_size=1, so it reads the all-1s
-                            # sparse_kv_last_page_lens (NOT the dense per-block
-                            # buffer, which makes the asm kernel over-read past
-                            # the written sparse-index region -> illegal access).
-                            # The draft reuses the target's attn_metadata but
-                            # drops to max_seqlen_q=1, so it must re-point this to
-                            # the per-seq all-1s slice itself.
-                            if "sparse_kv_last_page_lens" in var:
-                                attn_metadata.sparse_kv_last_page_lens = var[
-                                    "sparse_kv_last_page_lens"
-                                ].gpu[:bs]
-                        # block_tables, context_lens, and sparse_kv_indptr are
-                        # needed by both MHA and MLA+sparse attention
-                        attn_metadata.block_tables = var["block_tables"].gpu[:bs]
-                        attn_metadata.context_lens = var["context_lens"].gpu[:bs]
-                        if "sparse_kv_indptr" in var:
-                            attn_metadata.sparse_kv_indptr = var[
-                                "sparse_kv_indptr"
-                            ].gpu[: bs + 1]
-                        cu_seqlens_q[: bs + 1] = self.arrange_bs[: bs + 1]
-                        if target_uses_mla and has_flat_kv:
-                            # MLA: block_size=1, kv_indptr tracks tokens
-                            kv_indptr[1 : bs + 1] -= torch.cumsum(
-                                num_reject_tokens, dim=0
-                            )
-                        if positions.ndim == 1:
-                            positions = torch.index_select(
-                                positions, 0, last_token_indices
-                            )
-                        else:
-                            # MRoPE positions keep the token axis last (e.g.
-                            # [3, num_tokens] for Qwen3.5), so select columns
-                            # instead of indexing dim 0.
-                            positions = torch.index_select(
-                                positions, positions.ndim - 1, last_token_indices
-                            )
-                        context.is_prefill = False
+                        (
+                            i0_max_seqlen_q,
+                            positions,
+                            slot_mapping,
+                            kv_indptr,
+                            kv_indices,
+                        ) = self._enter_decode_metadata(
+                            bs, pad_bs, positions, last_token_indices, num_reject_tokens
+                        )
+                        # From here the loop owns the pass's positions buffer.
+                        # `prepare_mtp_decode` derives each step's SWA extents
+                        # from it, so it has to be `pad_bs` long before THAT --
+                        # padding it with the other rows, just before the
+                        # forward, is a step too late.
+                        #
+                        # No MRoPE case to guard: a model whose positions keep
+                        # the token axis last declares no pass, so `self.step` is
+                        # None and these stay the target's own 2-D positions.
+                        if self.step is not None:
+                            positions = self.step.stage(
+                                pad_bs, {"positions": positions}
+                            )["positions"]
 
                     # update metadata
                     attn_metadata.max_seqlen_k += 1
@@ -448,9 +647,12 @@ class EagleProposer(Drafter):
                             "positions_out": positions,
                         }
                     else:
-                        attn_metadata.context_lens[:bs] += 1
+                        attn_metadata.context_lens[:pad_bs] += 1
                         positions += 1
                         mtp_decode_kwargs = {}
+                    # `bs` stays the REAL sequence count; the builder reads
+                    # the padded row count off `positions`, which is the
+                    # pass's own buffer and therefore already `pad_bs` long.
                     workinfos = self.runner.attn_metadata_builder.prepare_mtp_decode(
                         bs,
                         (
@@ -468,7 +670,7 @@ class EagleProposer(Drafter):
                         attn_metadata.__dict__[k] = v
                     if has_flat_kv and "slot_mapping" not in workinfos:
                         # MLA/MHA path: slot derived from flat kv_indices.
-                        raw_slots = kv_indices[kv_indptr[1 : bs + 1] - 1]
+                        raw_slots = kv_indices[kv_indptr[1 : pad_bs + 1] - 1]
                         builder = self.runner.attn_metadata_builder
                         if getattr(builder, "dcp_world_size", 1) > 1:
                             # DCP interleave-S: only rank ((ctx-1)//S) % W owns this
@@ -476,13 +678,23 @@ class EagleProposer(Drafter):
                             # raw_slots would point at a stale slot. Emit -1. S=1 is
                             # the original round-robin ``(ctx-1) % W``.
                             S = getattr(builder, "cp_kv_cache_interleave_size", 1)
-                            ctx = attn_metadata.context_lens[:bs]
+                            ctx = attn_metadata.context_lens[:pad_bs]
                             owned = (
                                 ((ctx - 1) // S) % builder.dcp_world_size
                             ) == builder.dcp_rank
                             slot_mapping[:] = torch.where(owned, raw_slots, -1)
                         else:
                             slot_mapping[:] = raw_slots
+                    # A pad row's slot is some real sequence's, and the draft
+                    # writes KV through it. -1 is this path's existing "skip"
+                    # sentinel (the DCP branch above emits it too), and the aiter
+                    # cache kernels honour it.
+                    #
+                    # Outside the branch above: a backend that RETURNS a
+                    # slot_mapping computed it over `pad_bs` rows too, so leaving
+                    # this inside was how those pad rows kept a live slot.
+                    if pad_bs > bs:
+                        attn_metadata.slot_mapping[bs:] = -1
 
                     input_ids = new_draft_ids
                     hidden_states = sample_hidden_states

--- a/atom/utils/attn_ffn_piecewise.py
+++ b/atom/utils/attn_ffn_piecewise.py
@@ -49,18 +49,18 @@ def decode_bucket_key(forward_context) -> tuple:
     """``(bucket_bs, q_eff)`` for a core captured per decode bucket.
 
     Nothing here is model-specific -- both come off the forward context -- so
-    every decode core keys the same way. ``bucket_bs`` is the ceil-to-captured
-    graph_bs (``forward_mode.effective_bs`` at replay; a capture Context has no
-    forward_mode, so batch_size == graph_bs == bucket).
+    every decode core keys the same way. ``bucket_bs`` is the step's
+    ``running_bs`` (a capture Context has no forward_mode, so batch_size is
+    already the bucket).
     """
     attn_metadata = getattr(forward_context, "attn_metadata", None)
     context = getattr(forward_context, "context", None)
     q_eff = int(getattr(attn_metadata, "max_seqlen_q", 1) or 1)
     forward_mode = getattr(context, "forward_mode", None)
-    if forward_mode is not None and getattr(forward_mode, "effective_bs", 0):
-        bucket_bs = int(forward_mode.effective_bs)
+    if forward_mode is not None and getattr(forward_mode, "running_bs", 0):
+        bucket_bs = int(forward_mode.running_bs)
     else:
-        bucket_bs = int(getattr(context, "batch_size", 0) or 0)
+        bucket_bs = int(getattr(context, "scheduled_bs", 0) or 0)
     return (bucket_bs, q_eff)
 
 

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -317,6 +317,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("ATOM_USE_CUSTOM_ALL_GATHER", "1").lower() == "1"
     ),
     "ATOM_USE_FLYDSL_GDR": lambda: os.getenv("ATOM_USE_FLYDSL_GDR", "0").lower() == "1",
+    # Capture each declared draft pass into a per-graph_bs CUDAGraph as it is
+    # warmed, so the draft replays instead of relaunching every kernel. 0 drafts
+    # eagerly. On by default: DSpark tp1 acceptance is 65.25% captured vs 65.21%
+    # eager. Named for the draft, not a flavor -- see `DraftGraph.will_capture`.
+    "ATOM_DRAFT_CUDAGRAPH": lambda: (
+        os.getenv("ATOM_DRAFT_CUDAGRAPH", "1").lower() == "1"
+    ),
     # --- MoE (DeepSeek-style shared experts) ---
     # Dual-stream MoE only when num_tokens <= threshold; 0 disables dual-stream registration.
     "ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD": lambda: int(

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -317,7 +317,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("ATOM_USE_CUSTOM_ALL_GATHER", "1").lower() == "1"
     ),
     "ATOM_USE_FLYDSL_GDR": lambda: os.getenv("ATOM_USE_FLYDSL_GDR", "0").lower() == "1",
-    # Capture each declared draft pass into a per-graph_bs CUDAGraph as it is
+    # Capture each declared draft pass into a per-captured-size CUDAGraph as it is
     # warmed, so the draft replays instead of relaunching every kernel. 0 drafts
     # eagerly. On by default: DSpark tp1 acceptance is 65.25% captured vs 65.21%
     # eager. Named for the draft, not a flavor -- see `DraftGraph.will_capture`.

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -163,28 +163,21 @@ class SpecDecodeMetadata:
 
 @dataclass(frozen=True)
 class ForwardMode:
-    """Per-step dispatch decision: cudagraph vs eager + per-rank attention bs
-    + cross-DP MoE-pad bs.
+    """Per-step dispatch, and the two batch sizes ATOM names.
 
-    Two distinct sizes because they answer different questions:
-      - ``effective_bs`` sizes per-rank attention tensors (slot_mapping /
-        cu_seqlens_q). Must match ``input_ids.shape[0]`` (= local real tokens)
-        in eager so aiter's ``t == t_slot`` invariant holds.
-      - ``moe_pad_bs`` sizes ``context.graph_bs`` which MoE's
-        ``pad_for_all_gather`` reads to pad ``hidden_states`` before the
-        cross-DP ``all_gather``. Must be identical on every DP rank or the
-        collective shape-mismatches. Only matters when uniform_decode (the
-        variable-length all_gatherv path doesn't read it).
+    ``scheduled_bs`` is what this rank was handed; ``running_bs`` is what the
+    GPU is made to run. The second is DP-group-UNIFIED and that is its whole
+    point: MoE pads to it and a captured graph holds its collective at that
+    width, so a rank arriving with a different one hangs the group.
 
-    Two are equal on the cudagraph path (captured shape is unified by
-    construction) and on the non-uniform path (collective is variable-length,
-    so MoE doesn't care). They diverge only in the uniform-decode + eager
-    fallback corner — ``--enforce-eager`` and ``padded > graph_bs[-1]``.
+    An op reads whichever its own tensors carry. They differ in one corner --
+    uniform decode running eager -- where MoE pads while attention keeps its
+    unpadded rows for aiter's ``t == t_slot``.
     """
 
     use_cudagraph: bool
-    effective_bs: int
-    moe_pad_bs: int
+    scheduled_bs: int
+    running_bs: int
     is_prefill: bool
 
     @classmethod
@@ -192,77 +185,61 @@ class ForwardMode:
         cls,
         *,
         is_prefill: bool,
-        total_seqs_num: int,
-        scheduled_bs_decode: int,
-        num_input_tokens: int,
+        scheduled_bs: int,
+        running_tokens: int,
         dp_uniform_decode: bool,
         enforce_eager: bool,
-        graph_bs: list[int],
+        capture_sizes: list[int],
         mtp_step: int = 1,
     ) -> "ForwardMode":
-        """Compute dispatch + effective_bs + moe_pad_bs. Any new force-eager
+        """Pick dispatch and the step's ``running_bs``. Any new force-eager
         condition belongs here, not in caller-side checks."""
         if is_prefill:
-            # Prefill is always eager. effective_bs is the sequence count;
-            # per-token sums are tracked separately via cu_seqlens_q.
-            # moe_pad_bs is unused on prefill (MoE pad only fires for decode).
+            # Prefill is always eager, so nothing is padded and the two are the
+            # same number. Per-token sums ride cu_seqlens_q, not this.
             return cls(
                 use_cudagraph=False,
-                effective_bs=total_seqs_num,
-                moe_pad_bs=total_seqs_num,
+                scheduled_bs=scheduled_bs,
+                running_bs=scheduled_bs,
                 is_prefill=True,
             )
 
-        # padded_scheduled_bs is unified across DP ranks in uniform mode
-        # (num_input_tokens = max_tokens, set in ModelRunner._preprocess);
-        # local-equivalent in non-uniform mode.
-        padded_scheduled_bs = (num_input_tokens + mtp_step - 1) // mtp_step
+        # The sequences the step will run, recovered from the token count:
+        # DP-unified in uniform mode (`running_tokens` is the group max, set in
+        # ModelRunner._preprocess), local-equivalent otherwise.
+        unified_bs = (running_tokens + mtp_step - 1) // mtp_step
 
         if not dp_uniform_decode:
-            # Non-uniform: MoE goes through all_gatherv (variable-length,
-            # per-rank sizes); pad_for_all_gather is NOT reached so moe_pad_bs
-            # is irrelevant. Keep both at local for consistency.
+            # MoE goes through all_gatherv (variable-length, per-rank sizes),
+            # so pad_for_all_gather is never reached and there is nothing to
+            # unify. Running at the scheduled batch pads nothing.
             return cls(
                 use_cudagraph=False,
-                effective_bs=scheduled_bs_decode,
-                moe_pad_bs=scheduled_bs_decode,
+                scheduled_bs=scheduled_bs,
+                running_bs=scheduled_bs,
                 is_prefill=False,
             )
 
-        # From here on: dp_uniform_decode=True. MoE WILL go through
-        # pad_for_all_gather, so moe_pad_bs MUST be cross-rank unified.
-
-        if enforce_eager:
-            # --enforce-eager + uniform decode: attention input_ids is local
-            # real, so effective_bs = local; but MoE pad needs the unified
-            # padded_scheduled_bs.
+        # From here on uniform decode: MoE WILL pad_for_all_gather, so
+        # running_bs MUST be the same number on every rank.
+        if enforce_eager or unified_bs > capture_sizes[-1]:
+            # Eager under uniform decode, either forced or above the largest
+            # captured size. This is the one corner where the two differ:
+            # attention keeps its own scheduled batch while MoE pads to the
+            # unified one.
             return cls(
                 use_cudagraph=False,
-                effective_bs=scheduled_bs_decode,
-                moe_pad_bs=padded_scheduled_bs,
+                scheduled_bs=scheduled_bs,
+                running_bs=unified_bs,
                 is_prefill=False,
             )
 
-        if padded_scheduled_bs > graph_bs[-1]:
-            # Workload above the largest captured graph: eager fallback under
-            # uniform. Same split — attention local, MoE pad unified.
-            return cls(
-                use_cudagraph=False,
-                effective_bs=scheduled_bs_decode,
-                moe_pad_bs=padded_scheduled_bs,
-                is_prefill=False,
-            )
-
-        # CUDAGraph path: pick the smallest captured size that fits. Captured
-        # shape is unified by construction so attention and MoE pad agree.
-        eff = next(
-            (x for x in graph_bs if x >= padded_scheduled_bs),
-            padded_scheduled_bs,
-        )
+        # CUDAGraph: the smallest captured size that fits. Captured sizes are
+        # a static list every rank shares, so this is unified by construction.
         return cls(
             use_cudagraph=True,
-            effective_bs=eff,
-            moe_pad_bs=eff,
+            scheduled_bs=scheduled_bs,
+            running_bs=next((x for x in capture_sizes if x >= unified_bs), unified_bs),
             is_prefill=False,
         )
 
@@ -290,18 +267,33 @@ class ForwardMode:
             or attn_metadata.slot_mapping is None
         ):
             return
+        # Past the early-return nothing is padded, so the rows attention runs
+        # are exactly the scheduled ones.
         max_q = attn_metadata.max_seqlen_q
-        expected = self.effective_bs * max_q
+        expected = self.scheduled_bs * max_q
         actual_in = input_ids.shape[0]
         actual_slot = attn_metadata.slot_mapping.shape[0]
         assert actual_in == expected, (
-            f"eager input_ids length {actual_in} != effective_bs*max_q="
+            f"eager input_ids length {actual_in} != scheduled_bs*max_q="
             f"{expected} ({self})"
         )
         assert actual_slot == expected, (
-            f"eager slot_mapping length {actual_slot} != effective_bs*max_q="
+            f"eager slot_mapping length {actual_slot} != scheduled_bs*max_q="
             f"{expected} ({self}); attn_metadata_builder used a stale bs"
         )
+
+
+def running_tokens_from_bs(bs: int, *, is_prefill: bool, attn_metadata) -> int:
+    """``running_tokens`` for a bridge that only knows a request count.
+
+    Prefill returns that count verbatim, which is NOT a height: prompt lengths
+    are ragged, so no multiplier recovers one, and a number below the real
+    height just leaves the batch unpadded -- correct there, since a prefill
+    all_gather is variable-length.
+    """
+    if is_prefill or attn_metadata is None:
+        return bs
+    return bs * int(attn_metadata.max_seqlen_q)
 
 
 @dataclass
@@ -310,14 +302,24 @@ class Context:
     positions: torch.Tensor
     is_prefill: bool = False
     is_dummy_run: bool = False
-    batch_size: int = 0
-    graph_bs: int = 0
+    # What this rank was handed. Duplicated from `forward_mode` because a
+    # capture context has none; `scheduled_tokens` is what an eager forward
+    # actually runs.
+    scheduled_bs: int = 0
+    scheduled_tokens: int = 0
+    # The step's DP-unified padded shape. `running_bs` counts SEQUENCES (graph
+    # identity, the draft's pad width), `running_tokens` the hidden_states rows
+    # MoE pads to. Both stored, because the ratio is not always max_seqlen_q --
+    # a DSpark ragged step runs a flat bucket no rectangular bs*q recovers.
+    running_bs: int = 0
+    running_tokens: int = 0
     is_draft: bool = False
     # True iff all DP ranks are running pure decode this step (DP-disabled
     # case is treated as True). Mirrors vLLM's `uniform_decode` flag and
     # gates DP-specific variable-length all_gather/scatter paths.
     dp_uniform_decode: bool = True
-    # Single source of truth for cudagraph vs eager dispatch + effective_bs.
+    # Single source of truth for cudagraph vs eager dispatch + the step's
+    # scheduled_bs / running_bs.
     # Set by prepare_inputs via ForwardMode.decide(). None only on legacy
     # paths that haven't been routed through it (run_model falls back to
     # the original four-OR derivation in that case for back-compat).
@@ -344,8 +346,10 @@ class Context:
         positions: torch.Tensor,
         is_prefill: bool = False,
         is_dummy_run: bool = False,
-        batch_size: int = 0,
-        graph_bs: int = 0,
+        scheduled_bs: int = 0,
+        scheduled_tokens: int = 0,
+        running_bs: int = 0,
+        running_tokens: int = 0,
         is_draft: bool = False,
         dp_uniform_decode: bool = True,
         forward_mode: ForwardMode | None = None,
@@ -357,8 +361,10 @@ class Context:
         self.positions = positions
         self.is_prefill = is_prefill
         self.is_dummy_run = is_dummy_run
-        self.batch_size = batch_size
-        self.graph_bs = graph_bs
+        self.scheduled_bs = scheduled_bs
+        self.scheduled_tokens = scheduled_tokens
+        self.running_bs = running_bs
+        self.running_tokens = running_tokens
         self.is_draft = is_draft
         self.dp_uniform_decode = dp_uniform_decode
         self.forward_mode = forward_mode

--- a/atom/utils/tbo/ubatch_splitting.py
+++ b/atom/utils/tbo/ubatch_splitting.py
@@ -3,7 +3,6 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Optional
 
 import numpy as np
 import torch
@@ -58,10 +57,10 @@ def maybe_create_ubatch_slices(
     num_tokens: int,
     num_ubatches: int = 2,
     is_prefill: bool = False,
-    num_scheduled_tokens: Optional[np.ndarray] = None,
-    max_tokens_per_ubatch: Optional[int] = None,
+    num_scheduled_tokens: np.ndarray | None = None,
+    max_tokens_per_ubatch: int | None = None,
     force: bool = False,
-) -> Optional[list[UBatchSlice]]:
+) -> list[UBatchSlice] | None:
     """Split a batch into N micro-batch slices.
 
     For decode: split by request count (uniform tokens per request).
@@ -136,8 +135,8 @@ def _split_prefill_balanced(
     num_reqs: int,
     num_scheduled_tokens: list[int],
     num_ubatches: int,
-    max_tokens_per_ubatch: Optional[int],
-) -> Optional[list[UBatchSlice]]:
+    max_tokens_per_ubatch: int | None,
+) -> list[UBatchSlice] | None:
     """Split prefill requests into ubatches balanced by token count.
 
     Finds the request boundary closest to total_tokens / num_ubatches,
@@ -193,8 +192,8 @@ def _split_prefill_token_midpoint(
     num_reqs: int,
     num_scheduled_tokens: list[int],
     num_ubatches: int,
-    max_tokens_per_ubatch: Optional[int],
-) -> Optional[list[UBatchSlice]]:
+    max_tokens_per_ubatch: int | None,
+) -> list[UBatchSlice] | None:
     """split prefill at the exact token midpoint."""
     toks = np.asarray(num_scheduled_tokens[:num_reqs], dtype=np.int64)
     total_tokens = int(toks.sum())
@@ -283,7 +282,7 @@ def _get_tbo_cpu_lens(attn_metadata: AttentionMetaData, field_name: str):
 def split_attn_metadata(
     attn_metadata: AttentionMetaData,
     ub_slice: UBatchSlice,
-    padded_bs: int,
+    running_bs: int,
 ) -> AttentionMetaData:
     """Split AttentionMetaData for a single micro-batch."""
     rs = ub_slice.request_slice
@@ -299,10 +298,10 @@ def split_attn_metadata(
         # clamp absolute token offsets to [ts.start, ts.stop], then re-base
         clamped = torch.clamp(seg, min=ts.start, max=ts.stop)
         ub_cu_seqlens_q = clamped - clamped[0]
-        # Pad remaining entries up to padded_bs + 1
-        if padded_bs > ub_num_reqs:
+        # Pad remaining entries up to running_bs + 1
+        if running_bs > ub_num_reqs:
             last_val = ub_cu_seqlens_q[-1]
-            pad_size = padded_bs - ub_num_reqs
+            pad_size = running_bs - ub_num_reqs
             padding = last_val.expand(pad_size)
             ub_cu_seqlens_q = torch.cat([ub_cu_seqlens_q, padding])
 
@@ -312,7 +311,7 @@ def split_attn_metadata(
         ub_slot_mapping = attn_metadata.slot_mapping[ts]
         # Pad with -1 for padded positions
         tok_count = ts.stop - ts.start
-        padded_tok_count = padded_bs
+        padded_tok_count = running_bs
         if padded_tok_count > tok_count:
             pad = torch.full(
                 (padded_tok_count - tok_count,),
@@ -326,9 +325,9 @@ def split_attn_metadata(
     ub_context_lens = None
     if attn_metadata.context_lens is not None:
         ub_context_lens = attn_metadata.context_lens[rs]
-        if padded_bs > ub_num_reqs:
+        if running_bs > ub_num_reqs:
             pad = torch.zeros(
-                padded_bs - ub_num_reqs,
+                running_bs - ub_num_reqs,
                 dtype=attn_metadata.context_lens.dtype,
                 device=attn_metadata.context_lens.device,
             )
@@ -338,9 +337,9 @@ def split_attn_metadata(
     ub_block_tables = None
     if attn_metadata.block_tables is not None:
         ub_block_tables = attn_metadata.block_tables[rs]
-        if padded_bs > ub_num_reqs:
+        if running_bs > ub_num_reqs:
             pad = torch.zeros(
-                padded_bs - ub_num_reqs,
+                running_bs - ub_num_reqs,
                 attn_metadata.block_tables.shape[1],
                 dtype=attn_metadata.block_tables.dtype,
                 device=attn_metadata.block_tables.device,
@@ -353,9 +352,9 @@ def split_attn_metadata(
         orig_indptr = attn_metadata.kv_indptr
         base = orig_indptr[req_start]
         ub_kv_indptr = orig_indptr[req_start : req_end + 1] - base
-        if padded_bs > ub_num_reqs:
+        if running_bs > ub_num_reqs:
             last_val = ub_kv_indptr[-1]
-            pad_size = padded_bs - ub_num_reqs
+            pad_size = running_bs - ub_num_reqs
             padding = last_val.expand(pad_size)
             ub_kv_indptr = torch.cat([ub_kv_indptr, padding])
 
@@ -366,9 +365,9 @@ def split_attn_metadata(
     ub_kv_last_page_lens = None
     if attn_metadata.kv_last_page_lens is not None:
         ub_kv_last_page_lens = attn_metadata.kv_last_page_lens[rs]
-        if padded_bs > ub_num_reqs:
+        if running_bs > ub_num_reqs:
             pad = torch.zeros(
-                padded_bs - ub_num_reqs,
+                running_bs - ub_num_reqs,
                 dtype=attn_metadata.kv_last_page_lens.dtype,
                 device=attn_metadata.kv_last_page_lens.device,
             )
@@ -380,9 +379,9 @@ def split_attn_metadata(
     ub_num_cached_tokens = None
     if attn_metadata.num_cached_tokens is not None:
         ub_num_cached_tokens = attn_metadata.num_cached_tokens[rs]
-        if padded_bs > ub_num_reqs:
+        if running_bs > ub_num_reqs:
             pad = torch.zeros(
-                padded_bs - ub_num_reqs,
+                running_bs - ub_num_reqs,
                 dtype=attn_metadata.num_cached_tokens.dtype,
                 device=attn_metadata.num_cached_tokens.device,
             )
@@ -391,9 +390,9 @@ def split_attn_metadata(
     ub_seq_starts = None
     if attn_metadata.seq_starts is not None:
         ub_seq_starts = attn_metadata.seq_starts[rs]
-        if padded_bs > ub_num_reqs:
+        if running_bs > ub_num_reqs:
             pad = torch.zeros(
-                padded_bs - ub_num_reqs,
+                running_bs - ub_num_reqs,
                 dtype=attn_metadata.seq_starts.dtype,
                 device=attn_metadata.seq_starts.device,
             )
@@ -407,9 +406,9 @@ def split_attn_metadata(
         orig = attn_metadata.sparse_kv_indptr
         base = orig[req_start]
         ub_sparse_kv_indptr = orig[req_start : req_end + 1] - base
-        if padded_bs > ub_num_reqs:
+        if running_bs > ub_num_reqs:
             last_val = ub_sparse_kv_indptr[-1]
-            pad_size = padded_bs - ub_num_reqs
+            pad_size = running_bs - ub_num_reqs
             padding = last_val.expand(pad_size)
             ub_sparse_kv_indptr = torch.cat([ub_sparse_kv_indptr, padding])
 
@@ -423,9 +422,9 @@ def split_attn_metadata(
             ub_cu_seqlens_k = clamped_k - clamped_k[0]
         else:
             ub_cu_seqlens_k = seg_k - seg_k[0]
-        if padded_bs > ub_num_reqs:
+        if running_bs > ub_num_reqs:
             last_val = ub_cu_seqlens_k[-1]
-            pad_size = padded_bs - ub_num_reqs
+            pad_size = running_bs - ub_num_reqs
             padding = last_val.expand(pad_size)
             ub_cu_seqlens_k = torch.cat([ub_cu_seqlens_k, padding])
 

--- a/atom/utils/tbo/ubatch_wrapper.py
+++ b/atom/utils/tbo/ubatch_wrapper.py
@@ -50,7 +50,7 @@ class UBatchWrapper(nn.Module):
         self.comm_stream: torch.cuda.Stream | None = None
         # Barrier: ubatch threads + main thread
         self.ready_barrier = threading.Barrier(3)  # 2 ubatch threads + 1 main
-        # TBO CUDAGraph storage: keyed by (graph_bs, max_q_len)
+        # TBO CUDAGraph storage: keyed by (running_bs, max_q_len)
         self.tbo_graphs: dict[tuple, TBOGraphData] = {}
 
         # Persistent ubatch worker pool. Previously every forward spawned + joined
@@ -115,18 +115,18 @@ class UBatchWrapper(nn.Module):
 
         ub_dp_metadata = self._make_ubatch_dp_metadata(ctx, N)
 
-        full_graph_bs = ctx.context.graph_bs
+        full_running_bs = ctx.context.running_bs
         forward_contexts = []
         ub_inputs = []
 
-        # When using DP gather/scatter (no EP/all2all), compute
-        # DP-synchronized graph_bs per ubatch so MoE's pad_for_all_gather
-        # can just read context.graph_bs.  MORI path doesn't need this.
+        # When using DP gather/scatter (no EP/all2all), compute the
+        # DP-synchronized per-ubatch row count so MoE's pad_for_all_gather can
+        # just read context.running_tokens.  MORI path doesn't need this.
         dp_size = self._get_dp_size() if self.dp_gather_scatter else 1
-        ub_graph_bs_list = self._compute_ub_graph_bs(
+        ub_running_tokens_list = self._compute_ub_running_tokens(
             ctx,
             N,
-            full_graph_bs,
+            full_running_bs,
             dp_size,
             input_ids.device,
         )
@@ -134,16 +134,16 @@ class UBatchWrapper(nn.Module):
         for i, ub_slice in enumerate(ctx.ubatch_slices):
             ub_num_reqs = ub_slice.request_slice.stop - ub_slice.request_slice.start
             if ctx.context.is_prefill:
-                padded_bs = ub_num_reqs
+                ub_running_bs = ub_num_reqs
             else:
-                padded_bs = self._decode_ub_padded_bs(ctx, i, N, full_graph_bs)
+                ub_running_bs = self._decode_ub_running_bs(ctx, i, N, full_running_bs)
             ub_ctx = self._make_ubatch_context(
                 original_ctx,
                 ub_slice,
-                padded_bs,
+                ub_running_bs,
                 i,
                 ub_num_reqs,
-                ub_graph_bs=ub_graph_bs_list[i],
+                ub_running_tokens=ub_running_tokens_list[i],
                 dp_metadata=ub_dp_metadata[i] if ub_dp_metadata is not None else None,
             )
             forward_contexts.append(ub_ctx)
@@ -253,21 +253,22 @@ class UBatchWrapper(nn.Module):
         compute_stream = capture_stream
 
         # Build per-ubatch ForwardContexts from pre-allocated forward_vars.
-        full_graph_bs = ctx.context.graph_bs
+        full_running_bs = ctx.context.running_bs
+        max_q = int(getattr(ctx.attn_metadata, "max_seqlen_q", 1) or 1)
         ub_dp_metadata = self._make_ubatch_dp_metadata(ctx, N)
         forward_contexts = []
         ub_inputs = []
         for i, ub_slice in enumerate(ctx.ubatch_slices):
             if i < N - 1:
-                padded_bs = full_graph_bs // N
+                ub_running_bs = full_running_bs // N
             else:
-                padded_bs = full_graph_bs - (full_graph_bs // N) * (N - 1)
+                ub_running_bs = full_running_bs - (full_running_bs // N) * (N - 1)
             ub_ctx = self._make_ubatch_context(
                 ctx,
                 ub_slice,
-                padded_bs,
+                ub_running_bs,
                 i,
-                ub_graph_bs=padded_bs,
+                ub_running_tokens=ub_running_bs * max_q,
                 dp_metadata=ub_dp_metadata[i] if ub_dp_metadata is not None else None,
             )
             forward_contexts.append(ub_ctx)
@@ -353,7 +354,7 @@ class UBatchWrapper(nn.Module):
                 raise e
 
         # Store TBOContext objects to keep torch.Event alive during replay
-        graph_key = (ctx.context.graph_bs, ctx.attn_metadata.max_seqlen_q)
+        graph_key = (ctx.context.running_bs, ctx.attn_metadata.max_seqlen_q)
         self.tbo_graphs[graph_key] = TBOGraphData(
             graph=graph,
             tbo_ctxs=tbo_ctxs,
@@ -449,8 +450,8 @@ class UBatchWrapper(nn.Module):
         return metas
 
     @staticmethod
-    def _decode_ub_padded_bs(
-        ctx: ForwardContext, i: int, N: int, full_graph_bs: int
+    def _decode_ub_running_bs(
+        ctx: ForwardContext, i: int, N: int, full_running_bs: int
     ) -> int:
         """Per-ubatch padded request count for a decode micro-batch.
 
@@ -469,25 +470,27 @@ class UBatchWrapper(nn.Module):
             return max(1, ub_max[i] // max_q)
         # Fallback: local split (single-rank / value not precomputed).
         if i < N - 1:
-            return full_graph_bs // N
-        return full_graph_bs - (full_graph_bs // N) * (N - 1)
+            return full_running_bs // N
+        return full_running_bs - (full_running_bs // N) * (N - 1)
 
     @staticmethod
-    def _compute_ub_graph_bs(
+    def _compute_ub_running_tokens(
         ctx: ForwardContext,
         N: int,
-        full_graph_bs: int,
+        full_running_bs: int,
         dp_size: int,
         device: torch.device,
     ) -> list[int]:
-        """
-        For prefill (eager only): use cross-DP per-ubatch token MAX that
+        """Per-ubatch ``running_tokens`` -- what each micro-batch's MoE pads to.
+
+        In TOKENS on both branches, which is why neither multiplies by
+        ``dp_size``: pad_for_all_gather gathers across ranks itself.
+
+        For prefill (eager only): the cross-DP per-ubatch token MAX that
             ``ModelRunner._preprocess`` already packed into the single DP
             all_reduce (``ctx.ub_max_tokens_across_dp``). Falls back to
             local sizes when DP is off / value not precomputed.
-        For decode: per-rank padded_bs (the cross-DP all_gather in MoE's
-            pad_for_all_gather multiplies by dp_size itself, so do NOT
-            pre-multiply here).
+        For decode: the per-ubatch padded request count times ``max_seqlen_q``.
         """
         if ctx.context.is_prefill:
             if (
@@ -502,21 +505,20 @@ class UBatchWrapper(nn.Module):
                 ub_num_tokens = ub_slice.token_slice.stop - ub_slice.token_slice.start
                 ub_sizes.append(ub_num_tokens)
             return ub_sizes
-        else:
-            result = []
-            for i in range(N):
-                padded_bs = UBatchWrapper._decode_ub_padded_bs(ctx, i, N, full_graph_bs)
-                result.append(padded_bs)
-            return result
+        max_q = int(getattr(ctx.attn_metadata, "max_seqlen_q", 1) or 1)
+        return [
+            UBatchWrapper._decode_ub_running_bs(ctx, i, N, full_running_bs) * max_q
+            for i in range(N)
+        ]
 
     def _make_ubatch_context(
         self,
         ctx: ForwardContext,
         ub_slice: UBatchSlice,
-        padded_bs: int,
+        ub_running_bs: int,
         ubatch_idx: int = 0,
         actual_num_reqs: int | None = None,
-        ub_graph_bs: int | None = None,
+        ub_running_tokens: int | None = None,
         dp_metadata=None,
     ) -> ForwardContext:
         """Build a ForwardContext for a single micro-batch."""
@@ -526,11 +528,11 @@ class UBatchWrapper(nn.Module):
             ub_attn = self.attn_metadata_builder.build_ubatch_prefill_metadata(
                 ctx.attn_metadata,
                 ub_slice,
-                padded_bs,
+                ub_running_bs,
                 ubatch_idx=ubatch_idx,
             )
         else:
-            attn_bs = actual_num_reqs if actual_num_reqs is not None else padded_bs
+            attn_bs = actual_num_reqs if actual_num_reqs is not None else ub_running_bs
             ub_attn = self.attn_metadata_builder.build_ubatch_metadata(
                 ubatch_idx,
                 attn_bs,
@@ -538,18 +540,22 @@ class UBatchWrapper(nn.Module):
 
         # Split Context
         ub_num_tokens = ub_slice.token_slice.stop - ub_slice.token_slice.start
-        if ub_graph_bs is not None:
-            graph_bs = ub_graph_bs
+        if ub_running_tokens is not None:
+            running_tokens = ub_running_tokens
         elif ctx.context.is_prefill:
-            graph_bs = ub_num_tokens
+            running_tokens = ub_num_tokens
         else:
-            graph_bs = padded_bs
+            running_tokens = ub_running_bs * int(
+                getattr(ctx.attn_metadata, "max_seqlen_q", 1) or 1
+            )
         ub_context = Context(
             positions=ctx.context.positions[ub_slice.token_slice],
             is_prefill=ctx.context.is_prefill,
             is_dummy_run=ctx.context.is_dummy_run,
-            batch_size=ub_num_reqs,
-            graph_bs=graph_bs,
+            scheduled_bs=ub_num_reqs,
+            scheduled_tokens=ub_num_tokens,
+            running_bs=ub_running_bs,
+            running_tokens=running_tokens,
             is_draft=ctx.context.is_draft,
             # Carry over per-ubatch slice of input_ids for hash MoE (PCP+TBO mode).
             # run_model stores local (1/pcp) ids; each ubatch takes its token_slice.

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -2,8 +2,8 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Optional
 
 import numpy as np
 import torch
@@ -183,7 +183,7 @@ class DPSyncResult:
     # that structurally can't split, or a mixed prefill/decode step, vetoes it.)
     tbo_collective_active: bool
     # (ub0_max, ub1_max) across DP — only set when tbo_collective_active.
-    ub_max_tokens_across_dp: Optional[tuple[int, int]]
+    ub_max_tokens_across_dp: tuple[int, int] | None
     # DP-MAX of the DSpark decode shape (q, decode_bs, total_tokens) — only set when
     # ``dspark_shape`` was passed in (DSpark active + DP). Folded into this
     # packed all_gather so DSpark's graph-shape sync no longer needs its own
@@ -201,7 +201,7 @@ def sync_dp_metadata(
     *,
     dp_group,
     dp_size: int,
-    num_input_tokens: int,
+    scheduled_tokens: int,
     is_prefill: bool,
     tbo_on: bool,
     local_meets_min_tokens: bool = False,
@@ -226,7 +226,7 @@ def sync_dp_metadata(
 
     Layout (``sync`` is ``[n_fields, dp_size]``):
 
-      row 0 : num_input_tokens         -> num_tokens_across_dp
+      row 0 : scheduled_tokens        -> num_tokens_across_dp
       row 1 : is_prefill (0/1)         -> any_rank_has_prefill (OR)
       row 2 : meets_min_tokens (0/1)   -> OR  -> any rank reached the min-token bar [TBO only]
       row 3 : can_split (0/1)          -> AND -> every rank can split              [TBO only]
@@ -248,7 +248,7 @@ def sync_dp_metadata(
     # +1 extra DSpark field: per-rank is_dummy (OR-reduced -> any_dummy).
     n_fields = tbo_fields + (4 if dspark_on else 0)
     local = torch.zeros(n_fields, dtype=torch.int32, device="cpu")
-    local[0] = num_input_tokens
+    local[0] = scheduled_tokens
     local[1] = 1 if is_prefill else 0
     if tbo_on:
         local[2] = 1 if local_meets_min_tokens else 0
@@ -270,7 +270,7 @@ def sync_dp_metadata(
     num_tokens_across_dp = sync[0]
     any_rank_has_prefill = bool(sync[1].any())
     tbo_collective_active = False
-    ub_max_tokens_across_dp: Optional[tuple[int, int]] = None
+    ub_max_tokens_across_dp: tuple[int, int] | None = None
     if tbo_on:
         # OR(meets_min_tokens): one rank reaching the min-token bar turns TBO on
         # for all. AND(can_split): but EVERY rank must be structurally splittable, else
@@ -390,13 +390,13 @@ class TBOContext:
         self.gpu_comm_done_event = gpu_comm_done_event
         self.gpu_compute_done_event = gpu_compute_done_event
         self.current_stream = compute_stream
-        self.recv_hook: Optional[Callable] = None
+        self.recv_hook: Callable | None = None
         # Set True when this ubatch's model.forward returns (or raises).
         # Partner thread checks this in `_cpu_yield` so it doesn't sleep
         # forever if we exited (cleanly or via exception) ahead of it.
         self.done: bool = False
         # Filled by `make_tbo_contexts` — points to the OTHER ubatch's ctx.
-        self.partner: Optional["TBOContext"] = None
+        self.partner: TBOContext | None = None
 
     # -- context manager protocol ----------------------------------------
 

--- a/docs/architecture_guide.md
+++ b/docs/architecture_guide.md
@@ -97,7 +97,7 @@ ATOM uses a module-level global `ForwardContext` to pass metadata through CUDA g
   - `spec_decode_metadata` (`SpecDecodeMetadata`) — draft token IDs, target/bonus logits indices.
   - `kv_cache_data` (`dict[str, KVCacheTensor]`) — per-layer KV cache tensor references.
 
-- **`Context`** — lightweight struct: `positions`, `is_prefill`, `batch_size`, `graph_bs`, `is_draft`.
+- **`Context`** — lightweight struct: `positions`, `is_prefill`, `batch_size`, `running_bs`, `running_tokens`, `is_draft`. The last two are the step's DP-unified padded shape: sequences and hidden_states rows respectively.
 
 - **`DPMetadata`** — data parallel metadata with `num_tokens_across_dp()` (all-reduce), `max_tokens_across_dp`, and `chunked_sizes()` context manager.
 

--- a/docs/compilation_cudagraph_guide.md
+++ b/docs/compilation_cudagraph_guide.md
@@ -123,12 +123,12 @@ CUDA graph capture is handled by `ModelRunner.capture_cudagraph()` in `atom/mode
 ```text
 capture_cudagraph()
   |
-  +-- Determine graph_bs list
+  +-- Determine capture_sizes list
   |     |-- If cudagraph_capture_sizes is set: use directly
   |     |-- If cuda_graph_sizes has 1 value N: [1, 2, 4, 8, 16, 32, ..., N]
   |     +-- If cuda_graph_sizes has >1 values: use the provided list
   |
-  +-- Sort graph_bs in descending order (largest batch first)
+  +-- Sort capture_sizes in descending order (largest batch first)
   |
   +-- Assert max batch size <= max_num_seqs
   |
@@ -148,19 +148,19 @@ capture_cudagraph()
   |     +-- Store: self.graphs[(bs, max_q_len)] = graph
   |     +-- torch.cuda.synchronize()
   |
-  +-- Sort graph_bs back to ascending order
-  +-- Return (elapsed_time, graph_bs)
+  +-- Sort capture_sizes back to ascending order
+  +-- Return (elapsed_time, capture_sizes)
 ```
 
 ### Graph keying
 
-Each captured graph is stored in a dictionary keyed by a `(graph_bs, max_q_len)` tuple:
+Each captured graph is stored in a dictionary keyed by a `(running_bs, max_q_len)` tuple:
 
 ```python
 self.graphs: dict[tuple[int, int], torch.cuda.CUDAGraph] = dict()
 ```
 
-- `graph_bs`: The padded batch size used during capture.
+- `running_bs`: The padded batch size used during capture.
 - `max_q_len`: The maximum query length per sequence. For standard decode, this is `1`. For MTP (Multi-Token Prediction) speculative decoding, this is `mtp_k + 1`.
 
 ### Graph pool sharing
@@ -194,14 +194,14 @@ def run_model(self, input_ids):
     is_prefill = context.is_prefill
     positions = context.positions
 
-    if is_prefill or self.enforce_eager or bs > self.graph_bs[-1]:
+    if is_prefill or self.enforce_eager or bs > self.capture_sizes[-1]:
         # Eager path: prefills, enforce_eager mode, or oversized batches
         hidden_states = self.model(input_ids, positions)
     else:
         # Graph replay path: decode batches within captured range
-        graph_bs = context.graph_bs
+        running_bs = context.running_bs
         max_q_len = forward_context.attn_metadata.max_seqlen_q
-        graph_key = (graph_bs, max_q_len)
+        graph_key = (running_bs, max_q_len)
         self.graphs[graph_key].replay()
         num_tokens = context.batch_size * max_q_len
         hidden_states = self.forward_vars["outputs"][:num_tokens]
@@ -268,7 +268,7 @@ The `ForwardContext` dataclass in `atom/utils/forward_context.py` provides a mod
 | `no_compile_layers` | `dict[int, Any]` | Layers that should skip compilation (from `static_forward_context`) |
 | `attn_metadata` | `AttentionMetaData` or `dict` | Attention-specific metadata (sequence lengths, block tables, etc.) |
 | `kv_cache_data` | `dict[str, KVCacheTensor]` | KV cache tensors for each layer |
-| `context` | `Context` | Basic forward pass context (positions, is_prefill, batch_size, graph_bs) |
+| `context` | `Context` | Basic forward pass context (positions, is_prefill, batch_size, running_bs, running_tokens) |
 | `dp_metadata` | `DPMetadata` | Data-parallel metadata (token counts across DP ranks) |
 | `spec_decode_metadata` | `SpecDecodeMetadata` | Speculative decoding metadata (draft tokens, logits indices) |
 
@@ -292,15 +292,16 @@ class Context:
     positions: torch.Tensor    # Token position IDs
     is_prefill: bool = False   # Whether this is a prefill step
     batch_size: int = 0        # Number of sequences in the batch
-    graph_bs: int = 0          # Padded batch size for graph lookup
+    running_bs: int = 0        # Padded SEQUENCE count: graph lookup, draft width
+    running_tokens: int = 0    # Padded ROW count: what MoE all_gather pads to
     is_draft: bool = False     # Whether this is a draft model forward
 ```
 
-The `graph_bs` field is particularly important for CUDA graph dispatch: it holds the padded batch size that maps to a pre-captured graph key.
+`running_bs` drives CUDA graph dispatch: it holds the padded batch size that maps to a pre-captured graph key. `running_tokens` is the same shape counted in hidden_states rows, which is what MoE pads to before the cross-DP all_gather -- the two are not interconvertible on a prefill (ragged prompts) or a DSpark ragged decode (flat token bucket), which is why both are stored.
 
 ### Integration with CUDA graphs
 
-For ModelRunner's direct CUDA graph path (non-piecewise), the forward context is set before `run_model()` via `set_forward_context()`, and `run_model()` reads `context.graph_bs` and `attn_metadata.max_seqlen_q` to look up the correct pre-captured graph.
+For ModelRunner's direct CUDA graph path (non-piecewise), the forward context is set before `run_model()` via `set_forward_context()`, and `run_model()` reads `context.running_bs` and `attn_metadata.max_seqlen_q` to look up the correct pre-captured graph.
 
 For the piecewise path, `CUDAGraphWrapper` (in `atom/utils/cuda_graph.py`) expects `batch_descriptor` and `cudagraph_runtime_mode` fields on the forward context to decide whether to capture, replay, or run eagerly:
 
@@ -412,7 +413,7 @@ Related fields on `Config`:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enforce_eager` | `bool` | `False` | Force eager execution, skip all compilation and CUDA graphs. |
-| `graph_bs` | `Optional[list[int]]` | `None` | Final list of batch sizes for CUDA graph capture (computed from `CompilationConfig`). |
+| `capture_sizes` | `Optional[list[int]]` | `None` | Final list of batch sizes for CUDA graph capture (computed from `CompilationConfig`). |
 | `compilation_config` | `CompilationConfig` | `CompilationConfig()` | The compilation configuration dataclass. |
 
 ## Decision tree
@@ -461,7 +462,7 @@ CompilationConfig(level=3)
 #   splitting_ops = ["aiter.unified_attention_with_output", "aiter.mla_attention"]
 #   cudagraph_mode = CUDAGraphMode.PIECEWISE
 #   cuda_graph_sizes = [512]
-#   graph_bs = [1, 2, 4, 8, 16, 32, ..., 512]
+#   capture_sizes = [1, 2, 4, 8, 16, 32, ..., 512]
 ```
 
 **Custom capture sizes**:

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -51,7 +51,7 @@ Defined in `atom/config.py`. The root dataclass that the engine consumes.
 | `load_dummy` | `Optional[str]` | `None` | Dummy-weight mode (no checkpoint read): `None` off; `"empty"` skip load (uninitialized, legacy); `"zero"` all-zero; `"xavier"` xavier for bf16, constant target magnitude for fp4/fp8 |
 | `enable_expert_parallel` | `bool` | `False` | Enable Expert Parallelism for MoE models |
 | `master_addr` | `str` | `"127.0.0.1"` | Master address for distributed communication |
-| `graph_bs` | `Optional[list[int]]` | `None` | Explicit list of batch sizes for CUDA graph capture; derived from `compilation_config` during init |
+| `capture_sizes` | `Optional[list[int]]` | `None` | Explicit list of batch sizes for CUDA graph capture; derived from `compilation_config` during init |
 | `enable_dp_attention` | `bool` | `False` | Enable data-parallel attention |
 | `dp_load_balance` | `str` | `"least_requests"` | DP request-routing strategy: `"round_robin"` (legacy), `"least_requests"` (default; fewest in-flight requests, ties broken by lighter in-flight prompt-token load), or `"least_tokens"` (lowest `sum_prompt_tokens + ATOM_DP_LB_REQ_EQUIV * num_reqs`). Only effective when >1 DP rank. See distributed guide §2 |
 | `torch_dtype` | `torch.dtype` | *(computed)* | Inferred from `hf_config.torch_dtype`; falls back to `torch.bfloat16` |

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -134,12 +134,12 @@ At the end of CUDAGraph capture the runner runs each one once per captured batch
 size, so the per-shape JIT — aiter's flydsl builds an hgemm per tile config,
 in-process — is paid at startup instead of stalling a serving step. At serve
 time a pass runs at the batch the target just ran, which `ForwardMode.decide`
-picks out of those same `graph_bs` — that is what makes a warmed shape and a
+picks out of those same `capture_sizes` — that is what makes a warmed shape and a
 reachable shape one set rather than two lists that drift. The switch below decides whether that warm also *records*.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| **ATOM_DRAFT_CUDAGRAPH** | bool | 1 (true) | Capture each declared draft pass into a per-`graph_bs` CUDAGraph as it is warmed, so a draft pass replays instead of relaunching every kernel. `0` keeps the warmup (and therefore the JIT saving) but drafts eagerly. Only passes that can pad are captured — a graph is one shape — so this is inert wherever padding is declined (EPLB, the separate-draft Kimi-K3 path, dummy runs). Measured on V4-Flash-DSpark tp1: GSM8K 0.9527 / acceptance 65.25% captured against 0.9497 / 65.21% eager, i.e. indistinguishable; on tp4 with the LM head inside the capture, draft kernel launches went 30 → 0 per pass and draft wall time 915.8 → 118.9 µs. Read per pass at warmup time, so set it before the server starts. Grep a trace for a trailing ` graph` in a `propose_*` label to confirm which passes replayed. |
+| **ATOM_DRAFT_CUDAGRAPH** | bool | 1 (true) | Capture each declared draft pass into a per-`capture_sizes` CUDAGraph as it is warmed, so a draft pass replays instead of relaunching every kernel. `0` keeps the warmup (and therefore the JIT saving) but drafts eagerly. Only passes that can pad are captured — a graph is one shape — so this is inert wherever padding is declined (EPLB, the separate-draft Kimi-K3 path). A DP-sync dummy DOES replay, in lockstep with the ranks holding work — `is_dummy_run` is per-rank, so gating on it splits one DP group across two collectives. Measured on V4-Flash-DSpark tp1: GSM8K 0.9527 / acceptance 65.25% captured against 0.9497 / 65.21% eager, i.e. indistinguishable; on tp4 with the LM head inside the capture, draft kernel launches went 30 → 0 per pass and draft wall time 915.8 → 118.9 µs. Read per pass at warmup time, so set it before the server starts. Grep a trace for a trailing ` graph` in a `propose_*` label to confirm which passes replayed. |
 
 ### DSpark drafting
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -133,9 +133,9 @@ A drafter declares its forward passes as `DraftGraph`s (`atom/spec_decode/drafte
 At the end of CUDAGraph capture the runner runs each one once per captured batch
 size, so the per-shape JIT — aiter's flydsl builds an hgemm per tile config,
 in-process — is paid at startup instead of stalling a serving step. At serve
-time the drafter rounds its batch up to one of those same `graph_bs`, which is
-what makes a warmed shape and a reachable shape one set rather than two lists
-that drift. The switch below decides whether that warm also *records*.
+time a pass runs at the batch the target just ran, which `ForwardMode.decide`
+picks out of those same `graph_bs` — that is what makes a warmed shape and a
+reachable shape one set rather than two lists that drift. The switch below decides whether that warm also *records*.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -127,6 +127,20 @@ materializes two `[B, V]` fp32 tensors that only an `argmax` reads. See
 | **ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_RMSNORM_QUANT** | bool | 1 (true) | If set to `1`, use Triton kernel to fuse RMSNorm with quantization. |
 | **ATOM_LLAMA_ENABLE_AITER_TRITON_FUSED_SILU_MUL_QUANT** | bool | 1 (true) | If set to `1`, use Triton kernel to fuse SiLU and mul with quantization in MLP module. |
 
+### Draft CUDAGraphs (all drafter flavors)
+
+A drafter declares its forward passes as `DraftGraph`s (`atom/spec_decode/drafter.py`).
+At the end of CUDAGraph capture the runner runs each one once per captured batch
+size, so the per-shape JIT — aiter's flydsl builds an hgemm per tile config,
+in-process — is paid at startup instead of stalling a serving step. At serve
+time the drafter rounds its batch up to one of those same `graph_bs`, which is
+what makes a warmed shape and a reachable shape one set rather than two lists
+that drift. The switch below decides whether that warm also *records*.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| **ATOM_DRAFT_CUDAGRAPH** | bool | 1 (true) | Capture each declared draft pass into a per-`graph_bs` CUDAGraph as it is warmed, so a draft pass replays instead of relaunching every kernel. `0` keeps the warmup (and therefore the JIT saving) but drafts eagerly. Only passes that can pad are captured — a graph is one shape — so this is inert wherever padding is declined (EPLB, the separate-draft Kimi-K3 path, dummy runs). Measured on V4-Flash-DSpark tp1: GSM8K 0.9527 / acceptance 65.25% captured against 0.9497 / 65.21% eager, i.e. indistinguishable; on tp4 with the LM head inside the capture, draft kernel launches went 30 → 0 per pass and draft wall time 915.8 → 118.9 µs. Read per pass at warmup time, so set it before the server starts. Grep a trace for a trailing ` graph` in a `propose_*` label to confirm which passes replayed. |
+
 ### DSpark drafting
 
 The Kimi-K3 DSpark draft writes the target's context rows into its own paged MLA

--- a/scripts/start_atom_server.sh
+++ b/scripts/start_atom_server.sh
@@ -56,7 +56,13 @@ done
 
 # 4. Clear stale compile cache
 rm -rf ~/.cache/atom/*
-rm -rf ./gpucore.*
+
+# 5. Reclaim ROCm core dumps from a previous fault: one 8-rank fault writes
+# ~283GB and fills the disk. HSA_ENABLE_COREDUMP=0 does NOT prevent them
+# (measured), so clearing here is the only thing that works. Anchored to the
+# repo, since the dumps land next to the server's CWD, not the caller's.
+REPO_ROOT="$(dirname "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")")"
+rm -rf "$REPO_ROOT"/gpucore.* ./gpucore.*
 
 # Write config header to log (truncates old content).
 # Inherited env vars are dumped explicitly so you never have to wonder

--- a/tests/plugin/test_rtpllm_forward_context_semantics.py
+++ b/tests/plugin/test_rtpllm_forward_context_semantics.py
@@ -37,7 +37,13 @@ def _install_forward_context_stubs():
     plugin_attention.AiterFlashAttentionPrefillMetadata = _KwargsObject
     sys.modules["atom.plugin.attention"] = plugin_attention
 
+    # The one real symbol: `running_tokens_from_bs` is pure arithmetic and
+    # imports standalone, and it is exactly the rule under test here -- a
+    # hand-copied stub would pass while the bridge converted rows wrongly.
+    from atom.utils.forward_context import running_tokens_from_bs
+
     utils_forward_context = types.ModuleType("atom.utils.forward_context")
+    utils_forward_context.running_tokens_from_bs = running_tokens_from_bs
     utils_forward_context.AttentionMetaData = _KwargsObject
     utils_forward_context.Context = _KwargsObject
     utils_forward_context._forward_kv_cache_context = SimpleNamespace(kv_cache_data={})

--- a/tests/test_compress_plan.py
+++ b/tests/test_compress_plan.py
@@ -3,7 +3,7 @@
 
 Covers the three slicing modes (eager / decode-CUDAGraph / extend-shaped verify)
 and the CUDAGraph invariance that lets the decode write grid shrink to
-`graph_bs * min(qlen, K_pool)` while keeping `[bs, graph_bs)` padding rows
+`running_bs * min(qlen, K_pool)` while keeping `[bs, running_bs)` padding rows
 sentinel-filled. No GPU required — a fake CpuGpuBuffer backs the plan tensors.
 """
 
@@ -62,7 +62,7 @@ def _uniform_decode(bs, qlen, ctx=100):
     return extend, context
 
 
-# ── eager path (graph_bs=None) ────────────────────────────────────────────
+# ── eager path (running_bs=None) ────────────────────────────────────────────
 
 
 def test_eager_compress_tight_write_full_buffer():
@@ -76,11 +76,11 @@ def test_eager_compress_tight_write_full_buffer():
         assert p.write_plan_gpu.shape[0] == 200
 
 
-# ── decode CUDAGraph path (graph_bs set) ──────────────────────────────────
+# ── decode CUDAGraph path (running_bs set) ──────────────────────────────────
 
 
 def test_decode_cg_slice_equals_graph_bs_times_bound():
-    graph_bs, qlen = 8, 4
+    running_bs, qlen = 8, 4
     extend, context = _uniform_decode(bs=5, qlen=qlen)
     bufs = _buffers()
     plans = make_compress_plans(
@@ -88,13 +88,13 @@ def test_decode_cg_slice_equals_graph_bs_times_bound():
         context,
         RATIOS_OVERLAP,
         plan_buffers=bufs,
-        graph_bs=graph_bs,
+        running_bs=running_bs,
         max_q_len=qlen,
     )
     for ratio, is_overlap in RATIOS_OVERLAP:
         p = plans[ratio]
-        exp_ccap = graph_bs * ((qlen + ratio - 1) // ratio)
-        exp_wcap = graph_bs * min(qlen, _k_pool(ratio, is_overlap))
+        exp_ccap = running_bs * ((qlen + ratio - 1) // ratio)
+        exp_wcap = running_bs * min(qlen, _k_pool(ratio, is_overlap))
         assert p.compress_plan_gpu.shape[0] == exp_ccap
         assert p.write_plan_gpu.shape[0] == exp_wcap
 
@@ -102,14 +102,14 @@ def test_decode_cg_slice_equals_graph_bs_times_bound():
 def test_decode_write_count_is_bs_times_bound():
     # For decode (qlen <= K_pool) every query token lands in the ring window,
     # so num_write is EXACTLY bs * min(qlen, K_pool) — content-independent.
-    graph_bs, qlen, bs = 8, 4, 5
+    running_bs, qlen, bs = 8, 4, 5
     extend, context = _uniform_decode(bs=bs, qlen=qlen)
     plans = make_compress_plans(
         extend,
         context,
         RATIOS_OVERLAP,
         plan_buffers=_buffers(),
-        graph_bs=graph_bs,
+        running_bs=running_bs,
         max_q_len=qlen,
     )
     for ratio, is_overlap in RATIOS_OVERLAP:
@@ -117,15 +117,15 @@ def test_decode_write_count_is_bs_times_bound():
 
 
 def test_decode_padding_region_is_sentinel():
-    # The [n_write, cap) tail == the [bs, graph_bs) padding seqs → all sentinel.
-    graph_bs, qlen, bs = 8, 4, 5
+    # The [n_write, cap) tail == the [bs, running_bs) padding seqs → all sentinel.
+    running_bs, qlen, bs = 8, 4, 5
     extend, context = _uniform_decode(bs=bs, qlen=qlen)
     plans = make_compress_plans(
         extend,
         context,
         RATIOS_OVERLAP,
         plan_buffers=_buffers(),
-        graph_bs=graph_bs,
+        running_bs=running_bs,
         max_q_len=qlen,
     )
     for ratio, _ in RATIOS_OVERLAP:
@@ -137,47 +137,47 @@ def test_decode_padding_region_is_sentinel():
 
 
 def test_decode_cg_invariant_across_real_bs():
-    # Same (graph_bs, qlen), different real bs → identical slice shapes. This is
-    # the CUDAGraph capture/replay invariant: capture runs at bs==graph_bs,
-    # replay at bs<graph_bs, both must dispatch the same-shaped kernel.
-    graph_bs, qlen = 16, 2
+    # Same (running_bs, qlen), different real bs → identical slice shapes. This is
+    # the CUDAGraph capture/replay invariant: capture runs at bs==running_bs,
+    # replay at bs<running_bs, both must dispatch the same-shaped kernel.
+    running_bs, qlen = 16, 2
     shapes = {}
-    for bs in (graph_bs, 1, 7):
+    for bs in (running_bs, 1, 7):
         extend, context = _uniform_decode(bs=bs, qlen=qlen)
         plans = make_compress_plans(
             extend,
             context,
             RATIOS_OVERLAP,
             plan_buffers=_buffers(),
-            graph_bs=graph_bs,
+            running_bs=running_bs,
             max_q_len=qlen,
         )
         shapes[bs] = {
             r: (plans[r].compress_plan_gpu.shape[0], plans[r].write_plan_gpu.shape[0])
             for r, _ in RATIOS_OVERLAP
         }
-    assert shapes[graph_bs] == shapes[1] == shapes[7]
+    assert shapes[running_bs] == shapes[1] == shapes[7]
 
 
 # ── empty fwd ─────────────────────────────────────────────────────────────
 
 
 def test_empty_fwd_decode_cg_matches_caps_all_sentinel():
-    graph_bs, qlen = 8, 4
-    extend = np.zeros(graph_bs, dtype=np.int32)
-    context = np.zeros(graph_bs, dtype=np.int32)
+    running_bs, qlen = 8, 4
+    extend = np.zeros(running_bs, dtype=np.int32)
+    context = np.zeros(running_bs, dtype=np.int32)
     plans = make_compress_plans(
         extend,
         context,
         RATIOS_OVERLAP,
         plan_buffers=_buffers(),
-        graph_bs=graph_bs,
+        running_bs=running_bs,
         max_q_len=qlen,
     )
     for ratio, is_overlap in RATIOS_OVERLAP:
         p = plans[ratio]
         assert p.num_write == 0 and p.num_compress == 0
-        assert p.write_plan_gpu.shape[0] == graph_bs * min(
+        assert p.write_plan_gpu.shape[0] == running_bs * min(
             qlen, _k_pool(ratio, is_overlap)
         )
         assert (p.write_plan_gpu[:, POSITION_COL] == -1).all()
@@ -221,7 +221,7 @@ def test_graph_bs_and_decode_cap_mutually_exclusive():
             context,
             RATIOS_OVERLAP,
             plan_buffers=_buffers(),
-            graph_bs=4,
+            running_bs=4,
             max_q_len=2,
             decode_capacity_per_ratio={4: 8, 128: 8},
         )

--- a/tests/test_draft_graph.py
+++ b/tests/test_draft_graph.py
@@ -20,18 +20,21 @@ def _graph(**kw):
     """A pass over one int32 input, bound to a stub config."""
     kw.setdefault("inputs", {"row": StagedInput(dtype=torch.int32)})
     kw.setdefault("pads", True)
-    g = DraftGraph(forward=kw.pop("forward", lambda pad_bs, **rows: pad_bs), **kw)
+    g = DraftGraph(
+        forward=kw.pop("forward", lambda running_bs, **rows: running_bs), **kw
+    )
     config = dataclasses.make_dataclass("C", [("max_num_seqs", int)])(256)
     return g.bind(config, torch.device("cpu"))
 
 
-def _ctx(*, effective_bs, use_cudagraph=True, dummy=False, graph_bs=None):
-    """A forward context carrying only what `target_pad_bs` reads."""
+def _ctx(*, running_bs, use_cudagraph=True, dummy=False, running_tokens=None):
+    """A forward context carrying only what `target_running_bs` reads."""
     return types.SimpleNamespace(
         is_dummy_run=dummy,
-        graph_bs=effective_bs if graph_bs is None else graph_bs,
+        running_bs=running_bs,
+        running_tokens=running_bs if running_tokens is None else running_tokens,
         forward_mode=types.SimpleNamespace(
-            use_cudagraph=use_cudagraph, effective_bs=effective_bs
+            use_cudagraph=use_cudagraph, running_bs=running_bs
         ),
     )
 
@@ -39,9 +42,9 @@ def _ctx(*, effective_bs, use_cudagraph=True, dummy=False, graph_bs=None):
 @pytest.mark.parametrize("bs,ran_at,want", [(44, 48, 48), (50, 64, 64), (64, 64, 64)])
 def test_the_pad_batch_is_the_one_the_target_ran(bs, ran_at, want):
     """Never a batch the drafter picks. The target sized its per-sequence
-    metadata with `effective_bs`, so that is exactly how far a pad row may
+    metadata with `running_bs`, so that is exactly how far a pad row may
     reach; anything wider reads a row nobody wrote this step."""
-    assert _graph().target_pad_bs(bs, _ctx(effective_bs=ran_at)) == want
+    assert _graph().target_running_bs(bs, _ctx(running_bs=ran_at)) == want
 
 
 def test_an_empty_batch_is_never_widened():
@@ -52,35 +55,32 @@ def test_an_empty_batch_is_never_widened():
     reach the draft's collectives.
     """
     g = _graph()
-    assert g.target_pad_bs(0, _ctx(effective_bs=48)) == 0
+    assert g.target_running_bs(0, _ctx(running_bs=48)) == 0
     assert g.stage(0, {"row": torch.zeros(0, dtype=torch.int32)})["row"].shape[0] == 0
 
 
-def test_a_token_derived_graph_bs_cannot_be_mistaken_for_a_sequence_count():
-    """Under PIECEWISE + ragged, `_dspark_ragged_moe_graph_bs` overwrites
-    `context.graph_bs` with a TOKEN count (flat_bucket // q) that is neither a
-    captured size nor the batch the metadata was built at. Reading
-    `effective_bs` is what makes that unreachable rather than guarded against.
+def test_the_pad_batch_counts_sequences_and_never_rows():
+    """The context carries the step's padded shape in both units, and only one
+    of them is a batch.
+
+    `running_tokens` is what MoE pads hidden_states to; on a DSpark ragged step
+    it is a flat token bucket that no bs*q recovers, so reading it here would
+    stage hundreds of fabricated sequences. Pinned with the two far apart --
+    equal values would prove nothing about which one is read.
     """
-    ctx = _ctx(effective_bs=48, graph_bs=16336)
-    assert _graph().target_pad_bs(44, ctx) == 48
+    ctx = _ctx(running_bs=48, running_tokens=16336)
+    assert _graph().target_running_bs(44, ctx) == 48
 
 
-@pytest.mark.parametrize(
-    "ctx_kw,why",
-    [
-        ({"use_cudagraph": False}, "eager: nobody sized the metadata past bs"),
-        ({"dummy": True}, "a dummy run has no bound ring slots to pad against"),
-    ],
-)
-def test_nothing_is_padded_where_the_target_pinned_no_batch(ctx_kw, why):
+def test_nothing_is_padded_where_the_target_pinned_no_batch():
     g = _graph()
     # Planted first: owning a graph at 48 is NOT a licence to pad to it. Only a
     # replayed target sizes its per-sequence metadata past the real batch, and
     # a pad row that reaches further takes its ring slot -- which DSpark's block
     # SCATTERS draft KV through -- from a row nobody wrote this step.
     g._cuda_graphs[48] = ("graph", "out")
-    assert g.target_pad_bs(44, _ctx(effective_bs=256, **ctx_kw)) == 44, why
+    ctx = _ctx(running_bs=256, use_cudagraph=False)
+    assert g.target_running_bs(44, ctx) == 44, "eager: nobody sized metadata past bs"
 
 
 def test_a_pass_that_cannot_pad_stays_at_the_real_batch():
@@ -88,7 +88,7 @@ def test_a_pass_that_cannot_pad_stays_at_the_real_batch():
     because pad rows would route through the draft's MoE and land in the
     expert-load histogram."""
     g = _graph(pads=False)
-    assert g.target_pad_bs(44, _ctx(effective_bs=48)) == 44
+    assert g.target_running_bs(44, _ctx(running_bs=48)) == 44
     assert not g.will_capture
 
 
@@ -181,8 +181,8 @@ def test_warmup_runs_the_epilogue_too_not_just_the_capturable_forward(monkeypatc
     monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")  # capture needs a GPU
     ran = []
     g = _graph(
-        forward=lambda pad_bs, **rows: ran.append("forward"),
-        epilogue=lambda out, pad_bs, **rows: ran.append("epilogue"),
+        forward=lambda running_bs, **rows: ran.append("forward"),
+        epilogue=lambda out, running_bs, **rows: ran.append("epilogue"),
     )
     g.warmup(8)
     assert ran == ["forward", "epilogue"]
@@ -198,7 +198,7 @@ def test_warmup_happens_before_the_pad_and_capture_gates(monkeypatch):
     """
     monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")
     ran = []
-    g = _graph(pads=False, forward=lambda pad_bs, **rows: ran.append("forward"))
+    g = _graph(pads=False, forward=lambda running_bs, **rows: ran.append("forward"))
     assert not g.will_capture
     g.warmup(8)
     assert ran == ["forward"]
@@ -208,7 +208,7 @@ def test_warmup_inputs_sees_the_pass_own_buffers(monkeypatch):
     """The seed writes into the staging buffers, not into copies of them: the
     warm batch has to be the one the forward then reads."""
     monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")  # capture needs a GPU
-    g = _graph(warmup_inputs=lambda pad_bs, **rows: rows["row"].fill_(7))
+    g = _graph(warmup_inputs=lambda running_bs, **rows: rows["row"].fill_(7))
     g.warmup(4)
     assert g._buffers["row"][:4].tolist() == [7, 7, 7, 7]
 
@@ -223,17 +223,70 @@ def test_run_replays_the_recording_instead_of_the_forward():
         def replay(self):
             replays.append(1)
 
-    g = _graph(forward=lambda pad_bs, **rows: forwards.append(pad_bs))
+    g = _graph(forward=lambda running_bs, **rows: forwards.append(running_bs))
     src = {"row": torch.zeros(4, dtype=torch.int32)}
 
+    real = _ctx(running_bs=4)
     assert not g.is_captured(4)
-    g.run(4, **g.stage(4, src))
+    g.run(4, real, **g.stage(4, src))
     assert (forwards, replays) == ([4], []), "no recording: must run the forward"
 
     g._cuda_graphs[4] = (_Graph(), "recorded")
     assert g.is_captured(4)
-    assert g.run(4, **g.stage(4, src)) == "recorded"
+    assert g.run(4, real, **g.stage(4, src)) == "recorded"
     assert (forwards, replays) == ([4], [1]), "recorded: must replay, not re-run"
+
+
+def test_a_dummy_replays_in_lockstep_with_the_real_ranks():
+    """`is_dummy_run` is per-rank, so no decision that feeds a collective may
+    read it.
+
+    One DP step has the rank holding work running real while the others run
+    dummies purely to reach the collectives. Gating the replay on dummy-ness
+    therefore splits the group: the real rank replays a recorded collective
+    while the rest issue it eagerly, and all of them wait forever. Measured on
+    V4-Flash-DSpark tp8 + DPA -- one 32-token request hung 8/8 with exactly
+    that split (rank 0 `dummy=False` replaying, ranks 1-7 `dummy=True` eager),
+    and returned in 1.0s once the term was gone.
+
+    A dummy is safe to replay because `warmup` asserts the recording was made
+    on a REAL context: the graph holds the real branch, and doing a real rank's
+    work alongside it is the dummy's whole purpose.
+    """
+    replays, forwards = [], []
+
+    class _Graph:
+        def replay(self):
+            replays.append(1)
+
+    g = _graph(forward=lambda running_bs, **rows: forwards.append(running_bs))
+    g._cuda_graphs[1] = (_Graph(), "recorded")
+    src = {"row": torch.zeros(1, dtype=torch.int32)}
+
+    for dummy in (False, True):
+        ctx = _ctx(running_bs=1, dummy=dummy)
+        assert g.run(1, ctx, **g.stage(1, src)) == "recorded"
+        assert " graph" in g.label(1, 1, ctx)
+    assert (forwards, replays) == ([], [1, 1]), "both ranks replay, neither runs"
+
+
+@pytest.mark.parametrize("use_cudagraph", [True, False])
+def test_the_replay_decision_never_differs_between_a_dummy_and_a_real_step(
+    use_cudagraph,
+):
+    """The property the case above pins, stated over the whole decision.
+
+    Every term `_replays` reads has to be one the whole DP group agrees on;
+    `use_cudagraph` and the batch are (``ForwardMode.decide`` derives both from
+    DP-unified counts), and nothing else may enter. Asserting the equality
+    rather than the two values is what makes a future third term fail here.
+    """
+    g = _graph()
+    g._cuda_graphs[8] = ("graph", "out")
+    real = _ctx(running_bs=8, use_cudagraph=use_cudagraph)
+    dummy = _ctx(running_bs=8, use_cudagraph=use_cudagraph, dummy=True)
+    assert g.target_running_bs(8, real) == g.target_running_bs(8, dummy)
+    assert g.label(8, 8, real) == g.label(8, 8, dummy)
 
 
 def test_the_capture_gate_reaches_the_env_that_names_it(monkeypatch):

--- a/tests/test_draft_graph.py
+++ b/tests/test_draft_graph.py
@@ -44,6 +44,18 @@ def test_the_pad_batch_is_the_one_the_target_ran(bs, ran_at, want):
     assert _graph().target_pad_bs(bs, _ctx(effective_bs=ran_at)) == want
 
 
+def test_an_empty_batch_is_never_widened():
+    """A pad row is a copy of the last real row, and there is none.
+
+    `stage` would reach `src[-1]` on a zero-row source and raise IndexError,
+    which is a much worse way to learn that a rank was kept alive purely to
+    reach the draft's collectives.
+    """
+    g = _graph()
+    assert g.target_pad_bs(0, _ctx(effective_bs=48)) == 0
+    assert g.stage(0, {"row": torch.zeros(0, dtype=torch.int32)})["row"].shape[0] == 0
+
+
 def test_a_token_derived_graph_bs_cannot_be_mistaken_for_a_sequence_count():
     """Under PIECEWISE + ragged, `_dspark_ragged_moe_graph_bs` overwrites
     `context.graph_bs` with a TOKEN count (flat_bucket // q) that is neither a

--- a/tests/test_draft_graph.py
+++ b/tests/test_draft_graph.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: MIT
+"""The draft-pass machine's invariants, with no aiter and no GPU.
+
+These are what the whole padding scheme rests on, so they belong where CI can
+run them. `tests/test_dspark.py` keeps the DSpark-integration half, which needs
+the compiled draft and is therefore skipped on a CPU runner -- if the invariants
+lived only there, nothing would check them at all.
+"""
+
+import dataclasses
+
+import pytest
+import torch
+
+from atom.spec_decode.draft_graph import DraftGraph, StagedInput
+
+_GRAPH_BS = [1, 2, 4, 8, 16, 32, 48, 64, 128, 256]
+
+
+def _graph(**kw):
+    """A pass over one int32 input, bound to a stub runner and config."""
+    kw.setdefault("inputs", {"row": StagedInput(dtype=torch.int32)})
+    kw.setdefault("pads", True)
+    g = DraftGraph(forward=kw.pop("forward", lambda pad_bs, **rows: pad_bs), **kw)
+    runner = dataclasses.make_dataclass("R", [("graph_bs", list)])(list(_GRAPH_BS))
+    config = dataclasses.make_dataclass("C", [("max_num_seqs", int)])(256)
+    return g.bind(config, torch.device("cpu"), runner)
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 17, 33, 49, 64, 200, 256])
+def test_graph_bs_for_is_monotone_and_idempotent(n):
+    """The two invariants the whole scheme rests on. Monotone means padding can
+    never truncate; idempotent means "warmed at startup" and "reachable at
+    runtime" are one set rather than two lists that can drift."""
+    g = _graph()
+    q = g.graph_bs_for(n)
+    assert q >= n
+    assert g.graph_bs_for(q) == q
+    assert q in _GRAPH_BS
+
+
+def test_graph_bs_for_falls_through_when_nothing_covers_the_batch():
+    g = _graph()
+    assert g.graph_bs_for(999) == 999
+    # ...nor is an empty batch rounded up to the smallest graph_bs, which would
+    # ask `stage` to replicate a last real row that does not exist.
+    assert g.graph_bs_for(0) == 0
+
+
+def test_a_pass_that_cannot_pad_never_rounds_up():
+    g = _graph(pads=False)
+    assert g.graph_bs_for(44) == 44
+    assert not g.will_capture
+
+
+def test_declaring_pads_without_inputs_is_refused():
+    """`pads` promises the fabricated rows land somewhere inert; with nothing
+    staged there is no buffer for them to land in at all."""
+    with pytest.raises(AssertionError, match="stages nothing"):
+        _graph(inputs={}, pads=True)
+
+
+def test_staged_tail_repeats_a_real_row_rather_than_zero_filling():
+    """Zero-filling faults the GPU at the first padded decode step.
+
+    Measured on V4-Flash-DSpark tp8: an all-zero tail gives
+    `Memory access fault ... on address (nil)` on 8/8 ranks; repeating a real
+    row is clean on the same workload. Which input cannot take a zero was not
+    isolated, so this pins the repeat, not the reason.
+    """
+    g = _graph()
+    first = g._stage_one("row", 8, torch.arange(3, dtype=torch.int32) + 100)
+    assert first.tolist() == [100, 101, 102, 102, 102, 102, 102, 102]
+    ptr = g._buffers["row"].data_ptr()
+    second = g._stage_one("row", 4, torch.arange(2, dtype=torch.int32) + 5)
+    assert second.tolist() == [5, 6, 6, 6]
+    # Fixed storage: a per-step allocation would hand out a new address every
+    # step, which a capture cannot follow.
+    assert g._buffers["row"].data_ptr() == ptr
+
+
+def test_staging_a_wrong_dtype_fails_loudly():
+    g = _graph()
+    with pytest.raises(AssertionError, match="baked"):
+        g._stage_one("row", 4, torch.zeros(2, dtype=torch.int64))
+
+
+def test_staging_a_source_whose_leading_axis_is_not_the_batch_fails_loudly():
+    """Every staged source is indexed as `[rows, *StagedInput.shape]`.
+
+    MRoPE positions are the live case: they keep the token axis LAST (`[3, N]`),
+    so a drafter must not hand them to a pass at all. Without this the mismatch
+    surfaced as a `copy_` size error two frames down, which reads like a
+    batch-size bug rather than a layout one.
+    """
+    g = _graph()
+    with pytest.raises(AssertionError, match="leading axis is not the batch"):
+        g._stage_one("row", 8, torch.zeros(3, 8, dtype=torch.int32))
+
+
+def test_padding_a_pass_that_never_called_its_pad_rows_inert_is_refused():
+    """`pads` is the only part of the contract nothing else can check.
+
+    A pass that lies about it still runs and still returns the right shape; the
+    fabricated rows just land in another sequence's KV.
+    """
+    src = {"row": torch.zeros(3, dtype=torch.int32)}
+    assert _graph(pads=True).stage(4, src)["row"].shape[0] == 4
+
+    g = _graph(pads=False)
+    with pytest.raises(AssertionError, match="fabricated rows are inert"):
+        g.stage(4, src)
+    # Unpadded entry stays legal -- the contract is about fabricated rows only.
+    assert g.stage(3, src)["row"].shape[0] == 3
+
+
+def test_sources_that_disagree_on_the_batch_are_refused():
+    """They describe one step, so one of them is not this step's."""
+    g = _graph(
+        inputs={
+            "a": StagedInput(dtype=torch.int32),
+            "b": StagedInput(dtype=torch.int32),
+        }
+    )
+    with pytest.raises(AssertionError, match="batches of"):
+        g.stage(
+            8,
+            {
+                "a": torch.zeros(3, dtype=torch.int32),
+                "b": torch.zeros(5, dtype=torch.int32),
+            },
+        )
+
+
+def test_warmup_runs_the_epilogue_too_not_just_the_capturable_forward(monkeypatch):
+    """Warming only the capturable forward leaves the rest of the pass cold.
+
+    Measured: `hipModuleLoadData` per rank on the 16k/20/50c reproducer went
+    0 -> 4 when a block's warm was narrowed to the backbone, because the LM head
+    has its own per-shape flydsl builder and it then fired mid-serve.
+    """
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")  # capture needs a GPU
+    ran = []
+    g = _graph(
+        forward=lambda pad_bs, **rows: ran.append("forward"),
+        epilogue=lambda out, pad_bs, **rows: ran.append("epilogue"),
+    )
+    g.warmup(8)
+    assert ran == ["forward", "epilogue"]
+
+
+def test_warmup_happens_before_the_pad_and_capture_gates(monkeypatch):
+    """A pass that pads nothing and captures nothing is still WARMED.
+
+    That ordering is deliberate -- the JIT is worth paying at startup either
+    way -- but it means declining to pad does not keep a flavor's forward off
+    the startup sweep. A flavor whose model cannot answer it must decline the
+    whole pass.
+    """
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")
+    ran = []
+    g = _graph(pads=False, forward=lambda pad_bs, **rows: ran.append("forward"))
+    assert not g.will_capture
+    g.warmup(8)
+    assert ran == ["forward"]
+
+
+def test_warmup_inputs_sees_the_pass_own_buffers(monkeypatch):
+    """The seed writes into the staging buffers, not into copies of them: the
+    warm batch has to be the one the forward then reads."""
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")  # capture needs a GPU
+    g = _graph(warmup_inputs=lambda pad_bs, **rows: rows["row"].fill_(7))
+    g.warmup(4)
+    assert g._buffers["row"][:4].tolist() == [7, 7, 7, 7]
+
+
+def test_run_replays_the_recording_instead_of_the_forward():
+    """The replay seam. A `run` that returned the recorded output WITHOUT
+    replaying would serve every step the previous step's draft tokens, and
+    nothing else in the suite would notice."""
+    replays, forwards = [], []
+
+    class _Graph:
+        def replay(self):
+            replays.append(1)
+
+    g = _graph(forward=lambda pad_bs, **rows: forwards.append(pad_bs))
+    src = {"row": torch.zeros(4, dtype=torch.int32)}
+
+    assert not g.is_captured(4)
+    g.run(4, **g.stage(4, src))
+    assert (forwards, replays) == ([4], []), "no recording: must run the forward"
+
+    g._cuda_graphs[4] = (_Graph(), "recorded")
+    assert g.is_captured(4)
+    assert g.run(4, **g.stage(4, src)) == "recorded"
+    assert (forwards, replays) == ([4], [1]), "recorded: must replay, not re-run"
+
+
+def test_the_capture_gate_reaches_the_env_that_names_it(monkeypatch):
+    """The env has to be the answer, not merely documented as the answer.
+
+    It once was not: the flag behind this was a literal False while
+    `ATOM_DRAFT_CUDAGRAPH` sat in envs.py with no reader at all, so setting it
+    enabled nothing -- and nothing noticed, because the default was off then too.
+    """
+    g = _graph()
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")
+    assert not g.will_capture
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "1")
+    assert g.will_capture

--- a/tests/test_draft_graph.py
+++ b/tests/test_draft_graph.py
@@ -8,48 +8,75 @@ lived only there, nothing would check them at all.
 """
 
 import dataclasses
+import types
 
 import pytest
 import torch
 
 from atom.spec_decode.draft_graph import DraftGraph, StagedInput
 
-_GRAPH_BS = [1, 2, 4, 8, 16, 32, 48, 64, 128, 256]
-
 
 def _graph(**kw):
-    """A pass over one int32 input, bound to a stub runner and config."""
+    """A pass over one int32 input, bound to a stub config."""
     kw.setdefault("inputs", {"row": StagedInput(dtype=torch.int32)})
     kw.setdefault("pads", True)
     g = DraftGraph(forward=kw.pop("forward", lambda pad_bs, **rows: pad_bs), **kw)
-    runner = dataclasses.make_dataclass("R", [("graph_bs", list)])(list(_GRAPH_BS))
     config = dataclasses.make_dataclass("C", [("max_num_seqs", int)])(256)
-    return g.bind(config, torch.device("cpu"), runner)
+    return g.bind(config, torch.device("cpu"))
 
 
-@pytest.mark.parametrize("n", [1, 2, 3, 17, 33, 49, 64, 200, 256])
-def test_graph_bs_for_is_monotone_and_idempotent(n):
-    """The two invariants the whole scheme rests on. Monotone means padding can
-    never truncate; idempotent means "warmed at startup" and "reachable at
-    runtime" are one set rather than two lists that can drift."""
+def _ctx(*, effective_bs, use_cudagraph=True, dummy=False, graph_bs=None):
+    """A forward context carrying only what `target_pad_bs` reads."""
+    return types.SimpleNamespace(
+        is_dummy_run=dummy,
+        graph_bs=effective_bs if graph_bs is None else graph_bs,
+        forward_mode=types.SimpleNamespace(
+            use_cudagraph=use_cudagraph, effective_bs=effective_bs
+        ),
+    )
+
+
+@pytest.mark.parametrize("bs,ran_at,want", [(44, 48, 48), (50, 64, 64), (64, 64, 64)])
+def test_the_pad_batch_is_the_one_the_target_ran(bs, ran_at, want):
+    """Never a batch the drafter picks. The target sized its per-sequence
+    metadata with `effective_bs`, so that is exactly how far a pad row may
+    reach; anything wider reads a row nobody wrote this step."""
+    assert _graph().target_pad_bs(bs, _ctx(effective_bs=ran_at)) == want
+
+
+def test_a_token_derived_graph_bs_cannot_be_mistaken_for_a_sequence_count():
+    """Under PIECEWISE + ragged, `_dspark_ragged_moe_graph_bs` overwrites
+    `context.graph_bs` with a TOKEN count (flat_bucket // q) that is neither a
+    captured size nor the batch the metadata was built at. Reading
+    `effective_bs` is what makes that unreachable rather than guarded against.
+    """
+    ctx = _ctx(effective_bs=48, graph_bs=16336)
+    assert _graph().target_pad_bs(44, ctx) == 48
+
+
+@pytest.mark.parametrize(
+    "ctx_kw,why",
+    [
+        ({"use_cudagraph": False}, "eager: nobody sized the metadata past bs"),
+        ({"dummy": True}, "a dummy run has no bound ring slots to pad against"),
+    ],
+)
+def test_nothing_is_padded_where_the_target_pinned_no_batch(ctx_kw, why):
     g = _graph()
-    q = g.graph_bs_for(n)
-    assert q >= n
-    assert g.graph_bs_for(q) == q
-    assert q in _GRAPH_BS
+    # Planted first: owning a graph at 48 is NOT a licence to pad to it. Only a
+    # replayed target sizes its per-sequence metadata past the real batch, and
+    # a pad row that reaches further takes its ring slot -- which DSpark's block
+    # SCATTERS draft KV through -- from a row nobody wrote this step.
+    g._cuda_graphs[48] = ("graph", "out")
+    assert g.target_pad_bs(44, _ctx(effective_bs=256, **ctx_kw)) == 44, why
 
 
-def test_graph_bs_for_falls_through_when_nothing_covers_the_batch():
-    g = _graph()
-    assert g.graph_bs_for(999) == 999
-    # ...nor is an empty batch rounded up to the smallest graph_bs, which would
-    # ask `stage` to replicate a last real row that does not exist.
-    assert g.graph_bs_for(0) == 0
-
-
-def test_a_pass_that_cannot_pad_never_rounds_up():
+def test_a_pass_that_cannot_pad_stays_at_the_real_batch():
+    """`pads` gates the padding, not just the capture -- EPLB turns it off
+    because pad rows would route through the draft's MoE and land in the
+    expert-load histogram."""
     g = _graph(pads=False)
-    assert g.graph_bs_for(44) == 44
+    assert g.target_pad_bs(44, _ctx(effective_bs=48)) == 44
     assert not g.will_capture
 
 

--- a/tests/test_dspark.py
+++ b/tests/test_dspark.py
@@ -837,7 +837,7 @@ def test_forward_spec_passes_the_batch_through_unpadded(is_dummy, B):
     half of what changed.
 
     Batch padding lives in the drafter now, not here: `propose` rounds the block
-    up to the target's captured graph_bs before calling this
+    up to the target's captured running_bs before calling this
     (`test_propose_drafts_at_the_captured_graph_bs`). This end stays pass-through.
     """
     from atom.models.deepseek_v4_dspark import DeepseekV4DSpark
@@ -895,17 +895,19 @@ def test_forward_spec_passes_the_batch_through_unpadded(is_dummy, B):
 _GRAPH_BS = [1, 2, 4, 8, 16, 32, 48, 64, 128, 256]
 
 
-def _stub_forward_context(*, batch_size, target_bs, scheduled_bs, use_cudagraph=True):
+def _stub_forward_context(*, scheduled_bs, target_bs, use_cudagraph=True):
     context = types.SimpleNamespace(
-        batch_size=batch_size,
-        # A token count, as DSpark's ragged path leaves it. The drafter must
-        # read `effective_bs`, so a stub that agreed here would prove nothing.
-        graph_bs=target_bs * 337,
+        scheduled_bs=scheduled_bs,
+        running_bs=target_bs,
+        # Rows, not sequences -- a DSpark ragged step leaves these wildly apart.
+        # The drafter pads in SEQUENCES, so a stub that agreed would prove
+        # nothing about which of the two it reads.
+        running_tokens=target_bs * 337,
         is_dummy_run=False,
         is_draft=False,
         positions=None,
         forward_mode=types.SimpleNamespace(
-            use_cudagraph=use_cudagraph, effective_bs=target_bs
+            use_cudagraph=use_cudagraph, running_bs=target_bs
         ),
     )
     # `prepare_decode` publishes the ring slots at the PADDED batch, so the stub
@@ -926,17 +928,26 @@ def _proposer_with_graph_bs(monkeypatch, *, eplb=False, mtp_k=5, window=128):
         DSparkProposer, "aux_for", lambda self, h: [torch.zeros(1)], raising=False
     )
     monkeypatch.setattr(
-        DSparkProposer, "_refresh_dp_metadata", lambda self, fc, n: None, raising=False
+        DSparkProposer,
+        "_refresh_dp_metadata",
+        lambda self, fc, n: None,
+        raising=False,
     )
     monkeypatch.setattr(DSparkProposer, "verify_scheduler", None, raising=False)
 
     p = DSparkProposer.__new__(DSparkProposer)
-    p.config = types.SimpleNamespace(max_num_seqs=256, eplb_enable=eplb)
+    p.config = types.SimpleNamespace(
+        max_num_seqs=256,
+        eplb_enable=eplb,
+        # What `set_forward_context` reads; the warm goes through it.
+        parallel_config=types.SimpleNamespace(data_parallel_size=1),
+        compilation_config=types.SimpleNamespace(static_forward_context={}),
+    )
     p.device = torch.device("cpu")
     p.mtp_k = mtp_k
     p.model = types.SimpleNamespace(vocab_size=1024, window_size=window)
     p.runner = types.SimpleNamespace(
-        graph_bs=list(_GRAPH_BS),
+        capture_sizes=list(_GRAPH_BS),
         attn_metadata_builder=types.SimpleNamespace(
             row_ids=torch.arange(p.config.max_num_seqs + 1, dtype=torch.int32)
         ),
@@ -993,7 +1004,7 @@ def _run_propose(p, fc, real_bs, monkeypatch, seen):
     "real_bs,expect_B", [(44, 48), (50, 64), (1, 1), (64, 64), (35, 48)]
 )
 def test_propose_drafts_at_the_captured_graph_bs(monkeypatch, real_bs, expect_B):
-    """The block runs at the target's graph_bs, not the live batch size.
+    """The block runs at the target's running_bs, not the live batch size.
 
     Without this the drafter hands aiter a fresh width on every distinct decode
     batch and flydsl builds a new hgemm for each -- in-process, so the stall
@@ -1001,9 +1012,7 @@ def test_propose_drafts_at_the_captured_graph_bs(monkeypatch, real_bs, expect_B)
     """
     seen = {}
     p = _proposer_with_graph_bs(monkeypatch)
-    fc = _stub_forward_context(
-        batch_size=real_bs, target_bs=expect_B, scheduled_bs=real_bs
-    )
+    fc = _stub_forward_context(scheduled_bs=real_bs, target_bs=expect_B)
     out = _run_propose(p, fc, real_bs, monkeypatch, seen)
 
     assert seen["B"] == expect_B
@@ -1024,30 +1033,39 @@ def test_propose_drafts_at_the_captured_graph_bs(monkeypatch, real_bs, expect_B)
 
 
 @pytest.mark.parametrize(
-    "cudagraph,eplb,dummy,why",
+    "cudagraph,eplb,why",
     [
-        (
-            False,
-            False,
-            False,
-            "eager fallback: no capture at the drafter's own graph_bs",
-        ),
-        (True, True, False, "pad rows would poison the expert-load histogram"),
-        (True, False, True, "a dummy run has no bound ring slots to pad against"),
+        (False, False, "eager: the target pinned no wider batch to follow"),
+        (True, True, "pad rows would poison the expert-load histogram"),
     ],
 )
 def test_propose_leaves_the_batch_alone_when_nothing_pins_a_wider_one(
-    monkeypatch, cudagraph, eplb, dummy, why
+    monkeypatch, cudagraph, eplb, why
 ):
     seen = {}
     p = _proposer_with_graph_bs(monkeypatch, eplb=eplb)
-    fc = _stub_forward_context(
-        batch_size=44, target_bs=48, scheduled_bs=44, use_cudagraph=cudagraph
-    )
-    fc.context.is_dummy_run = dummy
+    fc = _stub_forward_context(scheduled_bs=44, target_bs=48, use_cudagraph=cudagraph)
     out = _run_propose(p, fc, 44, monkeypatch, seen)
     assert seen["B"] == 44, why
     assert out.shape[0] == 44
+
+
+def test_propose_pads_a_dp_sync_dummy_exactly_like_the_rank_with_work(monkeypatch):
+    """`is_dummy_run` is per-rank, so the draft's width must not read it.
+
+    One DP step runs the rank holding sequences for real while the others run
+    dummies purely to reach the collectives. A width that shrank on the dummies
+    would put two shapes into one MoE all_gather.
+    """
+    widths = []
+    for dummy in (False, True):
+        seen = {}
+        p = _proposer_with_graph_bs(monkeypatch)
+        fc = _stub_forward_context(scheduled_bs=44, target_bs=48)
+        fc.context.is_dummy_run = dummy
+        _run_propose(p, fc, 44, monkeypatch, seen)
+        widths.append(seen["B"])
+    assert widths == [48, 48]
 
 
 def test_the_token_map_is_usable_before_any_step_has_padded():
@@ -1057,6 +1075,40 @@ def test_the_token_map_is_usable_before_any_step_has_padded():
     """
     bufs = DSparkIndexBuffers.allocate(8, 2, 4, torch.device("cpu"))
     assert bufs.batch_ids.tolist() == [i // 2 for i in range(16)]
+
+
+def test_the_warm_marks_its_context_as_a_draft(monkeypatch):
+    """A capture bakes every Python branch taken while it is made.
+
+    `is_draft` gates the aux-capture hook away from the draft's own forward
+    (`Drafter._make_aux_hook`), and the draft shares the target's embedding --
+    so a warm that leaves it False records that hook copying the draft's own
+    embedding over the buffer it exists to protect, on every replay after.
+    """
+    seen = {}
+    p = _proposer_with_graph_bs(monkeypatch)
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")  # capture needs a GPU
+    fc = _stub_forward_context(scheduled_bs=8, target_bs=8)
+    assert fc.context.is_draft is False, "the capture builder leaves it off"
+
+    class _Inner:
+        @staticmethod
+        def __call__(ids, pos, num_draft):
+            seen["is_draft"] = fc.context.is_draft
+            return ("normed", ids.shape[0])
+
+        @staticmethod
+        def head_and_sample(normed, hc_hidden, anchor_ids):
+            return None, None
+
+    p.model.model = _Inner()
+    import atom.spec_decode.dspark_proposer as mod
+
+    monkeypatch.setattr(mod, "get_forward_context", lambda: fc)
+    p.runner.graph_pool = None
+    p.runner.rank = 0
+    p.warmup_draft_graphs(lambda bs: (fc.attn_metadata, fc.context), None)
+    assert seen["is_draft"] is True
 
 
 def test_the_pad_sentinel_lifts_off_a_row_that_becomes_real_again():
@@ -1090,7 +1142,7 @@ def test_confidence_is_sliced_back_before_the_verify_scheduler(monkeypatch):
         set_last_ell=lambda ell: None,
     )
     monkeypatch.setattr(DSparkProposer, "verify_scheduler", sched, raising=False)
-    fc = _stub_forward_context(batch_size=44, target_bs=48, scheduled_bs=44)
+    fc = _stub_forward_context(scheduled_bs=44, target_bs=48)
     _run_propose(p, fc, 44, monkeypatch, seen)
     assert seen["B"] == 48
     assert seen["ell_bs"] == 44
@@ -1118,7 +1170,7 @@ def test_the_block_wires_both_its_backbone_and_its_head_into_the_pass(monkeypatc
             return None, None
 
     p.model.model = _Inner()
-    fc = _stub_forward_context(batch_size=8, target_bs=8, scheduled_bs=8)
+    fc = _stub_forward_context(scheduled_bs=8, target_bs=8)
     import atom.spec_decode.dspark_proposer as mod
 
     monkeypatch.setattr(mod, "get_forward_context", lambda: fc)
@@ -1164,7 +1216,7 @@ def test_the_block_warms_where_the_whole_rolling_window_is_valid(monkeypatch, wi
             return None, None
 
     p.model.model = _Inner()
-    fc = _stub_forward_context(batch_size=8, target_bs=8, scheduled_bs=8)
+    fc = _stub_forward_context(scheduled_bs=8, target_bs=8)
     import atom.spec_decode.dspark_proposer as mod
 
     monkeypatch.setattr(mod, "get_forward_context", lambda: fc)
@@ -1199,7 +1251,7 @@ def test_warming_the_block_on_a_dummy_context_is_refused(monkeypatch):
             return None, None
 
     p.model.model = _Inner()
-    fc = _stub_forward_context(batch_size=8, target_bs=8, scheduled_bs=8)
+    fc = _stub_forward_context(scheduled_bs=8, target_bs=8)
     import atom.spec_decode.dspark_proposer as mod
 
     monkeypatch.setattr(mod, "get_forward_context", lambda: fc)

--- a/tests/test_dspark.py
+++ b/tests/test_dspark.py
@@ -13,6 +13,7 @@ pytest.importorskip("aiter", reason="the compiled draft imports aiter at module 
 
 import torch
 
+from atom.model_ops.v4_kernels.dspark_fp8_indices import DSparkIndexBuffers
 from atom.models.deepseek_v4_dspark import (
     DSparkConfidenceHead,
     DSparkMarkovHead,
@@ -894,19 +895,23 @@ def test_forward_spec_passes_the_batch_through_unpadded(is_dummy, B):
 _GRAPH_BS = [1, 2, 4, 8, 16, 32, 48, 64, 128, 256]
 
 
-def _stub_forward_context(*, batch_size, graph_bs, scheduled_bs, use_cudagraph=True):
+def _stub_forward_context(*, batch_size, target_bs, scheduled_bs, use_cudagraph=True):
     context = types.SimpleNamespace(
         batch_size=batch_size,
-        graph_bs=graph_bs,
+        # A token count, as DSpark's ragged path leaves it. The drafter must
+        # read `effective_bs`, so a stub that agreed here would prove nothing.
+        graph_bs=target_bs * 337,
         is_dummy_run=False,
         is_draft=False,
         positions=None,
-        forward_mode=types.SimpleNamespace(use_cudagraph=use_cudagraph),
+        forward_mode=types.SimpleNamespace(
+            use_cudagraph=use_cudagraph, effective_bs=target_bs
+        ),
     )
     # `prepare_decode` publishes the ring slots at the PADDED batch, so the stub
     # does too -- the block slices to that length and nothing stages it.
     attn_metadata = types.SimpleNamespace(
-        state_slot_out=torch.arange(max(graph_bs, scheduled_bs), dtype=torch.int32)
+        state_slot_out=torch.arange(max(target_bs, scheduled_bs), dtype=torch.int32)
         + 100
     )
     return types.SimpleNamespace(context=context, attn_metadata=attn_metadata)
@@ -930,7 +935,12 @@ def _proposer_with_graph_bs(monkeypatch, *, eplb=False, mtp_k=5, window=128):
     p.device = torch.device("cpu")
     p.mtp_k = mtp_k
     p.model = types.SimpleNamespace(vocab_size=1024, window_size=window)
-    p.runner = types.SimpleNamespace(graph_bs=list(_GRAPH_BS))
+    p.runner = types.SimpleNamespace(
+        graph_bs=list(_GRAPH_BS),
+        attn_metadata_builder=types.SimpleNamespace(
+            row_ids=torch.arange(p.config.max_num_seqs + 1, dtype=torch.int32)
+        ),
+    )
     p._build_draft_graphs()
     return p
 
@@ -948,8 +958,20 @@ def _run_propose(p, fc, real_bs, monkeypatch, seen):
         # A real class, not SimpleNamespace: __call__ is looked up on the type.
         __call__ = staticmethod(_backbone)
 
+        # The real bundle, not a stub: `mask_pad_tail` is what keeps a padded
+        # block from scattering draft KV, and `seen["batch_ids"]` is the only
+        # place these tests can watch it.
+        bufs = DSparkIndexBuffers.allocate(
+            p.config.max_num_seqs, p.mtp_k, int(p.model.window_size), p.device
+        )
+
+        @classmethod
+        def index_buffers(cls, draft, window, device):
+            return cls.bufs
+
         @staticmethod
         def head_and_sample(normed, hc_hidden, anchor_ids):
+            seen["batch_ids"] = _Inner.bufs.batch_ids.clone()
             return (
                 torch.zeros(hc_hidden, p.mtp_k, dtype=torch.int32),
                 torch.zeros(hc_hidden, p.mtp_k),
@@ -980,7 +1002,7 @@ def test_propose_drafts_at_the_captured_graph_bs(monkeypatch, real_bs, expect_B)
     seen = {}
     p = _proposer_with_graph_bs(monkeypatch)
     fc = _stub_forward_context(
-        batch_size=real_bs, graph_bs=expect_B, scheduled_bs=real_bs
+        batch_size=real_bs, target_bs=expect_B, scheduled_bs=real_bs
     )
     out = _run_propose(p, fc, real_bs, monkeypatch, seen)
 
@@ -991,6 +1013,14 @@ def test_propose_drafts_at_the_captured_graph_bs(monkeypatch, real_bs, expect_B)
     assert seen["slots"].shape[0] >= expect_B
     assert seen["slots"][:real_bs].tolist() == list(range(100, 100 + real_bs))
     assert out.shape[0] == real_bs
+
+    # ...but the rows it fabricated must scatter no draft KV. Their ring slot is
+    # the 0 `prepare_decode` fills that tail with, and 0 is a real position, so
+    # an unmasked pad row writes into another request's window.
+    t = p.mtp_k
+    ids = seen["batch_ids"]
+    assert ids[: real_bs * t].tolist() == [i // t for i in range(real_bs * t)]
+    assert ids[real_bs * t : expect_B * t].tolist() == [-1] * (expect_B - real_bs) * t
 
 
 @pytest.mark.parametrize(
@@ -1012,7 +1042,7 @@ def test_propose_leaves_the_batch_alone_when_nothing_pins_a_wider_one(
     seen = {}
     p = _proposer_with_graph_bs(monkeypatch, eplb=eplb)
     fc = _stub_forward_context(
-        batch_size=44, graph_bs=48, scheduled_bs=44, use_cudagraph=cudagraph
+        batch_size=44, target_bs=48, scheduled_bs=44, use_cudagraph=cudagraph
     )
     fc.context.is_dummy_run = dummy
     out = _run_propose(p, fc, 44, monkeypatch, seen)
@@ -1020,40 +1050,22 @@ def test_propose_leaves_the_batch_alone_when_nothing_pins_a_wider_one(
     assert out.shape[0] == 44
 
 
-def test_a_token_derived_graph_bs_is_not_mistaken_for_a_sequence_count(monkeypatch):
-    """Under PIECEWISE + ragged, `_dspark_ragged_moe_graph_bs` overwrites
-    `context.graph_bs` with a TOKEN count (flat_bucket // q), which need not be a
-    captured size. Padding to it would run the block at a shape the startup
-    sweep never warmed -- the exact stall this is supposed to remove."""
-    p = _proposer_with_graph_bs(monkeypatch)
-    ctx = types.SimpleNamespace(
-        graph_bs=100,  # not in _GRAPH_BS
-        is_dummy_run=False,
-        forward_mode=types.SimpleNamespace(use_cudagraph=True),
-    )
-    assert p._block_graph_bs(44, ctx) == 44
-    ctx.graph_bs = 48
-    assert p._block_graph_bs(44, ctx) == 48
+def test_the_pad_sentinel_lifts_off_a_row_that_becomes_real_again():
+    """The half a single step cannot show: the batch shrinks, then grows.
 
-
-def test_a_capture_is_its_own_licence_to_pad_off_the_target_graph_path(monkeypatch):
-    """A prefill step negotiates no sequence count, so the draft picks its own.
-
-    It may only do that where a capture already exists at that batch: a graph is
-    there only if the startup sweep both warmed and captured that shape, so the
-    choice needs no agreement from the target.
+    `batch_ids` outlives the step, so marking without restoring would leave the
+    -1 on rows the next, larger batch fills with real requests -- and a -1 there
+    drops that request's draft KV silently, which reads as lost acceptance
+    rather than as a bug.
     """
-    eager = types.SimpleNamespace(
-        graph_bs=16336,  # a prefill step's graph_bs is a TOKEN count
-        is_dummy_run=False,
-        forward_mode=types.SimpleNamespace(use_cudagraph=False),
-    )
-    p = _proposer_with_graph_bs(monkeypatch)
-    assert p._block_graph_bs(18, eager) == 18, "no capture yet: nothing to pad to"
+    bufs = DSparkIndexBuffers.allocate(8, 2, 4, torch.device("cpu"))
+    row_ids = torch.arange(9, dtype=torch.int32)
 
-    p.block._cuda_graphs[32] = ("graph", "out")
-    assert p._block_graph_bs(18, eager) == 32
-    assert p._block_graph_bs(40, eager) == 40, "capture is at 32, not 48"
+    bufs.mask_pad_tail(row_ids, 2, 6)
+    assert bufs.batch_ids[:12].tolist() == [0, 0, 1, 1] + [-1] * 8
+
+    bufs.mask_pad_tail(row_ids, 5, 6)
+    assert bufs.batch_ids[:12].tolist() == [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, -1, -1]
 
 
 def test_confidence_is_sliced_back_before_the_verify_scheduler(monkeypatch):
@@ -1069,7 +1081,7 @@ def test_confidence_is_sliced_back_before_the_verify_scheduler(monkeypatch):
         set_last_ell=lambda ell: None,
     )
     monkeypatch.setattr(DSparkProposer, "verify_scheduler", sched, raising=False)
-    fc = _stub_forward_context(batch_size=44, graph_bs=48, scheduled_bs=44)
+    fc = _stub_forward_context(batch_size=44, target_bs=48, scheduled_bs=44)
     _run_propose(p, fc, 44, monkeypatch, seen)
     assert seen["B"] == 48
     assert seen["ell_bs"] == 44
@@ -1097,7 +1109,7 @@ def test_the_block_wires_both_its_backbone_and_its_head_into_the_pass(monkeypatc
             return None, None
 
     p.model.model = _Inner()
-    fc = _stub_forward_context(batch_size=8, graph_bs=8, scheduled_bs=8)
+    fc = _stub_forward_context(batch_size=8, target_bs=8, scheduled_bs=8)
     import atom.spec_decode.dspark_proposer as mod
 
     monkeypatch.setattr(mod, "get_forward_context", lambda: fc)
@@ -1113,6 +1125,84 @@ def test_the_block_wires_both_its_backbone_and_its_head_into_the_pass(monkeypatc
         anchor_positions=torch.zeros(8, dtype=torch.int64),
     )
     assert ran == ["backbone"]
+
+
+@pytest.mark.parametrize("window", [128, 64, 7])
+def test_the_block_warms_where_the_whole_rolling_window_is_valid(monkeypatch, window):
+    """The seed decides which shape the warm compiles, not merely that it runs.
+
+    An anchor at position 0 masks every window slot but the last, so the warm
+    builds a near-empty-window variant and steady-state decode still meets its
+    own shape fresh -- the same defect class as leaving the LM head out of the
+    warm, and just as invisible: the pass runs, the graph captures, only the
+    flydsl build moves back into serving.
+
+    Asserted against the model's own ``window_size`` at three widths, so a seed
+    that happened to write the literal 128 would not pass.
+    """
+    seen = {}
+    p = _proposer_with_graph_bs(monkeypatch, window=window)
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")  # capture needs a GPU
+
+    class _Inner:
+        @staticmethod
+        def __call__(ids, pos, num_draft):
+            seen["pos"] = pos.clone()
+            return ("normed", ids.shape[0])
+
+        @staticmethod
+        def head_and_sample(normed, hc_hidden, anchor_ids):
+            return None, None
+
+    p.model.model = _Inner()
+    fc = _stub_forward_context(batch_size=8, target_bs=8, scheduled_bs=8)
+    import atom.spec_decode.dspark_proposer as mod
+
+    monkeypatch.setattr(mod, "get_forward_context", lambda: fc)
+    p.block.warmup(8)
+
+    assert seen["pos"].shape[0] == 8
+    assert (seen["pos"] >= window).all(), seen["pos"].tolist()
+
+
+def test_warming_the_block_on_a_dummy_context_is_refused(monkeypatch):
+    """A dummy context carries an all-zero rolling window, and the seed cannot
+    tell: it writes positions and reads the ring slots off whatever context it
+    is handed. Warming there compiles against zeros and shows up only as lost
+    acceptance downstream, so the pass refuses instead.
+
+    The armed half is the second call: the same warm on a real context reaches
+    the backbone, so the raise below is the guard firing and not the stub
+    failing to be reachable.
+    """
+    reached = []
+    p = _proposer_with_graph_bs(monkeypatch)
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")
+
+    class _Inner:
+        @staticmethod
+        def __call__(ids, pos, num_draft):
+            reached.append("backbone")
+            return ("normed", ids.shape[0])
+
+        @staticmethod
+        def head_and_sample(normed, hc_hidden, anchor_ids):
+            return None, None
+
+    p.model.model = _Inner()
+    fc = _stub_forward_context(batch_size=8, target_bs=8, scheduled_bs=8)
+    import atom.spec_decode.dspark_proposer as mod
+
+    monkeypatch.setattr(mod, "get_forward_context", lambda: fc)
+
+    fc.context.is_dummy_run = True
+    with pytest.raises(AssertionError, match="dummy"):
+        p.block.warmup(8)
+    assert reached == []
+
+    fc.context.is_dummy_run = False
+    p.block.warmup(8)
+    assert reached == ["backbone"]
 
 
 def test_the_separate_draft_model_path_declares_no_draft_graph(monkeypatch):

--- a/tests/test_dspark.py
+++ b/tests/test_dspark.py
@@ -5,6 +5,8 @@ Covers the self-contained, GPU-free pieces: Markov head + Confidence head
 numerics, and SpeculativeConfig DSpark detection/routing.
 """
 
+import types
+
 import pytest
 
 pytest.importorskip("aiter", reason="the compiled draft imports aiter at module load")
@@ -832,8 +834,11 @@ def test_forward_spec_passes_the_batch_through_unpadded(is_dummy, B):
 
     `is_dummy` is still varied because "dummy runs are not special either" is
     half of what changed.
+
+    Batch padding lives in the drafter now, not here: `propose` rounds the block
+    up to the target's captured graph_bs before calling this
+    (`test_propose_drafts_at_the_captured_graph_bs`). This end stays pass-through.
     """
-    expect_B = B
     from atom.models.deepseek_v4_dspark import DeepseekV4DSpark
 
     T = 5
@@ -876,10 +881,257 @@ def test_forward_spec_passes_the_batch_through_unpadded(is_dummy, B):
     finally:
         fc.get_forward_context = saved
 
-    assert seen["B"] == expect_B
-    if expect_B != B:
-        # The pad row copies the real request: a zero position would gather an
-        # uninitialised block-table entry and can fault the GPU.
-        assert seen["positions"] == [11] * expect_B
+    assert seen["B"] == B
     # Outputs always come back sliced to the real batch.
     assert (seen["normed_rows"], seen["hc_B"], seen["anchor_B"]) == (B * T, B, B)
+
+
+# --------------------------------------------------------------------------- #
+# DSpark's wiring into the draft-graph machine. The machine's own invariants
+# live in tests/test_draft_graph.py, which needs no aiter and so runs in CI.
+# --------------------------------------------------------------------------- #
+
+_GRAPH_BS = [1, 2, 4, 8, 16, 32, 48, 64, 128, 256]
+
+
+def _stub_forward_context(*, batch_size, graph_bs, scheduled_bs, use_cudagraph=True):
+    context = types.SimpleNamespace(
+        batch_size=batch_size,
+        graph_bs=graph_bs,
+        is_dummy_run=False,
+        is_draft=False,
+        positions=None,
+        forward_mode=types.SimpleNamespace(use_cudagraph=use_cudagraph),
+    )
+    # `prepare_decode` publishes the ring slots at the PADDED batch, so the stub
+    # does too -- the block slices to that length and nothing stages it.
+    attn_metadata = types.SimpleNamespace(
+        state_slot_out=torch.arange(max(graph_bs, scheduled_bs), dtype=torch.int32)
+        + 100
+    )
+    return types.SimpleNamespace(context=context, attn_metadata=attn_metadata)
+
+
+def _proposer_with_graph_bs(monkeypatch, *, eplb=False, mtp_k=5, window=128):
+    """A DSparkProposer carrying only what the block pass reads."""
+    from atom.spec_decode.dspark_proposer import DSparkProposer
+
+    monkeypatch.setattr(DSparkProposer, "_with_draft", False, raising=False)
+    monkeypatch.setattr(
+        DSparkProposer, "aux_for", lambda self, h: [torch.zeros(1)], raising=False
+    )
+    monkeypatch.setattr(
+        DSparkProposer, "_refresh_dp_metadata", lambda self, fc, n: None, raising=False
+    )
+    monkeypatch.setattr(DSparkProposer, "verify_scheduler", None, raising=False)
+
+    p = DSparkProposer.__new__(DSparkProposer)
+    p.config = types.SimpleNamespace(max_num_seqs=256, eplb_enable=eplb)
+    p.device = torch.device("cpu")
+    p.mtp_k = mtp_k
+    p.model = types.SimpleNamespace(vocab_size=1024, window_size=window)
+    p.runner = types.SimpleNamespace(graph_bs=list(_GRAPH_BS))
+    p._build_draft_graphs()
+    return p
+
+
+def _run_propose(p, fc, real_bs, monkeypatch, seen):
+    import atom.spec_decode.dspark_proposer as mod
+
+    def _backbone(ids, pos, num_draft):
+        seen["B"] = ids.shape[0]
+        seen["positions_B"] = pos.shape[0]
+        seen["slots"] = fc.attn_metadata.state_slot_out.clone()
+        return ("normed", ids.shape[0])
+
+    class _Inner:
+        # A real class, not SimpleNamespace: __call__ is looked up on the type.
+        __call__ = staticmethod(_backbone)
+
+        @staticmethod
+        def head_and_sample(normed, hc_hidden, anchor_ids):
+            return (
+                torch.zeros(hc_hidden, p.mtp_k, dtype=torch.int32),
+                torch.zeros(hc_hidden, p.mtp_k),
+            )
+
+    p.model.model = _Inner()
+    monkeypatch.setattr(mod, "get_forward_context", lambda: fc)
+    return p.propose(
+        target_token_ids=None,
+        target_positions=torch.arange(real_bs, dtype=torch.int64) * 7 + 3,
+        target_hidden_states=torch.zeros(real_bs, 4),
+        num_reject_tokens=None,
+        next_token_ids=torch.full((real_bs,), 5, dtype=torch.int32),
+        last_token_indices=torch.arange(real_bs, dtype=torch.int64),
+    )
+
+
+@pytest.mark.parametrize(
+    "real_bs,expect_B", [(44, 48), (50, 64), (1, 1), (64, 64), (35, 48)]
+)
+def test_propose_drafts_at_the_captured_graph_bs(monkeypatch, real_bs, expect_B):
+    """The block runs at the target's graph_bs, not the live batch size.
+
+    Without this the drafter hands aiter a fresh width on every distinct decode
+    batch and flydsl builds a new hgemm for each -- in-process, so the stall
+    lands mid-serve and every restart pays it again.
+    """
+    seen = {}
+    p = _proposer_with_graph_bs(monkeypatch)
+    fc = _stub_forward_context(
+        batch_size=real_bs, graph_bs=expect_B, scheduled_bs=real_bs
+    )
+    out = _run_propose(p, fc, real_bs, monkeypatch, seen)
+
+    assert seen["B"] == expect_B
+    assert seen["positions_B"] == expect_B
+    # The block does not touch the target's ring slots: they arrive already at
+    # the padded length, so there is nothing to install and nothing to restore.
+    assert seen["slots"].shape[0] >= expect_B
+    assert seen["slots"][:real_bs].tolist() == list(range(100, 100 + real_bs))
+    assert out.shape[0] == real_bs
+
+
+@pytest.mark.parametrize(
+    "cudagraph,eplb,dummy,why",
+    [
+        (
+            False,
+            False,
+            False,
+            "eager fallback: no capture at the drafter's own graph_bs",
+        ),
+        (True, True, False, "pad rows would poison the expert-load histogram"),
+        (True, False, True, "a dummy run has no bound ring slots to pad against"),
+    ],
+)
+def test_propose_leaves_the_batch_alone_when_nothing_pins_a_wider_one(
+    monkeypatch, cudagraph, eplb, dummy, why
+):
+    seen = {}
+    p = _proposer_with_graph_bs(monkeypatch, eplb=eplb)
+    fc = _stub_forward_context(
+        batch_size=44, graph_bs=48, scheduled_bs=44, use_cudagraph=cudagraph
+    )
+    fc.context.is_dummy_run = dummy
+    out = _run_propose(p, fc, 44, monkeypatch, seen)
+    assert seen["B"] == 44, why
+    assert out.shape[0] == 44
+
+
+def test_a_token_derived_graph_bs_is_not_mistaken_for_a_sequence_count(monkeypatch):
+    """Under PIECEWISE + ragged, `_dspark_ragged_moe_graph_bs` overwrites
+    `context.graph_bs` with a TOKEN count (flat_bucket // q), which need not be a
+    captured size. Padding to it would run the block at a shape the startup
+    sweep never warmed -- the exact stall this is supposed to remove."""
+    p = _proposer_with_graph_bs(monkeypatch)
+    ctx = types.SimpleNamespace(
+        graph_bs=100,  # not in _GRAPH_BS
+        is_dummy_run=False,
+        forward_mode=types.SimpleNamespace(use_cudagraph=True),
+    )
+    assert p._block_graph_bs(44, ctx) == 44
+    ctx.graph_bs = 48
+    assert p._block_graph_bs(44, ctx) == 48
+
+
+def test_a_capture_is_its_own_licence_to_pad_off_the_target_graph_path(monkeypatch):
+    """A prefill step negotiates no sequence count, so the draft picks its own.
+
+    It may only do that where a capture already exists at that batch: a graph is
+    there only if the startup sweep both warmed and captured that shape, so the
+    choice needs no agreement from the target.
+    """
+    eager = types.SimpleNamespace(
+        graph_bs=16336,  # a prefill step's graph_bs is a TOKEN count
+        is_dummy_run=False,
+        forward_mode=types.SimpleNamespace(use_cudagraph=False),
+    )
+    p = _proposer_with_graph_bs(monkeypatch)
+    assert p._block_graph_bs(18, eager) == 18, "no capture yet: nothing to pad to"
+
+    p.block._cuda_graphs[32] = ("graph", "out")
+    assert p._block_graph_bs(18, eager) == 32
+    assert p._block_graph_bs(40, eager) == 40, "capture is at 32, not 48"
+
+
+def test_confidence_is_sliced_back_before_the_verify_scheduler(monkeypatch):
+    """compute_ell reads its batch size off confidence.shape and zips the ell it
+    returns against batch.req_ids by position, so a pad row silently shifts every
+    request's verify length."""
+    from atom.spec_decode.dspark_proposer import DSparkProposer
+
+    seen = {}
+    p = _proposer_with_graph_bs(monkeypatch)
+    sched = types.SimpleNamespace(
+        compute_ell=lambda conf: seen.setdefault("ell_bs", conf.shape[0]),
+        set_last_ell=lambda ell: None,
+    )
+    monkeypatch.setattr(DSparkProposer, "verify_scheduler", sched, raising=False)
+    fc = _stub_forward_context(batch_size=44, graph_bs=48, scheduled_bs=44)
+    _run_propose(p, fc, 44, monkeypatch, seen)
+    assert seen["B"] == 48
+    assert seen["ell_bs"] == 44
+
+
+def test_the_block_wires_both_its_backbone_and_its_head_into_the_pass(monkeypatch):
+    """DSpark's own wiring, not the machine's ordering (that is in
+    tests/test_draft_graph.py): the head must be the pass's EPILOGUE, so warming
+    reaches it. It has its own per-shape flydsl builder, and leaving it out is
+    how `hipModuleLoadData` went 0 -> 4 on the reproducer once.
+    """
+    ran = []
+    p = _proposer_with_graph_bs(monkeypatch)
+    monkeypatch.setenv("ATOM_DRAFT_CUDAGRAPH", "0")  # capture needs a GPU
+
+    class _Inner:
+        @staticmethod
+        def __call__(ids, pos, num_draft):
+            ran.append("backbone")
+            return ("normed", ids.shape[0])
+
+        @staticmethod
+        def head_and_sample(normed, hc_hidden, anchor_ids):
+            ran.append("head")
+            return None, None
+
+    p.model.model = _Inner()
+    fc = _stub_forward_context(batch_size=8, graph_bs=8, scheduled_bs=8)
+    import atom.spec_decode.dspark_proposer as mod
+
+    monkeypatch.setattr(mod, "get_forward_context", lambda: fc)
+    p.block.warmup(8)
+    assert ran == ["backbone", "head"]
+
+    # ...and the forward really is only the backbone, so `capture_epilogue=False`
+    # would keep the LM head's all-gather out of a capture.
+    ran.clear()
+    p.block.forward(
+        8,
+        anchor_ids=torch.zeros(8, dtype=torch.int32),
+        anchor_positions=torch.zeros(8, dtype=torch.int64),
+    )
+    assert ran == ["backbone"]
+
+
+def test_the_separate_draft_model_path_declares_no_draft_graph(monkeypatch):
+    """Kimi-K3 must declare NO pass, not merely an unpaddable one.
+
+    Its draft carries neither `window_size` nor `model.head_and_sample`, which
+    the warmup and epilogue reach for -- and `warmup` runs both BEFORE it
+    consults the pad/capture gates. So an unpaddable-but-declared pass still
+    takes the startup sweep through `_block_warmup_inputs` and dies with an
+    AttributeError, which is what leaving this at `pads = False` used to do.
+    """
+    from atom.spec_decode.dspark_proposer import DSparkProposer
+
+    p = _proposer_with_graph_bs(monkeypatch)
+    assert p.draft_graphs and p.block.pads
+
+    monkeypatch.setattr(DSparkProposer, "_with_draft", True, raising=False)
+    p._build_draft_graphs()
+    assert p.draft_graphs == ()
+    # None, not absent and not the pass a previous build left behind: rebuilding
+    # is what the flavor probes in these tests do, and `propose` reads this.
+    assert p.block is None

--- a/tests/test_dspark.py
+++ b/tests/test_dspark.py
@@ -1050,6 +1050,15 @@ def test_propose_leaves_the_batch_alone_when_nothing_pins_a_wider_one(
     assert out.shape[0] == 44
 
 
+def test_the_token_map_is_usable_before_any_step_has_padded():
+    """The startup sweep runs the block before `propose` ever calls
+    `mask_pad_tail`, so `allocate` may not leave this undefined: the scatter
+    reads it as a liveness gate and would drop a random subset of the warm.
+    """
+    bufs = DSparkIndexBuffers.allocate(8, 2, 4, torch.device("cpu"))
+    assert bufs.batch_ids.tolist() == [i // 2 for i in range(16)]
+
+
 def test_the_pad_sentinel_lifts_off_a_row_that_becomes_real_again():
     """The half a single step cannot show: the batch shrinks, then grows.
 

--- a/tests/test_model_runner_staging_fence.py
+++ b/tests/test_model_runner_staging_fence.py
@@ -105,8 +105,8 @@ def test_late_draft_uploads_are_staged_by_prepare_model():
     """Draft setup must not start a new pinned H2D after the staging event."""
     prepare_model = _method("prepare_model")
     propose = _method("propose_draft_token_ids")
-    precompute = _method(
-        "precompute_context_kv",
+    compute_draft_kv = _method(
+        "compute_draft_kv",
         path=EAGLE_PROPOSER,
         class_name="EagleProposer",
     )
@@ -115,4 +115,4 @@ def test_late_draft_uploads_are_staged_by_prepare_model():
     assert len(_attribute_calls(prepare_model, "copy_to_gpu")) == 1
     assert not _attribute_calls(propose, "anchors_to_gpu")
     assert not _attribute_calls(propose, "copy_to_gpu")
-    assert not _attribute_calls(precompute, "anchors_to_gpu")
+    assert not _attribute_calls(compute_draft_kv, "anchors_to_gpu")

--- a/tests/test_mori_dispatch_trim_bound.py
+++ b/tests/test_mori_dispatch_trim_bound.py
@@ -7,8 +7,8 @@ source token whose several top-k experts all resolve to the same rank is written
 into that rank's receive buffer exactly once (see the "Deduplicate" block in
 mori intranode.hpp, which skips any top-k slot whose destPe already appeared in
 an earlier slot of the same token). So a single rank's receive buffer holds at
-most `graph_bs` tokens per source rank -> `graph_bs * dp_size` total, never
-`graph_bs * topk * dp_size`. The topk-inflated bound sat above the real
+most `running_tokens` tokens per source rank -> `running_tokens * dp_size` total, never
+`running_tokens * topk * dp_size`. The topk-inflated bound sat above the real
 valid-token count, making the trim a no-op and leaving fused_moe reading
 uninitialized tail rows.
 """
@@ -24,9 +24,9 @@ import torch
 import atom.model_ops.fused_moe.modular_kernel as mk
 
 
-def _trim(monkeypatch, *, graph_bs, dp_size, topk, recv_rows):
+def _trim(monkeypatch, *, running_tokens, dp_size, topk, recv_rows):
     context = SimpleNamespace(
-        graph_bs=graph_bs, is_prefill=False, dp_uniform_decode=True
+        running_tokens=running_tokens, is_prefill=False, dp_uniform_decode=True
     )
     monkeypatch.setattr(
         mk, "get_forward_context", lambda: SimpleNamespace(context=context)
@@ -47,11 +47,15 @@ def _trim(monkeypatch, *, graph_bs, dp_size, topk, recv_rows):
 
 
 def test_trims_to_graph_bs_times_dp_size_not_topk(monkeypatch):
-    graph_bs, dp_size, topk = 4, 8, 6
+    running_tokens, dp_size, topk = 4, 8, 6
     a1, scale, ids, weights = _trim(
-        monkeypatch, graph_bs=graph_bs, dp_size=dp_size, topk=topk, recv_rows=512
+        monkeypatch,
+        running_tokens=running_tokens,
+        dp_size=dp_size,
+        topk=topk,
+        recv_rows=512,
     )
-    expected = graph_bs * dp_size  # 32, NOT 32*topk=192
+    expected = running_tokens * dp_size  # 32, NOT 32*topk=192
     assert a1.shape[0] == expected
     assert ids.shape[0] == expected
     assert weights.shape[0] == expected
@@ -59,18 +63,22 @@ def test_trims_to_graph_bs_times_dp_size_not_topk(monkeypatch):
 
 
 def test_topk_does_not_change_the_bound(monkeypatch):
-    graph_bs, dp_size = 4, 8
+    running_tokens, dp_size = 4, 8
     rows = {
         topk: _trim(
-            monkeypatch, graph_bs=graph_bs, dp_size=dp_size, topk=topk, recv_rows=512
+            monkeypatch,
+            running_tokens=running_tokens,
+            dp_size=dp_size,
+            topk=topk,
+            recv_rows=512,
         )[0].shape[0]
         for topk in (1, 2, 6, 9)
     }
-    assert set(rows.values()) == {graph_bs * dp_size}
+    assert set(rows.values()) == {running_tokens * dp_size}
 
 
 def test_no_trim_when_bound_exceeds_buffer(monkeypatch):
     # fused_moe is driven by num_local_tokens; the buffer must never be cut
     # below the bound.
-    a1, _, _, _ = _trim(monkeypatch, graph_bs=64, dp_size=8, topk=4, recv_rows=16)
+    a1, _, _, _ = _trim(monkeypatch, running_tokens=64, dp_size=8, topk=4, recv_rows=16)
     assert a1.shape[0] == 16

--- a/tests/test_prepare_mtp_decode_contract.py
+++ b/tests/test_prepare_mtp_decode_contract.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""`prepare_mtp_decode` overrides must match what the drafter will call them with.
+
+Importing any backend pulls in aiter and a GPU, so this reads the source AST
+instead and stays in the non-GPU pre-checkin suite -- the same trick
+`test_model_runner_staging_fence.py` uses.
+
+The pairing this pins has been wrong twice: `GDNAttentionMetadataBuilder`
+inherited `fuse_mtp_decode_position_update = True` while declaring an override
+that takes none of the fused arguments, and `TritonMLAMetadataBuilder` grew an
+override that stopped at `num_reject_tokens`. Both are a `TypeError` on the
+first mid-step of any speculative decode, on a backend no CI job runs.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+BACKENDS = Path(__file__).resolve().parents[1] / "atom/model_ops/attentions"
+
+# What `EagleProposer.propose` adds when it takes the fused branch.
+FUSED_KWARGS = {"update_context_lens", "positions_out"}
+
+
+def _classes(path: Path) -> dict[str, ast.ClassDef]:
+    module = ast.parse(path.read_text())
+    return {n.name: n for n in ast.walk(module) if isinstance(n, ast.ClassDef)}
+
+
+def _all_classes() -> dict[str, tuple[Path, ast.ClassDef]]:
+    found: dict[str, tuple[Path, ast.ClassDef]] = {}
+    for path in sorted(BACKENDS.glob("*.py")):
+        for name, node in _classes(path).items():
+            found[name] = (path, node)
+    return found
+
+
+def _method(cls: ast.ClassDef, name: str) -> ast.FunctionDef | None:
+    for node in cls.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def _fuses(cls: ast.ClassDef, classes: dict) -> bool:
+    """The flag as this class sees it, following `Builder(...)` bases by name."""
+    for node in cls.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "fuse_mtp_decode_position_update"
+            for t in node.targets
+        ):
+            return bool(getattr(node.value, "value", False))
+    for base in cls.bases:
+        name = base.id if isinstance(base, ast.Name) else None
+        if name in classes and _fuses(classes[name][1], classes):
+            return True
+    return False
+
+
+def _accepts_fused(fn: ast.FunctionDef) -> bool:
+    if fn.args.kwarg is not None:  # **kwargs swallows whatever the base takes
+        return True
+    named = {a.arg for a in fn.args.kwonlyargs} | {a.arg for a in fn.args.args}
+    return FUSED_KWARGS <= named
+
+
+_OVERRIDES = sorted(
+    name
+    for name, (_, cls) in _all_classes().items()
+    if _method(cls, "prepare_mtp_decode") is not None
+)
+
+
+@pytest.mark.parametrize("class_name", _OVERRIDES)
+def test_a_fusing_backend_accepts_the_arguments_fusing_means(class_name):
+    """Declaring the flag is a promise to take `positions_out` and update it.
+
+    A backend that cannot absorb the position bump must say so on the class, not
+    accept the keywords and drop them -- that trades a `TypeError` for a draft
+    reading last step's positions, which nothing would report.
+    """
+    classes = _all_classes()
+    path, cls = classes[class_name]
+    fn = _method(cls, "prepare_mtp_decode")
+    assert _fuses(cls, classes) == _accepts_fused(fn), (
+        f"{path.name}:{cls.name}.prepare_mtp_decode "
+        f"{'takes' if _accepts_fused(fn) else 'does not take'} the fused "
+        f"arguments while the class resolves "
+        f"fuse_mtp_decode_position_update={_fuses(cls, classes)}"
+    )
+
+
+def test_the_scan_found_the_backends_it_is_meant_to_cover():
+    """A rename that emptied the sweep would leave every case above vacuous."""
+    assert len(_OVERRIDES) >= 4, _OVERRIDES

--- a/tests/test_run_label.py
+++ b/tests/test_run_label.py
@@ -46,7 +46,8 @@ class TestKindPrefix:
             use_cudagraph=False,
             is_dummy=False,
             tbo_on=False,
-            bs=2,
+            scheduled_bs=2,
+            running_bs=2,
             batch=prefill_batch(14721, [7803, 6918]),
         )
         assert lbl.startswith("prefill[")
@@ -58,7 +59,8 @@ class TestKindPrefix:
             use_cudagraph=True,
             is_dummy=False,
             tbo_on=False,
-            bs=64,
+            scheduled_bs=64,
+            running_bs=64,
             batch=decode_batch(64, d=64),
         )
         assert lbl.startswith("decode[")
@@ -70,7 +72,8 @@ class TestKindPrefix:
             use_cudagraph=False,
             is_dummy=False,
             tbo_on=False,
-            bs=300,
+            scheduled_bs=300,
+            running_bs=300,
             batch=decode_batch(300, d=300),
         )
         assert lbl.startswith("eager_decode[")
@@ -81,7 +84,8 @@ class TestKindPrefix:
             use_cudagraph=True,
             is_dummy=True,
             tbo_on=False,
-            bs=1,
+            scheduled_bs=1,
+            running_bs=1,
             batch=decode_batch(1, d=1),
         )
         real = build_run_label(
@@ -89,7 +93,8 @@ class TestKindPrefix:
             use_cudagraph=True,
             is_dummy=False,
             tbo_on=False,
-            bs=1,
+            scheduled_bs=1,
+            running_bs=1,
             batch=decode_batch(1, d=1),
         )
         assert dummy.startswith("dummy_decode[")
@@ -103,7 +108,8 @@ class TestKindPrefix:
             use_cudagraph=False,
             is_dummy=True,
             tbo_on=False,
-            bs=1,
+            scheduled_bs=1,
+            running_bs=1,
             batch=prefill_batch(8192, [8192]),
         )
         assert lbl.startswith("dummy_prefill[")
@@ -115,7 +121,8 @@ class TestKindPrefix:
             use_cudagraph=False,
             is_dummy=True,
             tbo_on=False,
-            bs=1,
+            scheduled_bs=1,
+            running_bs=1,
             batch=decode_batch(1, d=1),
         )
         assert lbl.startswith("dummy_eager_decode[")
@@ -128,7 +135,8 @@ class TestFields:
             use_cudagraph=False,
             is_dummy=False,
             tbo_on=True,
-            bs=3,
+            scheduled_bs=3,
+            running_bs=3,
             batch=prefill_batch(16384, [7000, 6000, 3384]),
         )
         assert lbl.endswith("tbo=1]")
@@ -139,7 +147,8 @@ class TestFields:
             use_cudagraph=True,
             is_dummy=False,
             tbo_on=False,
-            bs=128,
+            scheduled_bs=128,
+            running_bs=128,
             batch=decode_batch(128, d=126, p=2, spec=3),
         )
         assert " p=2" in lbl and " d=126" in lbl and " spec=3" in lbl
@@ -150,7 +159,8 @@ class TestFields:
             use_cudagraph=False,
             is_dummy=False,
             tbo_on=False,
-            bs=8,
+            scheduled_bs=8,
+            running_bs=8,
             batch=prefill_batch(8000, list(range(8))),
         )
         assert "...+5" in lbl  # 8 seqs → first 3 shown + "...+5"
@@ -161,7 +171,8 @@ class TestFields:
             use_cudagraph=True,
             is_dummy=False,
             tbo_on=False,
-            bs=16,
+            scheduled_bs=16,
+            running_bs=16,
             batch=None,
         )
         assert lbl == "decode[bs=16]"
@@ -175,8 +186,8 @@ class TestGraphBs:
             use_cudagraph=True,
             is_dummy=False,
             tbo_on=False,
-            bs=117,
-            graph_bs=128,
+            scheduled_bs=117,
+            running_bs=128,
             batch=decode_batch(117, d=117),
         )
         assert lbl.startswith("decode[bs=117/128 ")
@@ -188,41 +199,38 @@ class TestGraphBs:
             use_cudagraph=True,
             is_dummy=False,
             tbo_on=False,
-            bs=128,
-            graph_bs=128,
+            scheduled_bs=128,
+            running_bs=128,
             batch=decode_batch(128, d=128),
         )
         assert lbl.startswith("decode[bs=128 ")
         assert "/" not in lbl
 
-    def test_graph_bs_below_real_bs_omits_slash(self):
-        # Guard is "graph padded ABOVE real" (graph_bs > bs). A graph_bs < bs
-        # never happens in production (the cudagraph path always has
-        # graph_bs >= bs), but if it did we keep the plain real bs rather than
-        # emit a misleading "bs=128/64".
-        lbl = build_run_label(
-            is_prefill=False,
-            use_cudagraph=True,
-            is_dummy=False,
-            tbo_on=False,
-            bs=128,
-            graph_bs=64,
-            batch=decode_batch(128, d=128),
-        )
-        assert lbl.startswith("decode[bs=128 ")
-        assert "/" not in lbl
+    def test_the_single_number_is_what_ran(self):
+        """The unslashed form reports `running_bs`, not `scheduled_bs`.
 
-    def test_graph_bs_none_is_backward_compatible(self):
-        # Omitting graph_bs keeps the legacy single-number form.
-        lbl = build_run_label(
-            is_prefill=False,
-            use_cudagraph=True,
-            is_dummy=False,
-            tbo_on=False,
-            bs=64,
-            batch=decode_batch(64, d=64),
+        They are equal here -- `decide` ceils to a captured size, so the
+        cudagraph path never runs narrower than it scheduled -- which is
+        exactly why reading the wrong one is invisible in the output. Pinned
+        by construction instead: a caller that passed only `scheduled_bs`
+        would not compile.
+        """
+        import inspect
+
+        params = inspect.signature(build_run_label).parameters
+        assert params["running_bs"].default is inspect.Parameter.empty, (
+            "every step has a running_bs; making it optional invites a caller "
+            "to omit it and silently label a padded step as unpadded"
         )
-        assert lbl.startswith("decode[bs=64 ")
+        with pytest.raises(TypeError):
+            build_run_label(
+                is_prefill=False,
+                use_cudagraph=True,
+                is_dummy=False,
+                tbo_on=False,
+                scheduled_bs=64,
+                batch=decode_batch(64, d=64),
+            )
 
     def test_dummy_decode_padded(self):
         lbl = build_run_label(
@@ -230,21 +238,21 @@ class TestGraphBs:
             use_cudagraph=True,
             is_dummy=True,
             tbo_on=False,
-            bs=1,
-            graph_bs=8,
+            scheduled_bs=1,
+            running_bs=8,
             batch=decode_batch(1, d=1),
         )
         assert lbl.startswith("dummy_decode[bs=1/8 ")
 
     def test_graph_bs_ignored_on_eager_path(self):
-        # graph_bs only applies to the CUDAGraph path; eager decode ignores it.
+        # running_bs only applies to the CUDAGraph path; eager decode ignores it.
         lbl = build_run_label(
             is_prefill=False,
             use_cudagraph=False,
             is_dummy=False,
             tbo_on=False,
-            bs=300,
-            graph_bs=512,
+            scheduled_bs=300,
+            running_bs=512,
             batch=decode_batch(300, d=300),
         )
         assert lbl.startswith("eager_decode[bs=300 ")
@@ -260,8 +268,8 @@ class TestGraphBs:
             use_cudagraph=True,
             is_dummy=False,
             tbo_on=False,
-            bs=117,
-            graph_bs=128,
+            scheduled_bs=117,
+            running_bs=128,
             batch=decode_batch(117, d=117),
         )
         assert int(re.search(r"bs=(\d+)", lbl).group(1)) == 117

--- a/tests/test_v4_checkpoint_slot_copy.py
+++ b/tests/test_v4_checkpoint_slot_copy.py
@@ -9,10 +9,11 @@ those with the sliding-window rows that share the slot, turning the result into
 byte segments at a slot's real address, and round-tripping them through the
 copy planner.
 
-The builder is exercised through unbound methods on a stub rather than a real
-`DeepseekV4AttentionMetadataBuilder`, which would want a ModelRunner, a model
-and a GPU. What the stub supplies is exactly what these methods read, so the
-arithmetic under test is the shipped arithmetic.
+The stubs here SUBCLASS `DeepseekV4AttentionMetadataBuilder` and skip its
+construction, which would want a ModelRunner, a model and a GPU. They supply
+state, never behaviour, so the arithmetic under test is the shipped arithmetic
+and a method that grows a new dependency is picked up rather than silently
+stopping to stand for anything.
 """
 
 from __future__ import annotations
@@ -100,17 +101,16 @@ class _Geo:
         return list(ENTRY_ROW_RUNS)
 
 
-class _StubBuilder:
-    """Stands in for the parts of the builder these two methods touch."""
+class _StubBuilder(Builder):
+    """The real builder with the construction skipped, not a look-alike.
 
-    # The real methods, not copies of them: between them they read nothing the
-    # stub does not supply, and a reimplementation here would stop tracking the
-    # ones it stands in for.
-    _assert_ratios_divide_the_alignment = Builder._assert_ratios_divide_the_alignment
-    _checkpoint_slot_ranges = Builder._checkpoint_slot_ranges
-    _checkpoint_slot_bases = Builder._checkpoint_slot_bases
-    _checkpoint_segment_sizes = Builder._checkpoint_segment_sizes
-    checkpoint_image_bytes = Builder.checkpoint_image_bytes
+    Subclassed rather than given a list of borrowed methods: the list was the
+    fragile part -- `_page_unit_regions` grew a call to `_indexer_page_pools`
+    and six tests started erroring on a double that had silently stopped
+    standing for anything. Inheriting means a new dependency is picked up, and
+    only genuinely missing STATE fails, loudly. `__init__` deliberately does
+    not chain: the real one wants a ModelRunner, a model and a GPU.
+    """
 
     def __init__(self, plane: torch.Tensor, alignment: int = 256):
         self.pool_geometry = _Geo()
@@ -409,7 +409,7 @@ class TestTheBuilderDeclaresWhatItDrops:
 
     @staticmethod
     def builder_stub():
-        class _Stub:
+        class _Stub(Builder):
             _state_dtype = torch.float32
             csa_layers = (2, 4, 6)
             hca_layers = (3, 5)
@@ -426,10 +426,9 @@ class TestTheBuilderDeclaresWhatItDrops:
             _indexer_fp4 = False
             _field_window_dtype = torch.bfloat16
             _field_window_layers = (43,)
-            _window_field_row_bytes = Builder._window_field_row_bytes
-            _state_fields = Builder._state_fields
-            _geometry_ratios = Builder._geometry_ratios
-            state_transfer = Builder.state_transfer
+
+            def __init__(self):
+                pass  # the real one wants a ModelRunner, a model and a GPU
 
         return _Stub()
 
@@ -524,17 +523,16 @@ class TestPageUnitAddressesAreArithmetic:
         class _Geo:
             envelope_rows = self.ENVELOPE_ROWS
 
-        class _Stub:
-            _page_unit_regions = Builder._page_unit_regions
-            _page_unit_bases = Builder._page_unit_bases
-            _page_unit_stream_sizes = Builder._page_unit_stream_sizes
-            _kv_planes = Builder._kv_planes
+        class _Stub(Builder):
             model_runner = _Runner()
             pool_geometry = _Geo()
             csa_layers = tuple(range(self.N_CSA))
             _indexer_fp4 = False
             _page_unit_region_cache = None
             _page_unit_region_owners = ()
+
+            def __init__(self):
+                pass  # the real one wants a ModelRunner, a model and a GPU
 
             def _plane_row_widths(self):
                 return [16]

--- a/tools/analyze_trace_summary.py
+++ b/tools/analyze_trace_summary.py
@@ -49,7 +49,7 @@ def extract_labeled_events(events: list[dict]) -> list[StepEvent]:
         name = e.get("name", "")
         if e.get("ph") != "X":
             continue
-        if name.startswith(("prefill[", "decode[", "draft[")):
+        if name.startswith(("prefill[", "decode[", "propose_")):
             labeled.append(
                 StepEvent(
                     name=name,
@@ -84,7 +84,7 @@ def group_decode_iterations(events: list[StepEvent]) -> list[DecodeIteration]:
         if ev.name.startswith("decode["):
             current = DecodeIteration(decode=ev)
             iterations.append(current)
-        elif ev.name.startswith("draft[") and current is not None:
+        elif ev.name.startswith("propose_") and current is not None:
             current.draft_steps.append(ev)
 
     return iterations
@@ -116,9 +116,12 @@ def generate_report(events: list[StepEvent], filepath: str) -> str:
     decodes = [
         e for e in events if e.name.startswith("decode[") and e.cat == "user_annotation"
     ]
-    # draft[i/k bs=N] — each MTP speculative step
+    # propose_eagle[i/k tok=N bs=R/P] / propose_dspark[bs=R/P T=N] — one per
+    # draft pass, whichever drafter flavor produced it.
     draft_steps = [
-        e for e in events if e.name.startswith("draft[") and e.cat == "user_annotation"
+        e
+        for e in events
+        if e.name.startswith("propose_") and e.cat == "user_annotation"
     ]
 
     # --- Prefill Summary ---
@@ -157,7 +160,8 @@ def generate_report(events: list[StepEvent], filepath: str) -> str:
         # Group by step index
         step_durations: dict[str, list[float]] = defaultdict(list)
         for ev in draft_steps:
-            step_key = ev.name.split(" bs=")[0] + "]"  # e.g. "draft[0/3]"
+            # e.g. "propose_eagle[0/3]"; drop tok=/bs=, which vary per step.
+            step_key = ev.name.split(" tok=")[0].split(" bs=")[0] + "]"
             step_durations[step_key].append(ev.dur_us)
 
         lines.append("| Step | Calls | Mean | Min | Max | Δ vs step 0 |")


### PR DESCRIPTION
## What

aiter's flydsl builds one hgemm per tile config, in-process and chosen from the
row count, so a batch first seen mid-serve stalls that step — and every restart
pays it again. The draft never landed on the shapes the target had captured, so
it paid this on almost every distinct decode batch.

A drafter now **declares** its forwards as `DraftGraph`s. At the end of CUDAGraph
capture the runner runs each one once per `graph_bs`; at serve time a pass runs
at the batch the target just ran, which `ForwardMode.decide` picks out of that
same list — so "warmed" and "reachable" are one set by construction rather than
two that drift. `ATOM_DRAFT_CUDAGRAPH` (default on) also records each warmed
shape, so a pass replays instead of relaunching every kernel.

Three capabilities, each needing strictly more than the last: **warm** needs
nothing; **pad** needs staged inputs and a promise that fabricated rows are
inert; **capture** needs pad, since a graph is one shape. A flavor that cannot
answer one of them declares nothing rather than declaring a pass that claims to
be warmable and is not — Kimi-K3 drafts through a separate model, and MRoPE
keeps its token axis last, so neither declares.

## Measured

| Arm | GSM8K flexible | Acceptance | toks/fwd |
|---|---|---|---|
| V4-Flash-DSpark tp2, `--method dspark -n 5` | 0.9522 – 0.9553 | 65.07 – 65.41% | 4.25 – 4.27 |
| V4-Pro tp4, `--method mtp -n 3` (`EagleProposer`) | 0.9462 / 0.9545 | 66.14 / 66.25% | 2.98 / 2.99 |

Four DSpark runs and two eagle runs, each over 126k–150k draft tokens; every arm
sits on its pre-change baseline. On V4-Flash-DSpark tp4, putting the LM head
inside the recording took draft kernel launches 30 → 0 per pass and draft wall
time 915.8 → 118.9 µs; `hipModuleLoadData` per rank went 6 → 0 on the
16k/20/50c reproducer.

Startup cost is one log line: `Draft passes warmed at [1, 2, ..., 256] in 0.6s`.

## Correctness fixes carried along

- **`prepare_mtp_decode` is sized by rows, not by sequence count.** The row
  count is `positions.shape[-1]` — the LAST axis, because MRoPE keeps the token
  axis there and every other layout is one-dimensional, where the two agree.
  `bs` stays the real sequence count. All four backends and the base contract
  follow this.
- **DeepSeek-V4 marks its pad tail.** `batch_id_per_token` gets `-1` over the
  fabricated rows — the sentinel the verify forward already uses — so the index
  writer and `csa_translate_pack` skip them. At bs=65 padded to 128 that is half
  the batch.
- **A padded DSpark block no longer scatters KV through a live ring slot.**
  `prepare_decode` fills the padded tail of `state_slot_out` with `0`, and `0`
  is a real position (`physical_slot` is `slot_positions - 1 - group`, so it is
  the last group, which the pool hands out as concurrency approaches
  `max_num_seqs`). The fused SWA write gates on `bid >= 0`, so
  `DSparkIndexBuffers` now carries a `-1` tail.
- **Triton MLA and the MiniMax-M3 sparse path rebuild their derived decode
  metadata at the drafter's row count.** Neither did, which was invisible while
  the draft always ran at `scheduled_bs`.
- One arange over the batch axis, on `CommonAttentionBuilder`, replacing
  `Drafter.arrange_bs` and `DeepseekV4AttentionMetadataBuilder._v4_row_ids`.

## Trace labels

`propose_eagle[i/k tok= bs=<real>/<pad> (graph)]` and
`propose_dspark[bs=<real>/<pad> T= (graph)]`, both from one
`DraftGraph.label` — so "did the draft get into a graph" is a single grep across
flavors. `tools/analyze_trace_summary.py` follows the rename.

## Test plan

- [x] `bash .github/scripts/run_unit_tests.sh` — 4234 passed, 85 skipped. The 6
      failures in `tests/test_v4_checkpoint_slot_copy.py` reproduce on the merge
      base with none of these changes applied.
- [x] Every commit passes the suite standalone (bisect-safe).
- [x] `tests/test_draft_graph.py` — 18 cases with **no aiter and no GPU**, so CI
      actually runs them. `DraftGraph` was extracted from `drafter.py` for this:
      which batch a pass may run at, the tail-repeat, and the pad contract are
      pure torch.
- [x] `black` clean; `ruff` identical per file to the merge base.
- [x] GSM8K + acceptance on both drafter flavors, table above.
- [ ] **Not exercised on this box:** the Triton MLA and MiniMax-M3 sparse fixes
      (need `ATOM_FORCE_ATTN_TRITON=1` / M3 with an eagle3 draft), and anything
      under `data_parallel_size > 1`. Those are read from the source.

## Known and deliberately not addressed here

- Under DP the warm runs with `dp_uniform_decode` at its capture default, so a
  captured draft replays the uniform all-gather rather than the `all_gatherv`
  `_refresh_dp_metadata` selects. Every rank replays the same graph at the same
  batch, so the collective stays consistent; the variable-length path is simply
  dead for a captured draft.
- `DraftGraph._cuda_graphs` is invisible to `ModelRunner`'s graph reset and to
  the rollout sleep/wake release, so draft graphs keep pinning draft weights
  across a sleep.
- `capture_cudagraph` is skipped entirely under `--enforce-eager`, and it is the
  only caller of the warm — so the JIT saving is absent exactly where graphs
  cannot be used.
