### PR TITLE
support dsv4 bf16 opus attn on gfx1250

### DIFF
--- a/atom/model_ops/v4_kernels/paged_prefill.py
+++ b/atom/model_ops/v4_kernels/paged_prefill.py
@@ -651,20 +651,10 @@ def sparse_attn_v4_paged_prefill(
             attn_sink,
             softmax_scale,
         )  # [S, H, head_dim] bf16
-    if get_gfx() == "gfx1250":
-        return pa_prefill_sparse(
-            q,
-            unified_kv,
-            kv_indices_prefix,
-            kv_indptr_prefix,
-            kv,
-            kv_indices_extend,
-            kv_indptr_extend,
-            attn_sink,
-            softmax_scale,
-        )
     # Backend selection: prefer OPUS when available; fall back to Triton on
     # import failure, env override, or runtime error (e.g. unsupported GPU).
+    # OPUS covers both archs: gfx950 from source, gfx1250 from a prebuilt code
+    # object (bf16 only — fp16 raises and falls through).
     if not envs.ATOM_FORCE_ATTN_TRITON and _HAS_OPUS:
         try:
             return pa_sparse_prefill_opus(
@@ -681,6 +671,19 @@ def sparse_attn_v4_paged_prefill(
             )
         except RuntimeError:
             pass
+    if get_gfx() == "gfx1250":
+        # gfx12 Triton fallback; allocates its own output (no `out=` kwarg).
+        return pa_prefill_sparse(
+            q,
+            unified_kv,
+            kv_indices_prefix,
+            kv_indptr_prefix,
+            kv,
+            kv_indices_extend,
+            kv_indptr_extend,
+            attn_sink,
+            softmax_scale,
+        )
     return _sparse_attn_v4_paged_prefill_triton(
         q,
         unified_kv,


### PR DESCRIPTION
Cherry-pick of d8d8c9f3a (jun, 2026-08-27) from `gfx1250/test_main_823`, which
is not on main. Applies cleanly onto current main; author preserved.

`atom/model_ops/v4_kernels/paged_prefill.py`, one hunk moved: the gfx1250
`pa_prefill_sparse` branch sat *before* the backend selection, so gfx1250
short-circuited to Triton and never attempted OPUS. It now sits *after*, as the
gfx12 fallback.

Effect: OPUS covers both archs — gfx950 from source, gfx1250 from a prebuilt
code object (bf16 only; fp16 raises and falls through). gfx1250 reaches the
Triton path only when OPUS is unavailable, force-disabled via
`ATOM_FORCE_ATTN_TRITON`, or raises at runtime.

No behaviour change on gfx950. Not verified on hardware in this PR.