### PR TITLE
(feat)[ATOM] enable persistent sparse MLA DCP for GLM-5.2

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -67,6 +67,11 @@ from atom.utils.forward_context import (
     get_forward_context,
 )
 
+# Cap on the KV-split budget: aiter cuts the KV walk into
+# `min(num_clusters, cap * batch_size)` parts, and a negative cap means uncapped
+# -- as many parts as the machine has clusters (v1_2_device.cuh:894).
+_MLA_SPLIT_BUDGET_AUTO = -1
+
 
 def _sparse_index_workspace(
     out: torch.Tensor | None,
@@ -1744,7 +1749,7 @@ class MLAAttention(nn.Module):
             max_seqlen_qo=1,
             uni_seqlen_qo=1,
             fast_mode=1,
-            max_split_per_batch=16,
+            max_split_per_batch=_MLA_SPLIT_BUDGET_AUTO,
         )
 
     def _forward_decode(
@@ -1884,9 +1889,7 @@ class MLAAttention(nn.Module):
             # (max_seqlen_qo=2).
             is_sparse_mtp = self.is_sparse_mla and attn_metadata.max_seqlen_q > 1
 
-            if self._should_rebuild_sparse_dcp_persistent_metadata(
-                use_persistent_mode
-            ):
+            if self._should_rebuild_sparse_dcp_persistent_metadata(use_persistent_mode):
                 self._rebuild_sparse_dcp_persistent_metadata(
                     attn_metadata,
                     q,

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -16,6 +16,7 @@ from aiter import (
     flash_attn_varlen_func,
     fused_qk_rope_concat_and_cache_mla,
     get_hip_quant,
+    get_mla_metadata_v1,
 )
 
 # The segmented (page_size>1) MLA cache kernels only exist in newer aiter
@@ -179,25 +180,30 @@ _dcp_kernel_width_warned = False
 
 
 def mla_dcp_decode_is_persistent(
-    is_sparse: bool, dcp_world_size: int, dcp_persistent_supported: bool
+    is_sparse: bool,
+    dcp_world_size: int,
+    dcp_persistent_supported: bool,
+    *,
+    sparse_metadata_rebuild: bool = False,
 ) -> bool:
     """Whether a DCP decode will reach ``mla_decode_fwd`` in persistent mode.
 
     The live decision is made per step in ``_forward_decode``; this mirrors the
     parts of it that are already settled at construction time, because the
     gathered head width has to be fixed there (it sizes the persistent work
-    descriptors as well as the kernel's nhead). Sparse MLA under DCP is forced
-    non-persistent (its sparse region length varies per layer, which metadata
-    built once per step cannot describe), only gfx950 ships the lse-emitting
-    persistent kernel DCP needs, and persistent mode wants page_size 1. The one
-    remaining runtime gate, ``dpa_persistent_supported``, is unconditionally
-    true, so nothing here can claim persistent mode that the step then refuses.
+    descriptors as well as the kernel's nhead). Sparse MLA under DCP is
+    persistent only when the caller rebuilds work/reduce metadata after each
+    full indexer layer compacts its rank-local top-k. Only gfx950 ships the
+    lse-emitting persistent kernel DCP needs, and persistent mode wants page
+    size 1. The one remaining runtime gate, ``dpa_persistent_supported``, is
+    unconditionally true, so nothing here can claim persistent mode that the
+    step then refuses.
 
     ``dcp_persistent_supported`` is taken as an argument rather than queried
     here, the way ``should_use_persistent_mode`` takes it: callers already cache
     it to keep ``get_gfx()`` off the per-forward path.
     """
-    if dcp_world_size <= 1 or is_sparse:
+    if dcp_world_size <= 1 or (is_sparse and not sparse_metadata_rebuild):
         return False
     return dcp_persistent_supported and envs.ATOM_MLA_PAGE_SIZE <= 1
 
@@ -477,6 +483,10 @@ class MLAAttention(nn.Module):
         # (`mla_modules.is_sparse` defaults False, so non-sparse models and the
         # `indexer is not None` fallback keep their previous behavior.)
         self.is_sparse_mla = mla_modules.is_sparse or (mla_modules.indexer is not None)
+        # A full IndexShare layer owns an indexer and therefore produces a new
+        # layer-local DCP compact indptr. Shared layers reuse both its indices
+        # and the persistent work plan rebuilt from that indptr.
+        self.owns_sparse_indexer = mla_modules.indexer is not None
         self.topk_tokens = (
             mla_modules.indexer.topk_tokens
             if mla_modules.indexer is not None
@@ -593,6 +603,14 @@ class MLAAttention(nn.Module):
 
         self.dcp_persistent_supported = dcp_persistent_supported()
         self.dcp_prefill_merge_bf16_ok = dcp_prefill_merge_bf16_ok()
+        # Scope sparse persistent DCP to native non-speculative attention.
+        # Decode is q_len=1; sparse prefill is represented as per-token virtual
+        # q_len=1 rows. Plugin DCP reconfigures its group after construction.
+        self.sparse_dcp_metadata_rebuild = (
+            self.is_sparse_mla
+            and self.dcp_world_size > 1
+            and getattr(atom_config, "speculative_config", None) is None
+        )
 
         # Compacted per-layer sparse offsets for DCP decode; rebound by the
         # metadata builder to the shared buffer (see aiter_mla.py).
@@ -600,6 +618,18 @@ class MLAAttention(nn.Module):
         self.dcp_owned_counts_buffer = None
 
         self._configure_dcp_decode_head_padding(self.dcp_world_size)
+        if (
+            self.sparse_dcp_metadata_rebuild
+            and self.dcp_persistent_supported
+            and envs.ATOM_MLA_PAGE_SIZE <= 1
+            and not getattr(MLAAttention, "_sparse_dcp_persistent_logged", False)
+        ):
+            MLAAttention._sparse_dcp_persistent_logged = True
+            logger.info(
+                "Sparse DCP persistent attention enabled: rebuilding metadata "
+                "after each full indexer layer (kernel heads=%d).",
+                self.dcp_kernel_num_heads,
+            )
 
     def _configure_dcp_decode_head_padding(self, dcp_world_size: int) -> None:
         """Configure the kernel width used after DCP gathers query heads.
@@ -624,6 +654,9 @@ class MLAAttention(nn.Module):
                     self.is_sparse_mla,
                     dcp_world_size,
                     self.dcp_persistent_supported,
+                    sparse_metadata_rebuild=getattr(
+                        self, "sparse_dcp_metadata_rebuild", False
+                    ),
                 ),
             )
             self.dcp_head_pad = (
@@ -1460,7 +1493,11 @@ class MLAAttention(nn.Module):
         B = q.shape[0]
         num_heads_q = q.shape[1]
 
-        q = self._pad_query_heads(q)
+        q = (
+            self._pad_decode_query_heads(q)
+            if self.is_sparse_mla and self.dcp_world_size > 1
+            else self._pad_query_heads(q)
+        )
 
         # In the seg path q arrives with a padded per-head row stride
         # (_MLA_Q_OUT_PADDED_DIM); slice back to the logical
@@ -1511,10 +1548,27 @@ class MLAAttention(nn.Module):
             use_decode_kernel = self.kv_cache_dtype.startswith("fp8") or return_lse
             if use_decode_kernel:
                 is_fp8 = self.kv_cache_dtype.startswith("fp8")
-                # DCP compacts each rank's candidates per layer, so the once-per-step
-                # persistent work metadata (built from the GLOBAL sparse_kv_indptr)
-                # does not describe this rank's regions -- run non-persistent.
-                use_work_meta = is_fp8 and self.dcp_world_size <= 1
+                sparse_dcp_persistent = (
+                    is_fp8
+                    and self.is_sparse_mla
+                    and self.dcp_world_size > 1
+                    and self.sparse_dcp_metadata_rebuild
+                    and self.dcp_persistent_supported
+                    and page_size <= 1
+                )
+                if sparse_dcp_persistent and self.owns_sparse_indexer:
+                    self._rebuild_sparse_dcp_persistent_metadata(
+                        attn_metadata,
+                        q,
+                        kv_c_and_k_pe_cache,
+                        paged_cu_seqlens_q,
+                        paged_kv_indptr,
+                        kv_last_page_lens,
+                        work_prefix="sparse_prefill_",
+                    )
+                use_work_meta = is_fp8 and (
+                    self.dcp_world_size <= 1 or sparse_dcp_persistent
+                )
                 _, final_lse = mla_decode_fwd(
                     q,
                     kv_c_and_k_pe_cache.view(-1, page_size, 1, q.shape[-1]),
@@ -1578,9 +1632,14 @@ class MLAAttention(nn.Module):
                     None,
                 )
 
-        o = self._restore_query_heads(o, num_heads_q)
+        restore_heads = (
+            self._restore_decode_query_heads
+            if self.is_sparse_mla and self.dcp_world_size > 1
+            else self._restore_query_heads
+        )
+        o = restore_heads(o, num_heads_q)
         if final_lse is not None:
-            final_lse = self._restore_query_heads(final_lse, num_heads_q)
+            final_lse = restore_heads(final_lse, num_heads_q)
 
         if return_lse:
             assert final_lse is not None, (
@@ -1615,6 +1674,64 @@ class MLAAttention(nn.Module):
         num_blocks = num_token_slots // block_size
         # [num_token_slots, 1, d] -> [num_blocks, block_size, d] -> [.., 1, ..]
         return kv_cache.view(num_blocks, block_size, d).unsqueeze(1)
+
+    def _should_rebuild_sparse_dcp_persistent_metadata(
+        self, use_persistent_mode: bool
+    ) -> bool:
+        return (
+            use_persistent_mode
+            and self.is_sparse_mla
+            and self.dcp_world_size > 1
+            and self.owns_sparse_indexer
+        )
+
+    def _rebuild_sparse_dcp_persistent_metadata(
+        self,
+        attn_metadata: AttentionMetaData,
+        q: torch.Tensor,
+        kv_buffer: torch.Tensor,
+        paged_cu_seqlens_q: torch.Tensor,
+        paged_kv_indptr: torch.Tensor,
+        paged_kv_last_page_lens: torch.Tensor,
+        work_prefix: str = "",
+    ) -> None:
+        """Rebuild persistent work/reduce metadata from this layer's DCP top-k.
+
+        A full GLM IndexShare layer rewrites ``dcp_sparse_kv_indptr_buffer``
+        after selecting and compacting the rank-owned top-k. Persistent work
+        descriptors embed those region boundaries, so they must be rebuilt
+        after that mutation rather than once per decode step from the global
+        sparse indptr. Shared IndexShare layers reuse the preceding full layer's
+        indices, compact indptr, and work plan and therefore skip this call.
+        """
+        if not work_prefix:
+            assert attn_metadata.max_seqlen_q == 1, (
+                "Sparse DCP persistent decode metadata rebuild currently "
+                "supports non-speculative q_len=1 only."
+            )
+        assert q.shape[1] == self.dcp_kernel_num_heads
+        get_mla_metadata_v1(
+            paged_cu_seqlens_q,
+            paged_kv_indptr,
+            paged_kv_last_page_lens,
+            self.dcp_kernel_num_heads,
+            1,  # nhead_kv
+            True,
+            getattr(attn_metadata, f"{work_prefix}work_meta_data"),
+            getattr(attn_metadata, f"{work_prefix}work_info_set"),
+            getattr(attn_metadata, f"{work_prefix}work_indptr"),
+            getattr(attn_metadata, f"{work_prefix}reduce_indptr"),
+            getattr(attn_metadata, f"{work_prefix}reduce_final_map"),
+            getattr(attn_metadata, f"{work_prefix}reduce_partial_map"),
+            page_size=1,
+            dtype_q=q.dtype,
+            dtype_kv=kv_buffer.dtype,
+            kv_granularity=16,
+            max_seqlen_qo=1,
+            uni_seqlen_qo=1,
+            fast_mode=1,
+            max_split_per_batch=16,
+        )
 
     def _forward_decode(
         self,
@@ -1724,11 +1841,12 @@ class MLAAttention(nn.Module):
                     # all-1s sparse buffer, NOT the dense per-block
                     # kv_last_page_lens (which makes the asm kernel over-read
                     # past the written sparse-index region -> illegal access).
-                    paged_kv_indptr = attn_metadata.sparse_kv_indptr
+                    paged_cu_seqlens_q = attn_metadata.cu_seqlens_q[: B + 1]
+                    paged_kv_indptr = attn_metadata.sparse_kv_indptr[: B + 1]
                     paged_kv_indices = self.sparse_kv_indices_buffer
-                    paged_kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens
+                    paged_kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens[:B]
                     if self.dcp_world_size > 1:
-                        paged_kv_indptr = self.dcp_sparse_kv_indptr_buffer
+                        paged_kv_indptr = self.dcp_sparse_kv_indptr_buffer[: B + 1]
 
             dp_size = get_dp_group().world_size
             use_persistent_mode = should_use_persistent_mode(
@@ -1738,20 +1856,31 @@ class MLAAttention(nn.Module):
                 dcp_world_size=self.dcp_world_size,
                 dcp_persistent_supported=self.dcp_persistent_supported,
             )
-            # sparse + DCP compacts the per-rank top-k, which makes the sparse
-            # region length depend on the *per-layer* selection. The persistent
-            # work/reduce metadata is built once per step from sparse_kv_indptr
-            # (aiter_mla.set_mla_persistent_worker_buffers), so it cannot describe
-            # a length that changes layer to layer -- the timing simply does not
-            # line up. Run non-persistent until either the metadata build moves
-            # per-layer or aiter grows a per-request valid length.
+            # Sparse DCP persistent decode is enabled only for ordinary q_len=1
+            # native serving. Its full IndexShare layers rebuild the work plan
+            # below from the layer-local compact indptr; plugin/speculative paths
+            # retain the established non-persistent fallback.
             if self.is_sparse_mla and self.dcp_world_size > 1:
-                use_persistent_mode = False
+                use_persistent_mode = (
+                    use_persistent_mode and self.sparse_dcp_metadata_rebuild
+                )
 
             # Sparse layers in MTP verify use separate persistent metadata
             # (per-token, max_seqlen_qo=1) while dense layers use normal metadata
             # (max_seqlen_qo=2).
             is_sparse_mtp = self.is_sparse_mla and attn_metadata.max_seqlen_q > 1
+
+            if self._should_rebuild_sparse_dcp_persistent_metadata(
+                use_persistent_mode
+            ):
+                self._rebuild_sparse_dcp_persistent_metadata(
+                    attn_metadata,
+                    q,
+                    kv_buffer,
+                    paged_cu_seqlens_q,
+                    paged_kv_indptr,
+                    paged_kv_last_page_lens,
+                )
 
             if not use_persistent_mode:
                 work_meta_data = None

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -867,7 +867,17 @@ class MLAAttention(nn.Module):
         if not use_qrep:
             q_out = dcp_all_gather_query_heads(self.dcp_group, q_out)
         o, lse = self._forward_decode(q_out, kv_cache, attn_metadata, return_lse=True)
-        return self._dcp_project_merge_out(o, lse, ctx=self._cp_triton_ctx)
+        owned_counts = (
+            self.dcp_owned_counts_buffer[: q_out.shape[0]]
+            if self.is_sparse_mla and self.dcp_owned_counts_buffer is not None
+            else None
+        )
+        return self._dcp_project_merge_out(
+            o,
+            lse,
+            ctx=self._cp_triton_ctx,
+            owned_counts=owned_counts,
+        )
 
     def _v_up_proj(self, x, W_V=None, W_V_scale=None, num_heads=None):
         """V up-projection only: ``[B, N, kv_lora_rank] -> [B, N, v_head_dim]``.

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -790,14 +790,23 @@ class MLAAttention(nn.Module):
             self._qrep_local_src = w
         return self._qrep_local_proj
 
-    def _dcp_merge(self, o, lse, ctx=None):
+    def _dcp_merge(self, o, lse, ctx=None, owned_counts=None):
         """Bind this layer's DCP group and backend to ``dcp_ops.dcp_lse_merge``."""
         from atom.model_ops.dcp_ops import dcp_lse_merge
 
-        return dcp_lse_merge(o, lse, self.dcp_group, self.dcp_comm_backend, ctx=ctx)
+        return dcp_lse_merge(
+            o,
+            lse,
+            self.dcp_group,
+            self.dcp_comm_backend,
+            ctx=ctx,
+            owned_counts=owned_counts,
+        )
 
     @mark_trace(prefix="dcp_project_merge_out", torch_compile=False)
-    def _dcp_project_merge_out(self, o, lse, ctx=None, merge_in_fp32=False):
+    def _dcp_project_merge_out(
+        self, o, lse, ctx=None, merge_in_fp32=False, owned_counts=None
+    ):
         """Shared tail of both DCP paths: PBM projection, merge, o_proj.
 
         With PBM the V up-projection runs on the whole group's head set BEFORE
@@ -810,9 +819,11 @@ class MLAAttention(nn.Module):
             )
         if merge_in_fp32:
             dtype = o.dtype
-            o = self._dcp_merge(o.float(), lse, ctx=ctx).to(dtype)
+            o = self._dcp_merge(o.float(), lse, ctx=ctx, owned_counts=owned_counts).to(
+                dtype
+            )
         else:
-            o = self._dcp_merge(o, lse, ctx=ctx)
+            o = self._dcp_merge(o, lse, ctx=ctx, owned_counts=owned_counts)
         if self.pbm_enabled:
             return self.o_proj(o.reshape(-1, self.num_heads * self.v_head_dim))
         return self._v_up_proj_and_o_proj(o)
@@ -831,7 +842,10 @@ class MLAAttention(nn.Module):
             q_out, kv_cache, attn_metadata, return_lse=True
         )
         return self._dcp_project_merge_out(
-            o, lse, merge_in_fp32=not self.dcp_prefill_merge_bf16_ok
+            o,
+            lse,
+            merge_in_fp32=not self.dcp_prefill_merge_bf16_ok,
+            owned_counts=self.dcp_owned_counts_buffer[: q_out.shape[0]],
         )
 
     @mark_trace(prefix="dcp_decode", torch_compile=False)

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -262,13 +262,23 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # kernel and stays non-persistent, where this metadata is unused); scale
         # by dcp only there so gfx942 keeps the original per-rank head sizing.
         dcp_persistent = dcp_persistent_supported()
+        self.sparse_dcp_metadata_rebuild = (
+            self.is_sparse
+            and self.dcp_world_size > 1
+            and dcp_persistent
+            and self.block_size == 1
+            and config.speculative_config is None
+        )
         if self.dcp_world_size > 1 and dcp_persistent:
             self.persistent_num_heads = mla_dcp_kernel_num_heads(
                 self.num_attention_heads,
                 self.dcp_world_size,
                 kv_cache_dtype=config.kv_cache_dtype,
                 persistent=mla_dcp_decode_is_persistent(
-                    self.is_sparse, self.dcp_world_size, dcp_persistent
+                    self.is_sparse,
+                    self.dcp_world_size,
+                    dcp_persistent,
+                    sparse_metadata_rebuild=self.sparse_dcp_metadata_rebuild,
                 ),
             )
         else:
@@ -371,6 +381,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 dtype=torch.int32,
                 device=self.device,
             )
+            sparse_prefill_num_heads = (
+                self.persistent_num_heads
+                if self.sparse_dcp_metadata_rebuild
+                else self.padded_num_attention_heads
+            )
             (
                 (spp_wmd_size, spp_wmd_type),
                 (spp_wi_size, spp_wi_type),
@@ -381,7 +396,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             ) = get_mla_metadata_info_v1(
                 self.max_num_batched_tokens,
                 1,  # sparse prefill treats each query token as q_len=1
-                self.padded_num_attention_heads,
+                sparse_prefill_num_heads,
                 self.dtype_q,
                 self.dtype_kv,
                 is_sparse=True,

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -30,6 +30,7 @@ from atom.distributed.pcp_utils import (
 from atom.model_engine.scheduler import ScheduledBatch
 from atom.model_ops.attention_mla import (
     _MLA_MIN_HEADS,
+    _MLA_SPLIT_BUDGET_AUTO,
     MLAAttention,
     mla_dcp_decode_is_persistent,
     mla_dcp_kernel_num_heads,
@@ -55,11 +56,6 @@ try:
     )
 except (TypeError, ValueError):
     _MLA_META_SUPPORTS_MAX_SPLIT = False
-
-# Cap on the KV-split budget: aiter cuts the KV walk into
-# `min(num_clusters, cap * batch_size)` parts, and a negative cap means uncapped
-# -- as many parts as the machine has clusters (v1_2_device.cuh:894).
-_MLA_SPLIT_BUDGET_AUTO = -1
 
 
 def _mla_seg_meta_kwargs() -> dict:

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -292,6 +292,7 @@ def _lse_pack_slots(dtype: torch.dtype) -> int:
 def _dcp_a2a_pack_kernel(
     out_ptr,  # [B, H, D]      this rank's partial attention output
     lse_ptr,  # [B, H]         fp32
+    owned_counts_ptr,  # [B]   true rank-local sparse counts, or unused
     send_ptr,  # [N, B, H_LOCAL, D + LSE_PACK]
     out_stride_b,
     out_stride_h,
@@ -303,6 +304,7 @@ def _dcp_a2a_pack_kernel(
     H_LOCAL: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     LSE_PACK: tl.constexpr,
+    HAS_OWNED_COUNTS: tl.constexpr,
 ):
     """Scatter (output, lse) into the per-destination send buffer.
 
@@ -325,6 +327,11 @@ def _dcp_a2a_pack_kernel(
     tl.store(dst_base + d, src)
 
     lse = tl.load(lse_ptr + b * lse_stride_b + h * lse_stride_h)
+    if HAS_OWNED_COUNTS:
+        # Empty sparse-DCP rows carry one dummy KV slot so persistent metadata
+        # remains valid. Neutralize that slot while packing the existing A2A
+        # payload; this adds no kernel launch to the decode path.
+        lse = tl.where(tl.load(owned_counts_ptr + b) == 0, float("-inf"), lse)
     if LSE_PACK == 1:
         tl.store(dst_base + HEAD_DIM, lse)
     else:
@@ -422,7 +429,13 @@ def _dcp_a2a_unpack_combine_kernel(
     )
 
 
-def cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group, return_lse: bool = False):
+def cp_lse_a2a(
+    cp_attn_out,
+    cp_attn_lse,
+    cp_group,
+    return_lse: bool = False,
+    owned_counts=None,
+):
     """A2A backend: pack -> one all-to-all -> local LSE combine.
 
     Drop-in for ``cp_lse_ag_out_rs``: same inputs, same ``[B, H_local, D]``
@@ -433,6 +446,8 @@ def cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group, return_lse: bool = False):
         cp_attn_lse: ``[B, H]`` matching log-sum-exp, fp32.
         cp_group: DCP GroupCoordinator.
         return_lse: also return the merged ``[B, H_local]`` global LSE.
+        owned_counts: optional true rank-local sparse-KV count per row. Empty
+            rows are masked inside the existing A2A pack kernel.
     """
     n_ranks = cp_group.world_size
     if n_ranks == 1:
@@ -451,11 +466,20 @@ def cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group, return_lse: bool = False):
 
     cp_attn_out = cp_attn_out.contiguous()
     cp_attn_lse = cp_attn_lse.contiguous().to(torch.float32)
+    has_owned_counts = owned_counts is not None
+    if has_owned_counts:
+        owned_counts = owned_counts.contiguous()
+        assert owned_counts.numel() >= b
+    else:
+        # HAS_OWNED_COUNTS removes the load at compile time; use an existing
+        # device pointer so no placeholder tensor or allocation is introduced.
+        owned_counts = cp_attn_lse
 
     send = torch.empty((n_ranks, b, h_local, head_dim + pack), dtype=dtype, device=dev)
     _dcp_a2a_pack_kernel[(b, h_total)](
         cp_attn_out,
         cp_attn_lse,
+        owned_counts,
         send,
         cp_attn_out.stride(0),
         cp_attn_out.stride(1),
@@ -467,6 +491,7 @@ def cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group, return_lse: bool = False):
         H_LOCAL=h_local,
         HEAD_DIM=head_dim,
         LSE_PACK=pack,
+        HAS_OWNED_COUNTS=has_owned_counts,
     )
 
     # The N axis flips meaning here: it is "destination rank" on the way in and
@@ -531,10 +556,17 @@ def dcp_lse_merge(
     ``ctx`` is the Triton context the AG+RS backend caches its launches in; the
     a2a backend does not use one.
     """
-    if owned_counts is not None:
-        cp_attn_lse = mask_empty_dcp_lse(cp_attn_lse, owned_counts)
     if backend == "a2a":
-        return cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group)
+        return cp_lse_a2a(
+            cp_attn_out,
+            cp_attn_lse,
+            cp_group,
+            owned_counts=owned_counts,
+        )
+    if owned_counts is not None:
+        # AG+RS has no existing kernel before its LSE AllGather. The default
+        # A2A path above fuses this mask and remains launch-free.
+        cp_attn_lse = mask_empty_dcp_lse(cp_attn_lse, owned_counts)
     return cp_lse_ag_out_rs(cp_attn_out, cp_attn_lse, cp_group, ctx=ctx)
 
 
@@ -768,6 +800,7 @@ def _count_owned_dcp_kernel(
     global_kv_indptr,  # int32 [num_requests + 1] -- GLOBAL context (column range)
     token_indices_ptr,  # int32 [num_tokens, NUM_TOPK_TOKENS] -- GLOBAL top-k positions
     out_counts,  # int32 [num_requests] -- owned top-k count per request
+    out_metadata_counts,  # int32 [num_requests] -- max(out_counts, 1)
     DCP_RANK: tl.constexpr,
     DCP_WORLD: tl.constexpr,
     INTERLEAVE: tl.constexpr,  # cp_kv_cache_interleave_size S (1 = round-robin)
@@ -797,6 +830,7 @@ def _count_owned_dcp_kernel(
         count += tl.sum(owned.to(tl.int32))
 
     tl.store(out_counts + batch_id, count)
+    tl.store(out_metadata_counts + batch_id, tl.maximum(count, 1))
 
 
 @triton.jit
@@ -880,6 +914,11 @@ def _compact_filter_dcp_kernel(
         tl.store(out_kv_indices + out_kv_start + dst, slot, mask=idx_valid)
         written += tl.sum(owned_i32)
 
+    # Keep persistent fast-mode metadata valid for a rank that owns no selected
+    # KV. The A2A pack kernel neutralizes this dummy row's LSE without adding a
+    # separate pointwise launch.
+    tl.store(out_kv_indices + out_kv_start, 0, mask=written == 0)
+
 
 def triton_filter_and_convert_dcp_index(
     qo_indptr: torch.Tensor,  # int32 [num_requests + 1]
@@ -912,9 +951,9 @@ def triton_filter_and_convert_dcp_index(
     rewritten to the resulting per-request lengths. This replaces the earlier
     "fixed length + -1 sentinel" layout, whose holes broke aiter's lse output.
     Because the kept count depends on the per-layer top-k selection,
-    ``out_kv_indptr`` is layer-dependent and must be recomputed on every call --
-    it cannot feed the once-per-step persistent metadata, which is why sparse+DCP
-    runs non-persistent for now.
+    ``out_kv_indptr`` is layer-dependent. Sparse+DCP persistent mode therefore
+    rebuilds its work metadata after each full IndexShare layer and reuses that
+    plan in the following shared layers.
 
     The 8 ranks' kept sets are disjoint and their union is exactly the global
     top-k, which is what makes the downstream ``cp_lse_ag_out_rs`` merge valid.
@@ -941,11 +980,13 @@ def triton_filter_and_convert_dcp_index(
 
     # Pass 1: per-request count of owned top-k positions.
     counts = owned_counts[:num_batch]
+    metadata_counts = out_kv_indptr[1 : num_batch + 1]
     _count_owned_dcp_kernel[grid](
         qo_indptr_c,
         global_kv_indptr_c,
         token_indices_c,
         counts,
+        metadata_counts,
         dcp_rank,
         dcp_world_size,
         cp_kv_cache_interleave_size,
@@ -963,7 +1004,12 @@ def triton_filter_and_convert_dcp_index(
     # through a host->device copy, which HIP rejects while a graph is capturing
     # (hipErrorStreamCaptureUnsupported). Everything here must stay device-side.
     out_kv_indptr[:1].zero_()
-    torch.cumsum(counts, dim=0, dtype=torch.int32, out=out_kv_indptr[1 : num_batch + 1])
+    torch.cumsum(
+        metadata_counts,
+        dim=0,
+        dtype=torch.int32,
+        out=metadata_counts,
+    )
 
     # Pass 2: write the owned slots packed to the front of each region.
     _compact_filter_dcp_kernel[grid](
@@ -994,6 +1040,7 @@ def _count_owned_dcp_prefill_kernel(
     topk_indices,  # int32 [num_tokens, NUM_TOPK_TOKENS] -- FLAT KV indices
     cu_seqlens_k,  # int32 [num_req + 1] -- per-seq base of the flat KV axis
     out_counts,  # int32 [num_tokens]
+    out_metadata_counts,  # int32 [num_tokens], max(out_counts, 1)
     DCP_RANK: tl.constexpr,
     DCP_WORLD: tl.constexpr,
     INTERLEAVE: tl.constexpr,  # cp_kv_cache_interleave_size S (1 = round-robin)
@@ -1031,6 +1078,7 @@ def _count_owned_dcp_prefill_kernel(
         count += tl.sum(owned.to(tl.int32))
 
     tl.store(out_counts + token_id, count)
+    tl.store(out_metadata_counts + token_id, tl.maximum(count, 1))
 
 
 @triton.jit
@@ -1163,12 +1211,14 @@ def triton_filter_and_convert_dcp_index_prefill(
     grid = (num_tokens,)
 
     counts = owned_counts[:num_tokens]
+    metadata_counts = out_kv_indptr[1 : num_tokens + 1]
     _count_owned_dcp_prefill_kernel[grid](
         dsa_kv_indptr_c,
         token_to_seq_idxs_c,
         topk_indices_c,
         cu_seqlens_k_c,
         counts,
+        metadata_counts,
         dcp_rank,
         dcp_world_size,
         cp_kv_cache_interleave_size,
@@ -1178,16 +1228,15 @@ def triton_filter_and_convert_dcp_index_prefill(
         ti_stride1,
     )
 
-    # Keep the true counts in `owned_counts` for post-attention neutralization,
-    # but give every metadata row at least one valid slot. Persistent MLA's fast
-    # metadata path can corrupt work descriptors after a zero-length row.
-    metadata_counts = counts.clamp_min(1)
+    # The count kernel already wrote max(count, 1) into the destination tail,
+    # so this per-full-layer path needs neither an allocation nor another
+    # pointwise operator. Exact input/output overlap is supported by cumsum.
     out_kv_indptr[:1].zero_()
     torch.cumsum(
         metadata_counts,
         dim=0,
         dtype=torch.int32,
-        out=out_kv_indptr[1 : num_tokens + 1],
+        out=metadata_counts,
     )
 
     _compact_filter_dcp_prefill_kernel[grid](

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -134,8 +134,7 @@ def _correct_attn_cp_out_kernel(
 
     lse = tl.load(lses_ptr + lse_offsets)
     lse = tl.where(
-        (lse != lse)  # noqa: PLR0124 - Triton NaN check
-        | (lse == float("inf")),
+        (lse != lse) | (lse == float("inf")),  # noqa: PLR0124 - Triton NaN check
         -float("inf"),
         lse,
     )

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -133,7 +133,12 @@ def _correct_attn_cp_out_kernel(
     )
 
     lse = tl.load(lses_ptr + lse_offsets)
-    lse = tl.where((lse != lse) | (lse == float("inf")), -float("inf"), lse)
+    lse = tl.where(
+        (lse != lse)  # noqa: PLR0124 - Triton NaN check
+        | (lse == float("inf")),
+        -float("inf"),
+        lse,
+    )
 
     lse_max = tl.max(lse, axis=0)
     lse_max = tl.where(lse_max == -float("inf"), 0, lse_max)
@@ -151,7 +156,8 @@ def _correct_attn_cp_out_kernel(
     local_lse = tl.load(lses_ptr + local_lse_offset)
     lse_diff = local_lse - global_lse
     lse_diff = tl.where(
-        (lse_diff != lse_diff) | (lse_diff == float("inf")),
+        (lse_diff != lse_diff)  # noqa: PLR0124 - Triton NaN check
+        | (lse_diff == float("inf")),
         -float("inf"),
         lse_diff,
     )
@@ -495,7 +501,21 @@ def cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group, return_lse: bool = False):
     return (out, out_lse) if return_lse else out
 
 
-def dcp_lse_merge(cp_attn_out, cp_attn_lse, cp_group, backend="a2a", ctx=None):
+def mask_empty_dcp_lse(
+    cp_attn_lse: torch.Tensor, owned_counts: torch.Tensor
+) -> torch.Tensor:
+    """Mark dummy-backed local rows as absent before the DCP softmax merge."""
+    return cp_attn_lse.masked_fill(owned_counts[:, None] == 0, float("-inf"))
+
+
+def dcp_lse_merge(
+    cp_attn_out,
+    cp_attn_lse,
+    cp_group,
+    backend="a2a",
+    ctx=None,
+    owned_counts=None,
+):
     """Reconstruct the global softmax from the per-rank partials.
 
     Dispatches to one of the two backends above. Both compute the same weighted
@@ -504,9 +524,16 @@ def dcp_lse_merge(cp_attn_out, cp_attn_lse, cp_group, backend="a2a", ctx=None):
     why one all-to-all can replace AllGather-LSE + ReduceScatter). Equivalent
     math, not bitwise identical.
 
+    ``owned_counts`` is the optional rank-local sparse-KV count per row. Empty
+    prefill rows contain a dummy cache slot to keep persistent metadata valid;
+    masking only their small LSE tensor here lets the existing merge kernels
+    suppress the corresponding output without another full-output pass.
+
     ``ctx`` is the Triton context the AG+RS backend caches its launches in; the
     a2a backend does not use one.
     """
+    if owned_counts is not None:
+        cp_attn_lse = mask_empty_dcp_lse(cp_attn_lse, owned_counts)
     if backend == "a2a":
         return cp_lse_a2a(cp_attn_out, cp_attn_lse, cp_group)
     return cp_lse_ag_out_rs(cp_attn_out, cp_attn_lse, cp_group, ctx=ctx)
@@ -1081,11 +1108,13 @@ def _compact_filter_dcp_prefill_kernel(
         tl.store(out_kv_indices + out_kv_start + dst, slot, mask=idx_valid)
         written += tl.sum(owned_i32)
 
-    # A row this rank owns nothing of is left EMPTY (zero-length region). That is
-    # both legal and correct for mla_decode_fwd: it writes lse = -inf, which
-    # cp_lse_ag_out_rs turns into a zero weight. Its `o` comes out NaN (0/0), so
-    # the caller zeroes those rows -- see _forward_prefill_mla. No dummy candidate
-    # is injected; the attention never sees fabricated KV.
+    # Persistent MLA's fast metadata builder does not handle zero-length rows:
+    # one empty row can leave that row and several following short rows without
+    # valid work descriptors. Reserve one slot for an empty row and point it at
+    # a valid dummy cache entry. The attention caller uses the original
+    # `owned_counts == 0` to replace this row with the exact softmax identity
+    # (O=0, LSE=-inf), so the dummy never contributes to the DCP merge.
+    tl.store(out_kv_indices + out_kv_start, 0, mask=written == 0)
 
 
 def triton_filter_and_convert_dcp_index_prefill(
@@ -1150,11 +1179,16 @@ def triton_filter_and_convert_dcp_index_prefill(
         ti_stride1,
     )
 
-    # Same device-side-only cumsum as the decode path (see its comment for why
-    # zero_() and dtype=torch.int32 are required).
+    # Keep the true counts in `owned_counts` for post-attention neutralization,
+    # but give every metadata row at least one valid slot. Persistent MLA's fast
+    # metadata path can corrupt work descriptors after a zero-length row.
+    metadata_counts = counts.clamp_min(1)
     out_kv_indptr[:1].zero_()
     torch.cumsum(
-        counts, dim=0, dtype=torch.int32, out=out_kv_indptr[1 : num_tokens + 1]
+        metadata_counts,
+        dim=0,
+        dtype=torch.int32,
+        out=out_kv_indptr[1 : num_tokens + 1],
     )
 
     _compact_filter_dcp_prefill_kernel[grid](

--- a/docs/context_parallel_guide.md
+++ b/docs/context_parallel_guide.md
@@ -520,30 +520,38 @@ hit it.
 DeepSeek-R1 never needed this: 128 heads at `-tp 8` is 16 per rank, and the dcp8
 gather lands on 128 exactly.
 
-### The gqa=64 exception (non-persistent fp8 decode)
+### Sparse DCP persistent attention and gqa=64
 
-One of those four native widths is not always available: with an **fp8 Q and an
-fp8 KV cache**, aiter serves gqa=64 only from the **persistent** decode kernel
-and aborts the process otherwise (`asm_mla.cu`: *"fp8/fp8 with gqa_ratio=64 only
-supports persistent mode"*). A DCP decode that cannot be persistent therefore
-rounds a gathered 64 up to **128** instead of taking 64. Two situations force
-non-persistent:
+With an **fp8 Q and an fp8 KV cache**, aiter serves gqa=64 only from the
+**persistent** decode kernel and aborts the process otherwise (`asm_mla.cu`:
+*"fp8/fp8 with gqa_ratio=64 only supports persistent mode"*).
 
-- **sparse MLA / DSA under DCP** — the per-rank top-k compaction makes the sparse
-  region length depend on the layer, which work metadata built once per step
-  cannot describe (see `_forward_decode`);
-- **gfx942**, which ships no lse-emitting persistent kernel at all.
+Native sparse MLA / DSA attention under DCP handles this on gfx950 by rebuilding
+the persistent work/reduce metadata after every **full IndexShare layer**
+compacts its rank-local top-k. The rebuild consumes that layer's
+`dcp_sparse_kv_indptr`; following shared layers reuse the same indices, compact
+indptr, and work plan. This makes the persistent descriptors and the actual
+sparse regions agree without rebuilding metadata on shared layers.
 
-`mla_dcp_decode_is_persistent` decides this once at construction, so the width
-the module pads to and the width the persistent descriptors are planned for
-cannot disagree.
+The implementation is scoped to native, non-speculative serving on gfx950 with
+page size 1: decode is q_len=1, while sparse prefill is represented as per-token
+virtual q_len=1 rows. Unsupported paths (including gfx942 and plugin or
+speculative sparse DCP paths without the per-layer rebuild) remain
+non-persistent and round a gathered 64 up to **128**.
 
-**GLM-5.2 is the model that lands on it**: 64 query heads at `-tp 8` is 8 per
-rank, so `-dcp 8` gathers exactly 64 — sparse, hence non-persistent, hence padded
-to 128. Half the kernel's heads are padding in that configuration; making it 64
-means giving sparse + DCP a persistent path first.
+**GLM-5.2 is the model that benefits**: 64 query heads at `-tp 8` is 8 per
+rank, so `-dcp 8` gathers exactly 64 and now dispatches the native persistent
+gqa64 kernel instead of padding to 128. `-tp 4 -dcp 4` has the same gathered
+width and uses the same persistent gqa64 path.
 
-**Validated** (ATOM server, 8×MI355 gfx950, `-tp 8 -dcp 8`, fp8 KV, full 1319
+**Validated** (native ATOM, MI355 gfx950, GLM-5.2-MXFP4, fp8 KV, no
+speculative decode): both `-tp 8 -dcp 8` and `-tp 4 -dcp 4` complete CUDA graph
+capture, short decode, 7.7k-token sparse prefill/decode, and the full 1319
+GSM8K 5-shot set. Both topologies score **flexible-extract 0.9689 /
+strict-match 0.9666**. The TP8/DCP8 run also completes a 32-concurrent graph
+smoke with no traceback, HIP error, or engine failure.
+
+**Kimi-K3 validated** (ATOM server, 8×MI355 gfx950, `-tp 8 -dcp 8`, fp8 KV, full 1319
 GSM8K 5-shot at 64 concurrency): **flexible-extract 0.9553 / strict-match
 0.9553**, inside the [Kimi-K3 recipe](../recipes/Kimi-K3.md)'s
 0.9538–0.9591 band. Prefix caching was **off** for that run, matching the
@@ -644,7 +652,7 @@ contributing under DCP rather than collapsing back to single-token decode.
 | prefix caching / chunked prefill | Supported (dense and sparse / DSA). On **Kimi-K3** the validated configuration has prefix caching **off**, per its recipe |
 | Kimi-K3 KDA layers | Not sharded — the KDA recurrent state is per-request, not paged, so DCP frees only the MLA share of attention memory |
 | Kimi-K3 gathered head width | Padded to a natively dispatched MLA width (16 / 32 / 64 / 128); past 128 it falls back to the folded kernel with a warning — lower `-dcp` or raise `-tp` |
-| gathered head width 64 + fp8 KV | Only the persistent kernel serves gqa=64 on fp8 Q/KV, so a non-persistent DCP decode (sparse / DSA, or any DCP decode on gfx942) pads to 128 instead — see [the gqa=64 exception](#the-gqa64-exception-non-persistent-fp8-decode) |
+| gathered head width 64 + fp8 KV | Native sparse / DSA prefill and q_len=1 decode on gfx950 rebuild persistent metadata per full IndexShare layer and run gqa64 directly; unsupported non-persistent paths still pad to 128 — see [Sparse DCP persistent attention and gqa=64](#sparse-dcp-persistent-attention-and-gqa64) |
 | speculative decode (MTP), dense MLA | Supported on **gfx950 only** (bf16/fp8, `num_speculative_tokens` 1–3); raises at startup on gfx942 |
 | speculative decode (DSpark), Kimi-K3 | Supported on gfx950; validated at `tp8 -dcp 8` with `num_speculative_tokens 2` |
 | speculative decode (MTP), sparse / DSA | **Not supported** — sparse decode with `q > 1` under DCP is rejected by an assert |

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -609,7 +609,7 @@ def test_projection_does_not_defeat_the_empty_rank_scrub():
 # ──────────────────────────────────────────────────────── A2A merge backend ──
 
 
-def _a2a_roundtrip(o_per_rank, lse_per_rank, n_ranks):
+def _a2a_roundtrip(o_per_rank, lse_per_rank, n_ranks, owned_counts_per_rank=None):
     """pack -> all-to-all -> combine, with the collective done as a local permute.
 
     ``all_to_all_single`` needs a real process group, which a single-process test
@@ -632,9 +632,14 @@ def _a2a_roundtrip(o_per_rank, lse_per_rank, n_ranks):
         send = torch.empty((n_ranks, b, h_local, d + pack), dtype=dtype, device=DEV)
         o_r = o_per_rank[r].contiguous()
         l_r = lse_per_rank[r].contiguous().to(torch.float32)
+        has_owned_counts = owned_counts_per_rank is not None
+        counts_r = (
+            owned_counts_per_rank[r].contiguous() if has_owned_counts else l_r
+        )
         _dcp_a2a_pack_kernel[(b, h_total)](
             o_r,
             l_r,
+            counts_r,
             send,
             o_r.stride(0),
             o_r.stride(1),
@@ -646,6 +651,7 @@ def _a2a_roundtrip(o_per_rank, lse_per_rank, n_ranks):
             H_LOCAL=h_local,
             HEAD_DIM=d,
             LSE_PACK=pack,
+            HAS_OWNED_COUNTS=has_owned_counts,
         )
         sends.append(send)
 
@@ -735,11 +741,11 @@ def test_a2a_lse_survives_the_16_bit_split():
 
 @needs_gpu
 def test_a2a_scrubs_the_empty_rank():
-    """Same hazard as the ag_rs path: a rank owning no KV returns o=NaN, lse=-inf.
+    """A dummy-backed empty rank has finite LSE and a meaningless output.
 
-    The combine kernel must force that contribution to a hard zero. Without it
-    NaN*0 = NaN survives the accumulation and poisons the row for every rank --
-    silently, since nothing raises.
+    The existing pack kernel must use the true count to send LSE=-inf, after
+    which the combine kernel forces its contribution to a hard zero. This is
+    the launch-free sparse-DCP zero-row path used by decode and prefill.
     """
     b, h, d, n_ranks = 2, 4, 32, 2
     g = torch.Generator(device=DEV).manual_seed(5)
@@ -747,14 +753,17 @@ def test_a2a_scrubs_the_empty_rank():
         torch.randn(b, h, d, generator=g, device=DEV).bfloat16() for _ in range(n_ranks)
     ]
     lse = [torch.randn(b, h, generator=g, device=DEV) for _ in range(n_ranks)]
-    o[0][0, 0] = float("nan")
-    lse[0][0, 0] = NEG_INF
+    o[0][0] = float("nan")
+    owned_counts = [
+        torch.tensor([0, 1], dtype=torch.int32, device=DEV),
+        torch.tensor([1, 1], dtype=torch.int32, device=DEV),
+    ]
 
-    got = _a2a_roundtrip(o, lse, n_ranks)
+    got = _a2a_roundtrip(o, lse, n_ranks, owned_counts)
     assert torch.isfinite(got).all(), "empty-rank NaN reached the a2a output"
     # Rank 0 contributed nothing, so the row is rank 1 alone (weight 1).
     torch.testing.assert_close(
-        got[0, 0].float(), o[1][0, 0].float(), rtol=8e-3, atol=8e-3
+        got[0].float(), o[1][0].float(), rtol=8e-3, atol=8e-3
     )
 
 

--- a/tests/test_dcp_merge_ops.py
+++ b/tests/test_dcp_merge_ops.py
@@ -633,9 +633,7 @@ def _a2a_roundtrip(o_per_rank, lse_per_rank, n_ranks, owned_counts_per_rank=None
         o_r = o_per_rank[r].contiguous()
         l_r = lse_per_rank[r].contiguous().to(torch.float32)
         has_owned_counts = owned_counts_per_rank is not None
-        counts_r = (
-            owned_counts_per_rank[r].contiguous() if has_owned_counts else l_r
-        )
+        counts_r = owned_counts_per_rank[r].contiguous() if has_owned_counts else l_r
         _dcp_a2a_pack_kernel[(b, h_total)](
             o_r,
             l_r,
@@ -762,9 +760,7 @@ def test_a2a_scrubs_the_empty_rank():
     got = _a2a_roundtrip(o, lse, n_ranks, owned_counts)
     assert torch.isfinite(got).all(), "empty-rank NaN reached the a2a output"
     # Rank 0 contributed nothing, so the row is rank 1 alone (weight 1).
-    torch.testing.assert_close(
-        got[0].float(), o[1][0].float(), rtol=8e-3, atol=8e-3
-    )
+    torch.testing.assert_close(got[0].float(), o[1][0].float(), rtol=8e-3, atol=8e-3)
 
 
 @needs_dcp_ops

--- a/tests/test_dcp_sparse_filter.py
+++ b/tests/test_dcp_sparse_filter.py
@@ -163,23 +163,26 @@ def test_decode_filter(name, g_ctxs, seed):
 
         exp = _decode_reference(g_ctxs, block_table, token_indices, rank)
         indptr = out_indptr.cpu().tolist()
+        true_counts = counts.cpu().tolist()
 
         for b in range(bs):
             got_len = indptr[b + 1] - indptr[b]
-            assert got_len == len(exp[b]), (
+            assert true_counts[b] == len(exp[b])
+            assert got_len == max(len(exp[b]), 1), (
                 f"[{name}] rank{rank} req{b}: region length {got_len} "
-                f"!= {len(exp[b])}"
+                f"!= metadata length {max(len(exp[b]), 1)}"
             )
         for b in range(bs):
             got = out_buf[indptr[b] : indptr[b + 1]].cpu().tolist()
-            assert got == exp[b], f"[{name}] rank{rank} req{b}: {got} != {exp[b]}"
+            expected = exp[b] if exp[b] else [0]
+            assert got == expected, f"[{name}] rank{rank} req{b}: {got} != {expected}"
 
         written = out_buf[: indptr[bs]]
         assert (
             int((written < 0).sum()) == 0
         ), f"[{name}] rank{rank}: -1 hole inside the compacted region"
 
-        per_rank_lens.append([indptr[b + 1] - indptr[b] for b in range(bs)])
+        per_rank_lens.append(true_counts)
 
     # Partition: every valid top-k token is claimed by exactly one rank.
     # Checked on COUNTS, not on slot values -- slots are per-rank local
@@ -237,11 +240,14 @@ def test_decode_filter_block_interleave(interleave, g_ctxs, seed):
 
         exp = _decode_reference(g_ctxs, block_table, token_indices, rank, interleave)
         indptr = out_indptr.cpu().tolist()
+        true_counts = counts.cpu().tolist()
         for b in range(bs):
             got = out_buf[indptr[b] : indptr[b + 1]].cpu().tolist()
-            assert got == exp[b], f"S={interleave} rank{rank} req{b}: {got} != {exp[b]}"
+            assert true_counts[b] == len(exp[b])
+            expected = exp[b] if exp[b] else [0]
+            assert got == expected, f"S={interleave} rank{rank} req{b}: {got} != {expected}"
         assert int((out_buf[: indptr[bs]] < 0).sum()) == 0, "-1 hole in region"
-        per_rank_lens.append([indptr[b + 1] - indptr[b] for b in range(bs)])
+        per_rank_lens.append(true_counts)
 
     for b, g in enumerate(g_ctxs):
         n = min(g, DEC_K)

--- a/tests/test_dcp_sparse_filter.py
+++ b/tests/test_dcp_sparse_filter.py
@@ -397,21 +397,20 @@ def test_prefill_filter(seq_lens, interleave):
                 if owner == r
             ]
 
-            # Contract: a row this rank owns nothing of stays
-            # EMPTY -- no dummy candidate is injected. mla_decode_fwd accepts a
-            # zero-length region and writes lse=-inf; the caller zeroes the
-            # matching NaN `o`. So the region must be exactly length 0 and
-            # owned_counts must report 0.
+            # Contract: a row this rank owns nothing of gets one valid dummy
+            # slot so persistent MLA metadata never sees a zero-length row.
+            # owned_counts remains 0, allowing the caller to replace its
+            # attention result with O=0/LSE=-inf before the DCP merge.
             # Counted off the kernel's own indptr, never off the reference:
             # summing the reference's per-rank splits would reproduce `want` by
             # construction and assert nothing.
-            n_claimed += len(slots)
+            n_claimed += int(cnts[t])
 
             if not exp_slots:
                 n_empty += 1
-                assert len(slots) == 0 and cnts[t] == 0, (
-                    f"token={t} rank={r}: unowned row must stay empty, got "
-                    f"len={len(slots)} count={cnts[t]}"
+                assert list(slots) == [0] and cnts[t] == 0, (
+                    f"token={t} rank={r}: unowned row must hold one dummy, got "
+                    f"slots={list(slots)} count={cnts[t]}"
                 )
                 continue
 

--- a/tests/test_dcp_sparse_filter.py
+++ b/tests/test_dcp_sparse_filter.py
@@ -245,7 +245,9 @@ def test_decode_filter_block_interleave(interleave, g_ctxs, seed):
             got = out_buf[indptr[b] : indptr[b + 1]].cpu().tolist()
             assert true_counts[b] == len(exp[b])
             expected = exp[b] if exp[b] else [0]
-            assert got == expected, f"S={interleave} rank{rank} req{b}: {got} != {expected}"
+            assert (
+                got == expected
+            ), f"S={interleave} rank{rank} req{b}: {got} != {expected}"
         assert int((out_buf[: indptr[bs]] < 0).sum()) == 0, "-1 hole in region"
         per_rank_lens.append(true_counts)
 

--- a/tests/test_dcp_topk.py
+++ b/tests/test_dcp_topk.py
@@ -392,7 +392,11 @@ def _filter_owned_prefill(
 
     per_row = []
     for t in range(rows):
-        s, e = int(out_kv_indptr[t]), int(out_kv_indptr[t + 1])
+        s = int(out_kv_indptr[t])
+        # The persistent metadata reserves one dummy slot for a rank-local
+        # zero-length row. Only the true owned count belongs to the partition
+        # being checked here; the dummy is neutralized by the DCP LSE merge.
+        e = s + int(owned_counts[t])
         slots = out[s:e]
         blk, off = slots // block_size, slots % block_size
         req = int(token_req[t])


### PR DESCRIPTION
## Summary

- Enable persistent sparse MLA under DCP for GLM-5.2.
- Rebuild AITER persistent work/reduce metadata after each full IndexShare layer updates its rank-local top-k layout.
- Reuse the generated sparse metadata for shared IndexShare layers.
- Align all MLA metadata construction paths to `_MLA_SPLIT_BUDGET_AUTO`.
- Handle zero-owned DCP sparse prefill rows without falling back to non-persistent MLA.
- Preserve the existing KV-cache layout and standalone LMCache offload compatibility.

## Motivation

With FP8 Q/KV cache, AITER requires the persistent kernel for the gathered GQA=64 path. Previously, GLM-5.2 sparse DCP could not use persistent attention because the sparse KV region length changes per IndexShare layer, forcing the gathered head width to be padded to 128.

This change rebuilds persistent metadata from the layer-local compact sparse KV indptr, allowing the native persistent GQA=64 kernel to run without unnecessary head padding.

Long-context sparse prefill also exposes zero-owned rank-local rows. These occur when early query tokens have no selected KV tokens on a particular DCP rank. AITER persistent fast metadata does not safely handle zero-length rows and may generate invalid work descriptors for that row and subsequent short rows. This causes severe accuracy degradation once the prompt exceeds `index_topk=2048`, as observed with GSM8K 20-shot.

The fix reserves one valid dummy KV slot for zero-owned rows so persistent metadata never receives a zero-length region. The original owned count is preserved, and the corresponding local LSE is masked to `-inf` in the existing DCP merge path. The dummy slot therefore contributes neither output nor probability mass.

Only the small LSE tensor is masked. No additional full attention-output scan is introduced.

## Supported scope

- Native ATOM serving
- MI355 / gfx950
- Non-speculative decoding
- GLM-5.2 sparse MLA with DCP
- TP4/DCP4 and TP8/DCP8
- FP8 KV cache

Unsupported paths retain the existing non-persistent fallback, including gfx942, speculative sparse DCP, and unsupported plugin configurations.

## Validation

### Full GSM8K 5-shot

Validated GLM-5.2 serving with TP4/DCP4
```bash
local-chat-completions ({'model': '/shared/data/amd_int/models/GLM-5.2-MXFP4', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 64, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 1048576}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9682|±  |0.0048|
|     |       |strict-match    |     5|exact_match|↑  |0.9682|±  |0.0048|
```

### Long-context GSM8K 20-shot
```bash
local-chat-completions ({'model': '/shared/data/amd_int/models/GLM-5.2-MXFP4', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 64, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 1048576}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: 20, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9651|±  |0.0051|
|     |       |strict-match    |    20|exact_match|↑  |0.9659|±  |0.0050|
```


This exercises prompts longer than `index_topk=2048` and covers the sparse persistent prefill path.