### PR TITLE
docs: Fix duplicated table on atom overview

### DIFF
--- a/atom_overview_draft.md
+++ b/atom_overview_draft.md
@@ -45,12 +45,6 @@ ATOM is the vehicle enabling AMD to challenge the NVIDIA B200.
 | **ATOM** | AMD-optimized inference execution and orchestration |
 | Communication (MORI) | Multi-GPU and multi-node communication |
 
-------|------|
-| Frameworks (PyTorch, vLLM, SGLang) | Model definition and serving APIs |
-| Compiler (AITER / MLIR) | Graph‑level optimization and fusion |
-| **ATOM** | AMD‑optimized inference execution engine |
-| Communication (MORI) | Multi‑GPU and multi‑node communication |
-
 ATOM serves as the central performance layer, coordinating compiler decisions, kernel selection, and distributed execution.
 
 ---


### PR DESCRIPTION
## Motivation

I was reviewing the ATOM project to understand it and saw a malformed (Duplicated) table on [atom_overview_draft.md](https://github.com/ROCm/ATOM/blob/main/atom_overview_draft.md).

This simply updates this resource to not render a broken duplicated datatable in the Markdown doc.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

N/A

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

N/a

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
