### PR TITLE
[DO NOT MERGE] bench: fixed-length prompts and no warmup

### DIFF
--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -20,7 +20,7 @@ _n=$(( $# < 7 ? $# : 7 ))
 shift "$_n" 2>/dev/null || true
 EXTRA_ARGS="$*"
 NUM_PROMPTS=$(( CONCURRENCY * PROMPT_MULTIPLIER ))
-RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-0.8}"
+RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO:-1}"
 OUTPUT_DIR="/app/logs_claude"
 
 echo "========================================"
@@ -82,7 +82,7 @@ python -m atom.benchmarks.benchmark_serving \
     --max-concurrency="$CONCURRENCY" \
     --num-prompts="$NUM_PROMPTS" \
     --trust-remote-code \
-    --num-warmups=$((CONCURRENCY * 2)) \
+    --num-warmups=$((CONCURRENCY * 0)) \
     --request-rate=inf --ignore-eos \
     --save-result \
     --result-filename="$RESULT_FILE" \


### PR DESCRIPTION
Temporary branch for reproducing a serving run. **Not for merge.**

`scripts/run_benchmark.sh`, two lines:

| | before | after |
|---|---|---|
| `RANDOM_RANGE_RATIO` default | `0.8` | `1` |
| `--num-warmups` | `CONCURRENCY * 2` | `0` |

`1` is `benchmark_serving.py`'s own default for `--random-range-ratio`, so
lengths come from the sampler's unmodified range instead of the script's
narrowed one. `--num-warmups=0` makes the measured window start at the first
request, with no warmed-up state in front of it.

Based on 1e7659fde so the tree matches the container the run came from.

Why not to merge: dropping warmup is the opposite of what a steady-state
number wants. A cold first round has been measured to move prefill throughput
by double digits, which is exactly the kind of phantom difference warmup
exists to remove. `main` should keep `0.8` / `CONCURRENCY * 2`.