### PR TITLE
fix(vllm): mark DP lockstep dummy batch as dummy run

### DIFF
--- a/atom/plugin/vllm/deepseek_v4_bridge.py
+++ b/atom/plugin/vllm/deepseek_v4_bridge.py
@@ -2087,6 +2087,7 @@ def atom_deepseek_v4_forward_context(
     slot_allocator=None,
     proxy_layer_name: str = ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME,
 ):
+    from atom.plugin.vllm.req_id_passthrough_patch import in_dp_lockstep_dummy_batch
     from atom.utils.forward_context import (
         Context,
         reset_forward_context,
@@ -2153,10 +2154,12 @@ def atom_deepseek_v4_forward_context(
         getattr(common_attn_metadata, "num_reqs", 0)
         or (input_ids.shape[0] if input_ids is not None else 0)
     )
+    _dp_lockstep_dummy = in_dp_lockstep_dummy_batch()
+
     context = Context(
         positions=positions,
         is_prefill=is_prefill,
-        is_dummy_run=force_dummy or common_attn_metadata is None,
+        is_dummy_run=force_dummy or common_attn_metadata is None or _dp_lockstep_dummy,
         scheduled_bs=batch_size,
         # The rows this forward really runs -- what MoE will be handed.
         scheduled_tokens=int(input_ids.shape[0]) if input_ids is not None else 0,

--- a/atom/plugin/vllm/req_id_passthrough_patch.py
+++ b/atom/plugin/vllm/req_id_passthrough_patch.py
@@ -96,9 +96,15 @@ def _wrap_execute_dummy_batch() -> bool:
     try:
         from vllm.v1.worker.gpu_worker import Worker
     except ImportError as e:
+        logger.debug(
+            "ATOM vLLM req_id passthrough patch: Worker unavailable (%s), skip",
+            e,
+        )
+        return False
+    except Exception as e:  # noqa: BLE001 - a broken vLLM must not abort registration
         logger.warning(
-            "ATOM plugin: cannot import vLLM Worker to mark DP dummy batches "
-            "(%s); DeepSeek-V4 state writes on an idle rank will not be skipped",
+            "ATOM plugin: importing vLLM Worker failed unexpectedly (%s); "
+            "DeepSeek-V4 state writes on an idle rank will not be skipped",
             e,
         )
         return False
@@ -130,7 +136,7 @@ def apply_vllm_req_id_passthrough_patch() -> bool:
         )
     try:
         from vllm.v1.worker.gpu_model_runner import GPUModelRunner
-    except ImportError as e:  # pragma: no cover - import guard
+    except Exception as e:  # noqa: BLE001  # pragma: no cover - import guard
         logger.debug(
             "ATOM vLLM req_id passthrough patch: GPUModelRunner unavailable (%s), "
             "skip",

--- a/atom/plugin/vllm/req_id_passthrough_patch.py
+++ b/atom/plugin/vllm/req_id_passthrough_patch.py
@@ -40,6 +40,11 @@ import threading
 logger = logging.getLogger("atom")
 
 _req_id_local = threading.local()
+_dp_dummy_local = threading.local()
+
+
+def in_dp_lockstep_dummy_batch() -> bool:
+    return bool(getattr(_dp_dummy_local, "active", False))
 
 
 def get_current_req_ids() -> list[str] | None:
@@ -87,16 +92,51 @@ def _wrap_with_req_id_snapshot(cls, method_name: str) -> bool:
     return True
 
 
+def _wrap_execute_dummy_batch() -> bool:
+    try:
+        from vllm.v1.worker.gpu_worker import Worker
+    except ImportError as e:
+        logger.warning(
+            "ATOM plugin: cannot import vLLM Worker to mark DP dummy batches "
+            "(%s); DeepSeek-V4 state writes on an idle rank will not be skipped",
+            e,
+        )
+        return False
+
+    original = getattr(Worker, "execute_dummy_batch", None)
+    if original is None or getattr(original, "_atom_dp_dummy_patched", False):
+        return False
+
+    @functools.wraps(original)
+    def wrapped(self, *args, **kwargs):
+        prev = getattr(_dp_dummy_local, "active", False)
+        _dp_dummy_local.active = True
+        try:
+            return original(self, *args, **kwargs)
+        finally:
+            _dp_dummy_local.active = prev
+
+    wrapped._atom_dp_dummy_patched = True
+    Worker.execute_dummy_batch = wrapped
+    return True
+
+
 def apply_vllm_req_id_passthrough_patch() -> bool:
+    patched_dp_dummy = _wrap_execute_dummy_batch()
+    if patched_dp_dummy:
+        logger.info(
+            "ATOM plugin: patched vLLM Worker.execute_dummy_batch to mark the DP "
+            "lockstep dummy batch (skips DeepSeek-V4 state writes on idle ranks)"
+        )
     try:
         from vllm.v1.worker.gpu_model_runner import GPUModelRunner
-    except Exception as e:  # pragma: no cover - import guard
+    except ImportError as e:  # pragma: no cover - import guard
         logger.debug(
             "ATOM vLLM req_id passthrough patch: GPUModelRunner unavailable (%s), "
             "skip",
             e,
         )
-        return False
+        return patched_dp_dummy
 
     # Target attention metadata build.
     patched_target = _wrap_with_req_id_snapshot(
@@ -118,4 +158,4 @@ def apply_vllm_req_id_passthrough_patch() -> bool:
             patched_target,
             patched_draft,
         )
-    return patched_target or patched_draft
+    return patched_target or patched_draft or patched_dp_dummy


### PR DESCRIPTION
**fix(vllm): mark DP lockstep dummy batch as dummy run**

With data parallelism, idle ranks run Worker.execute_dummy_batch to stay
in lockstep with busy ranks. That forward carries no requests, but ATOM
was building Context with is_dummy_run=False on those steps.

This surfaces when the V2 runner is active. Not all speculative decoding
forces V2 -- DSpark does. Without V2, DP8 works because
common_attn_metadata is None on the dummy batch, so is_dummy_run is True.
Under V2, real attention metadata is built even for dummy batches, so that
fallback is false; force_dummy is also false once the proxy cache binds at
startup. Idle ranks then run the real DeepSeek-V4 decode path -- swa_write,
Compressor, Indexer -- against arange slots that belong to live requests on
other ranks, causing illegal memory access under DP8 + DSpark.

Patch Worker.execute_dummy_batch to expose in_dp_lockstep_dummy_batch()
and OR it into is_dummy_run in the V4 bridge. Unlike empty req_ids or
cudagraph flags, this keys on the one caller that means exactly this and
nothing else.