### PR TITLE
[DCP] Enable fused indexer_qk_rope_quant_and_cache for dcp

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -16,6 +16,8 @@ from aiter import (
     flash_attn_varlen_func,
     fused_qk_rope_concat_and_cache_mla,
     get_hip_quant,
+)
+from aiter import (
     indexer_qk_rope_quant_and_cache as _indexer_qk_rope_quant_and_cache,
 )
 

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -16,6 +16,7 @@ from aiter import (
     flash_attn_varlen_func,
     fused_qk_rope_concat_and_cache_mla,
     get_hip_quant,
+    indexer_qk_rope_quant_and_cache as _indexer_qk_rope_quant_and_cache,
 )
 
 # The segmented (page_size>1) MLA cache kernels only exist in newer aiter
@@ -65,6 +66,50 @@ from atom.utils.forward_context import (
     ForwardContext,
     get_forward_context,
 )
+
+
+def indexer_qk_rope_quant_and_cache(
+    q: torch.Tensor,
+    q_out: torch.Tensor,
+    weights: torch.Tensor,
+    weights_out: torch.Tensor,
+    k: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_bias: torch.Tensor,
+    positions: torch.Tensor,
+    cos_cache: torch.Tensor,
+    sin_cache: torch.Tensor,
+    epsilon: float,
+    quant_block_size: int,
+    scale_fmt: str | None,
+    weights_scale: float,
+    preshuffle: bool = False,
+    is_neox: bool = True,
+) -> None:
+    """Run the fused indexer cache op with ATOM's DCP query semantics."""
+    _indexer_qk_rope_quant_and_cache(
+        q,
+        q_out,
+        weights,
+        weights_out,
+        k,
+        kv_cache,
+        slot_mapping,
+        norm_weight,
+        norm_bias,
+        positions,
+        cos_cache,
+        sin_cache,
+        epsilon,
+        quant_block_size,
+        scale_fmt,
+        weights_scale,
+        preshuffle=preshuffle,
+        is_neox=is_neox,
+        compute_all_q_rope=get_dcp_world_size() > 1,
+    )
 
 
 def _sparse_index_workspace(

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -35,7 +35,6 @@ from aiter import (
     gemm_a8w8_blockscale_bpreshuffle,
     get_hip_quant,
     indexer_k_quant_and_cache,
-    indexer_qk_rope_quant_and_cache,
     top_k_per_row_decode,
     top_k_per_row_prefill,
 )
@@ -81,6 +80,7 @@ from atom.model_ops import module_dispatch_ops as _module_dispatch_ops
 from atom.model_ops.activation import SiluAndMul
 from atom.model_ops.attention_mla import (
     MLAModules,
+    indexer_qk_rope_quant_and_cache,
     is_rocm_aiter_fp4bmm_enabled,
     qrep_tp_override,
     triton_convert_req_index_to_global_index,
@@ -1606,7 +1606,6 @@ def sparse_attn_indexer(
         weights_out = torch.empty(
             weights.shape, device=weights.device, dtype=torch.float32
         )
-        extra = {"compute_all_q_rope": True} if get_dcp_world_size() > 1 else {}
         indexer_qk_rope_quant_and_cache(
             q_bf16,
             q_fp8,
@@ -1626,7 +1625,6 @@ def sparse_attn_indexer(
             weights_scale,
             preshuffle=True,
             is_neox=is_neox_style,
-            **extra,
         )
         weights = weights_out
     else:

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1606,6 +1606,9 @@ def sparse_attn_indexer(
         weights_out = torch.empty(
             weights.shape, device=weights.device, dtype=torch.float32
         )
+        extra = (
+            {"compute_all_q_rope": True} if get_dcp_world_size() > 1 else {}
+        )
         indexer_qk_rope_quant_and_cache(
             q_bf16,
             q_fp8,
@@ -1625,6 +1628,7 @@ def sparse_attn_indexer(
             weights_scale,
             preshuffle=True,
             is_neox=is_neox_style,
+            **extra,
         )
         weights = weights_out
     else:
@@ -2321,14 +2325,10 @@ class Indexer(nn.Module):
         # rope q (1/pcp) and k (full) separately. The op then scores 1/pcp
         # queries against the gathered full KV and writes the full k-cache.
         pcp = _pcp_active()
-        # DCP must also take the unfused path: the fused q-rope/quant+cache op is
-        # driven by slot_mapping, which is -1 on every rank that does not own the
-        # current token, so those ranks skip it entirely and leave q_fp8 /
-        # weights_out uninitialized. Only the owner rank ends up with a valid
-        # query -- invisible while ctx <= index_topk (top-k selects everything
-        # anyway), garbage beyond it.
-        dcp = get_dcp_world_size() > 1
-        unfused_qk_rope = (not self.use_qk_rope_cache_fusion) or pcp or dcp
+        # With compute_all_q_rope, DCP uses the fused path even when this rank's
+        # slot is -1: Q/weights are produced on every rank, positions are clamped
+        # for padded rows, and only the owner rank writes K cache.
+        unfused_qk_rope = (not self.use_qk_rope_cache_fusion) or pcp
         positions_op = positions
         if unfused_qk_rope:
             q_pe, _ = torch.split(

--- a/atom/models/deepseek_v2.py
+++ b/atom/models/deepseek_v2.py
@@ -1606,9 +1606,7 @@ def sparse_attn_indexer(
         weights_out = torch.empty(
             weights.shape, device=weights.device, dtype=torch.float32
         )
-        extra = (
-            {"compute_all_q_rope": True} if get_dcp_world_size() > 1 else {}
-        )
+        extra = {"compute_all_q_rope": True} if get_dcp_world_size() > 1 else {}
         indexer_qk_rope_quant_and_cache(
             q_bf16,
             q_fp8,


### PR DESCRIPTION
## Motivation

This PR enable fused indexer_qk_rope_quant_and_cache in DCP scenario. This PR depends on the kernel modification at https://github.com/ROCm/aiter/pull/5066

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->


## Test Plan

```bash

#!/usr/bin/env bash
set -euo pipefail
cd "$(dirname "$0")"

export PYTHONPATH="$PWD/../aiter${PYTHONPATH:+:$PYTHONPATH}"
export HIP_VISIBLE_DEVICES=0,1,2,3
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export AITER_USE_FLYDSL_MOE_SORTING=1
export PYTHONHASHSEED=0

python -m atom.entrypoints.openai_server \
  --model /workspace/shared/data/amd_int/models/GLM-5.2-MXFP4 \
  --host 0.0.0.0 \
  --server-port 8000 \
  --kv_cache_dtype fp8 \
  --block-size 16 \
  --gpu-memory-utilization 0.9 \
  --online_quant_config \
    '{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate","*expert*"]}' \
  --tensor-parallel-size 4 \
  --decode-context-parallel-size 4 \
  --max-num-seqs 64 \
  2>&1 | tee server-glm52-dcp4-persistent-c64.log
```

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<img width="945" height="148" alt="image" src="https://github.com/user-attachments/assets/2bdf7313-a150-4e8c-b6c5-6f997a42b1af" />


<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

