### PR TITLE
[MTP] fix low acceptance rate issue of glm5.2 MTP

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2825,7 +2825,24 @@ class FusedMoE(torch.nn.Module):
             return need_gather_w2
 
         need_gather_w2 = check_need_allgather()
-        tp_group = get_tp_group() if need_gather_w2 else None
+        w2_gather_groups = []
+        if need_gather_w2:
+            # ``self.tp_size`` includes DP ranks when DPA flattens DP x TP for
+            # MoE, while get_tp_group() only spans physical TP. Gather in the
+            # same order as flat rank = dp_rank * physical_tp_size + tp_rank.
+            tp_group = get_tp_group()
+            if tp_group.world_size > 1:
+                w2_gather_groups.append(tp_group)
+            if self.dp_size > 1 and get_current_atom_config().enable_dp_attention:
+                w2_gather_groups.append(get_dp_group())
+
+            gathered_world_size = 1
+            for group in w2_gather_groups:
+                gathered_world_size *= group.world_size
+            assert gathered_world_size == self.tp_size, (
+                "w2 online-quant gather groups do not cover effective TP: "
+                f"gathered={gathered_world_size}, effective_tp={self.tp_size}"
+            )
         load_full_w2 = not need_gather_w2
 
         # Save references to old weights before create_weights overwrites them.
@@ -2910,7 +2927,9 @@ class FusedMoE(torch.nn.Module):
                     old_w2_scale[expert_id],
                 )
             if need_gather_w2:
-                w2_full = tp_group.all_gather(w2_local, dim=1)
+                w2_full = w2_local
+                for group in w2_gather_groups:
+                    w2_full = group.all_gather(w2_full, dim=1)
                 w2_q, w2_s = _quant_weight(w2_full)
                 del w2_full
             else:

--- a/atom/spec_decode/dspark_proposer.py
+++ b/atom/spec_decode/dspark_proposer.py
@@ -366,11 +366,12 @@ class DSparkProposer(Drafter):
         rows are harmless -- they land on future positions, unread until the
         step that accepts them rewrites them.
 
-        `next_token_ids` is unused: DSpark drafts from aux hidden states.
-        `produces_output` is unused: the window has to cover every scheduled
-        row, so a forward that also reaches `propose()` is not skippable here.
+        `next_token_ids` is only read to re-run the block pass for DP
+        collective alignment (see below); the KV write itself drafts from aux
+        hidden states.
+        `produces_output` is not skippable for the window write -- it has to
+        cover every scheduled row -- but it does select the DP sync below.
         """
-        del next_token_ids, produces_output
         aux_hidden_states = self.aux_for(hidden_states)
         if aux_hidden_states is None:
             return
@@ -379,6 +380,34 @@ class DSparkProposer(Drafter):
         main_hidden_all = torch.cat(aux_hidden_states, dim=-1)
         with record_function(f"dspark_ctx_kv[bs={bs} tok={main_hidden_all.shape[0]}]"):
             self.model.write_context_kv(main_hidden_all, positions)
+
+        if produces_output or self.config.parallel_config.data_parallel_size <= 1:
+            return
+        if not next_token_ids:
+            return
+        anchors = next_token_ids[:bs]
+        if any(t < 0 for t in anchors):
+            return
+        # A batch that produces no output returns before `postprocess`, so
+        # `propose()` never runs on this rank -- but peers that DO sample run it
+        # and issue one DPMetadata all_reduce plus one block pass (which carries
+        # the backbone's DP-attention MoE collectives). Replay the same pass and
+        # drop its tokens, or those peers deadlock in the all_reduce. The
+        # verify scheduler is detached so this replay leaves no ell behind.
+        last_token_indices = self.prepare_inputs(bs, 1)
+        anchor_ids = self.anchors_to_gpu(anchors)
+        verify_scheduler, self.verify_scheduler = self.verify_scheduler, None
+        try:
+            self.propose(
+                target_token_ids=None,
+                target_positions=positions,
+                target_hidden_states=hidden_states,
+                num_reject_tokens=None,
+                next_token_ids=anchor_ids,
+                last_token_indices=last_token_indices,
+            )
+        finally:
+            self.verify_scheduler = verify_scheduler
 
     def propose(
         self,

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -189,7 +189,6 @@ class EagleProposer(Drafter):
         carrying `dspark_block_size` to `DSparkProposer`, and every model on
         hand takes that branch.
         """
-        del produces_output
         if not next_token_ids:
             return
         forward_context = get_forward_context()
@@ -217,14 +216,27 @@ class EagleProposer(Drafter):
         input_ids = self.runner.tokenID_processor.input_ids.gpu[1 : num_tokens + 1]
         input_ids.scatter_(0, last_token_indices, anchor_ids)
 
+        # A batch that produces no output returns before `postprocess`, so
+        # `propose()` never runs on this rank -- but peers that DO sample run it
+        # and issue `mtp_k` DPMetadata all_reduces plus `mtp_k` draft-model MoE
+        # collectives. Match that ledger here or the peers deadlock. The repeats
+        # feed identical inputs, so the extra passes rewrite the same draft KV
+        # with the same values.
+        num_draft_passes = 1
+        if not produces_output and self.config.parallel_config.data_parallel_size > 1:
+            num_draft_passes = self.mtp_k
+
         was_draft = context.is_draft
         context.is_draft = True
         try:
-            self.model(
-                input_ids=input_ids,
-                positions=positions[:num_tokens] + 1,
-                hidden_states=draft_hidden,
-            )
+            for _ in range(num_draft_passes):
+                if num_draft_passes > 1:
+                    self._refresh_dp_metadata(forward_context, num_tokens)
+                self.model(
+                    input_ids=input_ids,
+                    positions=positions[:num_tokens] + 1,
+                    hidden_states=draft_hidden,
+                )
         finally:
             context.is_draft = was_draft
 


### PR DESCRIPTION
## Summary

* This PR fixes near-zero GLM-5.2 MTP acceptance under DP Attention by correctly reconstructing MoE `w2` weights before online quantization. 
* It also adds draft-pass alignment for no-output context prefill paths to keep speculative-decoding collectives consistent across DP ranks.

## Root Cause

* With DP Attention enabled, MoE uses an effective TP topology flattened across physical TP and DP ranks. The previous online-quantization path gathered `w2` only through the physical TP group, which has world size 1 in the DPA4 configuration, while subsequent logic still sliced the result using effective TP size 4. This left part of the quantized `w2` buffer uninitialized, producing NaNs in the MTP MoE output and reducing draft acceptance to nearly 0%.

* No-output context chunks introduce a separate synchronization risk: these ranks return before normal proposal processing, while peer ranks may continue running speculative draft passes and their associated DP metadata and MoE collectives. The proposer changes replay the otherwise-missing draft passes to align the expected collective sequence.

## Changes

- Gather `w2` across both physical TP and DP groups in flattened-rank order before online quantization.
- Validate that the combined gather groups cover the effective MoE TP size.
- Replay the required Eagle/MTP draft passes for no-output context chunks under data parallelism.
- Add equivalent DP collective alignment for DSpark block drafting while preserving its context-KV writes.

## Validation

- DPA + MTP1 eager: first draft token matches the target token.
- DPA + MTP3 eager: acceptance recovered to approximately 78%.
- DPA + MTP3 + CUDA Graph + LMCache: approximately 80%–82% acceptance.
- GSM8K, 64 samples, 20-shot: 95.31% flexible-extract and 92.19% strict-match.
- LMCache: all four DP ranks successfully stored and retrieved 8,960 tokens.
