### PR TITLE
refactor(v4): let QKNormRopeOut produce its own custom-op return

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -70,7 +70,7 @@
           "label": "DPA DSpark",
           "suffix": "-dpa-dspark",
           "path": "deepseek-ai/DeepSeek-V4-Pro-DSpark",
-          "extra_args": "--method dspark --num-speculative-tokens 7 --cudagraph-mode PIECEWISE --enable-dp-attention --dspark-config '{\"confidence_schedule\": true, \"ragged\": true, \"ragged_graph_sizes\": \"8\"}'",
+          "extra_args": "--method dspark --num-speculative-tokens 7 --cudagraph-mode AF_PIECEWISE --enable-dp-attention --dspark-config '{\"confidence_schedule\": true, \"ragged\": true, \"ragged_graph_sizes\": \"8\"}'",
           "bench_args": "--use-chat-template",
           "conc_min": 64,
           "conc_max": 512

--- a/atom/model_ops/v4_kernels/qk_norm_rope_maybe_quant.py
+++ b/atom/model_ops/v4_kernels/qk_norm_rope_maybe_quant.py
@@ -71,6 +71,22 @@ class QKNormRopeOut:
     k_packed: torch.Tensor | None = None
     k_rope: torch.Tensor | None = None
 
+    def custom_op_return(self) -> list["torch.Tensor"]:
+        """This struct as a custom op's return value: the active layout's
+        tensors, in the order the boundary carries them.
+
+        A custom op schema cannot express this struct. It has no dataclass, and
+        `Tensor[]` cannot hold None (`infer_schema` rejects
+        `list[Tensor | None]` outright), while half of these fields always are
+        None -- so what crosses is the live ones only, and the ORDER is the
+        contract the caller re-expands by. Which layout is live is readable off
+        the struct itself -- the inactive path's fields stay None, as above --
+        so callers do not thread `kv_fp8` through to say it a second time.
+        """
+        if self.q_packed is not None:
+            return [self.q_packed, self.q_rope, self.k_packed, self.k_rope]
+        return [self.q_sa, self.kv]
+
 
 # Lazy-imported flydsl path (optional dependency). Set to None when flydsl
 # is unavailable; the dispatch in ``qk_norm_rope_maybe_quant`` will fall

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -349,16 +349,6 @@ def _qkn_placeholder(layer, q: torch.Tensor, num_tokens: int, *, zeros: bool):
     return QKNormRopeOut(q_sa=alloc((num_tokens, h, d)), kv=alloc((num_tokens, d)))
 
 
-def _qkn_to_list(qkn: "QKNormRopeOut", kv_fp8: bool) -> list[torch.Tensor]:
-    """Flatten for the op boundary: a custom op schema carries no dataclass, and
-    no Optionals in a tuple return, so this is the active layout's fields as a
-    list. Shared with the fake impl, which is what keeps the two from
-    disagreeing on length."""
-    if kv_fp8:
-        return [qkn.q_packed, qkn.q_rope, qkn.k_packed, qkn.k_rope]
-    return [qkn.q_sa, qkn.kv]
-
-
 def _v4_qk_norm_rope_fake(
     q: torch.Tensor,
     kv_pre: torch.Tensor,
@@ -367,7 +357,7 @@ def _v4_qk_norm_rope_fake(
 ) -> list[torch.Tensor]:
     atom_config = get_current_atom_config()
     self = atom_config.compilation_config.static_forward_context[layer_name]
-    return _qkn_to_list(_qkn_placeholder(self, q, q.shape[0], zeros=False), self.kv_fp8)
+    return _qkn_placeholder(self, q, q.shape[0], zeros=False).custom_op_return()
 
 
 def v4_qk_norm_rope(
@@ -385,7 +375,7 @@ def v4_qk_norm_rope(
     """
     atom_config = get_current_atom_config()
     self = atom_config.compilation_config.static_forward_context[layer_name]
-    return _qkn_to_list(self._qk_norm_rope(q, kv_pre, positions), self.kv_fp8)
+    return self._qk_norm_rope(q, kv_pre, positions).custom_op_return()
 
 
 direct_register_custom_op(

--- a/tests/test_dspark.py
+++ b/tests/test_dspark.py
@@ -1666,9 +1666,9 @@ def test_every_op_fake_agrees_with_its_body():
                 [t.shape for t in v4._v4_qk_norm_rope_fake(q, kv_pre, positions, "L")],
                 [
                     t.shape
-                    for t in v4._qkn_to_list(
-                        A._qk_norm_rope(layer, q, kv_pre, positions), layer.kv_fp8
-                    )
+                    for t in A._qk_norm_rope(
+                        layer, q, kv_pre, positions
+                    ).custom_op_return()
                 ],
             ),
             (
@@ -1814,8 +1814,8 @@ def test_qk_norm_rope_shapes_match_what_the_paged_kernel_asserts():
     assert bf16.q_packed is None and bf16.q_rope is None
 
     # And the op's return list has to carry the active layout's four / two.
-    assert len(v4._qkn_to_list(fp8, True)) == 4
-    assert len(v4._qkn_to_list(bf16, False)) == 2
+    assert len(fp8.custom_op_return()) == 4
+    assert len(bf16.custom_op_return()) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`_qkn_to_list` sat next to `_qkn_placeholder` and the two were always nested -- the fake impl built the struct only to flatten it again. Both also took `kv_fp8` to say which layout was live, which the struct already knows: the inactive path's fields stay None, as its own docstring says.

Move the flatten onto the struct as `custom_op_return()`. The name is the point: what crosses is not merely "the tensors as a list" but a custom op's return value, and the ORDER is the contract the caller re-expands by.


`kv_fp8` disappears from all three call sites. Net -14 lines in deepseek_v4.py.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
