### PR TITLE
fix: size fake-eplb balance router logits to routed expert count

### DIFF
--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2974,7 +2974,7 @@ class FusedMoE(torch.nn.Module):
         _dp_shard = self.use_ep and atom_config.enable_dp_attention
         self.balance_router_logits = (
             init_balance_router_logits(
-                self.global_num_experts,
+                self.expert_layout.num_routed,
                 top_k,
                 self.ep_size if self.use_ep else 1,
                 self.dp_size if _dp_shard else 1,

--- a/tests/model_ops/test_balance_router_logits.py
+++ b/tests/model_ops/test_balance_router_logits.py
@@ -1,0 +1,57 @@
+import pytest
+import torch
+
+from atom.model_ops.fused_moe.expert_layout import MoEExpertLayout
+from atom.model_ops.moe import _FAKE_EPLB_LOGIT, init_balance_router_logits
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="balance router logits are CUDA-only"
+)
+@pytest.mark.parametrize(
+    "layout_kwargs",
+    [
+        pytest.param(
+            dict(
+                num_routed=256,
+                num_fused_shared_experts=1,
+                num_configured_redundant=0,
+                ep_size=8,
+                use_all2all=True,
+                eplb_enabled=False,
+            ),
+            id="local_replica_shared",
+        ),
+        pytest.param(
+            dict(
+                num_routed=256,
+                num_fused_shared_experts=1,
+                num_configured_redundant=32,
+                ep_size=8,
+                use_all2all=True,
+                eplb_enabled=True,
+            ),
+            id="eplb_routed_shared",
+        ),
+    ],
+)
+def test_balance_router_logits_matches_routed_gate_width(layout_kwargs):
+    layout = MoEExpertLayout.make(**layout_kwargs)
+    assert layout.num_physical > layout.num_routed
+
+    top_k = 8
+    ep_size = layout_kwargs["ep_size"]
+    max_tokens = 16
+    logits = init_balance_router_logits(
+        layout.num_routed,
+        top_k,
+        ep_size,
+        max_num_tokens=max_tokens,
+    )
+
+    assert logits.shape == (max_tokens, layout.num_routed)
+
+    selected = (logits == _FAKE_EPLB_LOGIT).nonzero(as_tuple=False)[:, 1]
+    assert selected.numel() == max_tokens * top_k
+    assert selected.min().item() >= 0
+    assert selected.max().item() < layout.num_routed

--- a/tests/model_ops/test_balance_router_logits.py
+++ b/tests/model_ops/test_balance_router_logits.py
@@ -1,6 +1,10 @@
 import pytest
 import torch
 
+pytest.importorskip(
+    "aiter", reason="init_balance_router_logits lives in atom.model_ops.moe"
+)
+
 from atom.model_ops.fused_moe.expert_layout import MoEExpertLayout
 from atom.model_ops.moe import _FAKE_EPLB_LOGIT, init_balance_router_logits
 
@@ -12,25 +16,25 @@ from atom.model_ops.moe import _FAKE_EPLB_LOGIT, init_balance_router_logits
     "layout_kwargs",
     [
         pytest.param(
-            dict(
-                num_routed=256,
-                num_fused_shared_experts=1,
-                num_configured_redundant=0,
-                ep_size=8,
-                use_all2all=True,
-                eplb_enabled=False,
-            ),
+            {
+                "num_routed": 256,
+                "num_fused_shared_experts": 1,
+                "num_configured_redundant": 0,
+                "ep_size": 8,
+                "use_all2all": True,
+                "eplb_enabled": False,
+            },
             id="local_replica_shared",
         ),
         pytest.param(
-            dict(
-                num_routed=256,
-                num_fused_shared_experts=1,
-                num_configured_redundant=32,
-                ep_size=8,
-                use_all2all=True,
-                eplb_enabled=True,
-            ),
+            {
+                "num_routed": 256,
+                "num_fused_shared_experts": 1,
+                "num_configured_redundant": 32,
+                "ep_size": 8,
+                "use_all2all": True,
+                "eplb_enabled": True,
+            },
             id="eplb_routed_shared",
         ),
     ],


### PR DESCRIPTION
## Summary
- Pass `expert_layout.num_routed` instead of `global_num_experts` into `init_balance_router_logits` so synthetic fake-EPLB logits match the gate width.
- Add regression tests covering LOCAL_REPLICA shared fusion and EPLB routed shared layouts where `num_physical > num_routed`.

## Test plan
- [ ] `pytest tests/model_ops/test_balance_router_logits.py -v` (CUDA)
- [ ] Run a fake-EPLB EP job with fused shared experts and confirm balanced rank load


Made with [Cursor](https://cursor.com)