### PR TITLE
Fuse SiTUv2 activation with per-token FP8 quant in KimiMLP

### DIFF
--- a/atom/model_ops/kimi_k3/__init__.py
+++ b/atom/model_ops/kimi_k3/__init__.py
@@ -6,6 +6,7 @@
 from atom.model_ops.kimi_k3.activations import (
     rmsnorm_gated,
     situ_and_mul,
+    situ_and_mul_quant,
 )
 from atom.model_ops.kimi_k3.attention_residual import apply_attn_res
 from atom.model_ops.kimi_k3.kda_state import gather_kda_initial_state
@@ -15,4 +16,5 @@ __all__ = [
     "gather_kda_initial_state",
     "rmsnorm_gated",
     "situ_and_mul",
+    "situ_and_mul_quant",
 ]

--- a/atom/model_ops/kimi_k3/activations.py
+++ b/atom/model_ops/kimi_k3/activations.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import torch
 from aiter import QuantType, dtypes, get_hip_quant
+from aiter.ops.activation import situv2_and_mul_quant
 
 from atom.utils.decorators import mark_trace
 
@@ -163,6 +164,38 @@ def situ_and_mul(
         BLOCK=BLOCK,
     )
     return y.reshape(*lead, d)
+
+
+@mark_trace
+def situ_and_mul_quant(
+    x: torch.Tensor,
+    beta: float,
+    linear_beta: float | None,
+    quant_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """SiTUv2 gated activation fused with per-token quant.
+
+    Returns ``(quantized [m, d], scale [m, 1])`` for the consuming GEMM's
+    ``x_scale=`` path; falls back to activation-then-quant when the fused
+    AITER kernel does not cover the case.
+    """
+    d = x.shape[-1] // 2
+    fusable = (
+        x.ndim == 2
+        and x.numel() > 0
+        and x.dtype == torch.bfloat16
+        and quant_dtype == dtypes.fp8
+        and linear_beta is not None
+        and d % 8 == 0
+    )
+    if not fusable:
+        y = situ_and_mul(x, beta, linear_beta).reshape(-1, d)
+        return get_hip_quant(QuantType.per_Token)(y, quant_dtype=quant_dtype)
+    x = x.contiguous()
+    out = torch.empty((x.shape[0], d), dtype=quant_dtype, device=x.device)
+    scale = torch.empty((x.shape[0], 1), dtype=torch.float32, device=x.device)
+    situv2_and_mul_quant(out, x, scale, d, float(beta), float(linear_beta))
+    return out, scale
 
 
 @mark_trace

--- a/atom/models/kimi_k3.py
+++ b/atom/models/kimi_k3.py
@@ -198,14 +198,27 @@ class _NoPositionalRotaryEmbedding(RotaryEmbedding):
 
 
 class SituAndMul(nn.Module):
-    def __init__(self, beta: float = 1.0, linear_beta: float | None = None):
+    def __init__(
+        self,
+        beta: float = 1.0,
+        linear_beta: float | None = None,
+        quant_type: QuantType | None = None,
+        quant_dtype: torch.dtype | None = None,
+    ):
         super().__init__()
         self.beta = beta
         self.linear_beta = linear_beta
+        # Only per-token FP8 fuses into the activation; other schemes stay in the Linear.
+        self.fuse_quant = quant_type == QuantType.per_Token and quant_dtype is not None
+        self.quant_dtype = quant_dtype
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        from atom.model_ops.kimi_k3 import situ_and_mul
+    def forward(
+        self, x: torch.Tensor
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        from atom.model_ops.kimi_k3 import situ_and_mul, situ_and_mul_quant
 
+        if self.fuse_quant:
+            return situ_and_mul_quant(x, self.beta, self.linear_beta, self.quant_dtype)
         return situ_and_mul(x, self.beta, self.linear_beta)
 
 
@@ -277,9 +290,14 @@ class KimiMLP(nn.Module):
         )
         if config.hidden_act != "situ":
             raise ValueError(f"Unsupported Kimi-K3 activation: {config.hidden_act}")
+        down_type, down_dtype = _effective_layer_quant(
+            quant_config, f"{prefix}.down_proj"
+        )
         self.act_fn = SituAndMul(
             beta=getattr(config, "activation_situ_beta", None) or 1.0,
             linear_beta=getattr(config, "activation_situ_linear_beta", None),
+            quant_type=down_type,
+            quant_dtype=down_dtype,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -288,7 +306,10 @@ class KimiMLP(nn.Module):
         x_scale = None
         if isinstance(x, tuple):
             x, x_scale = x
-        return self.down_proj(self.act_fn(self.gate_up_proj(x, x_scale)))
+        act = self.act_fn(self.gate_up_proj(x, x_scale))
+        if isinstance(act, tuple):
+            return self.down_proj(*act)
+        return self.down_proj(act)
 
 
 class KimiSparseMoeBlock(nn.Module):


### PR DESCRIPTION
## What

`KimiMLP` ran the SiTUv2 activation and the per-token FP8 quantization as two
separate passes over the bf16 intermediate. Where `down_proj` resolves to
per-token FP8, this routes through AITER's `situv2_and_mul_quant`, which does
both in a single memory pass and hands `down_proj` its `x_scale` directly.

The quant scheme is resolved with the existing `_effective_layer_quant` helper,
the same way `KimiRMSNormGated` already decides whether to fuse into `o_proj`.
Any case the kernel does not cover falls back to the current path.

## Performance

Activation + quant step, bf16 in / fp8 out, at both Kimi-K3 TP8 shapes:

| tokens | d=768 (shared expert) | d=4224 (dense MLP) |
|-------:|----------------------:|-------------------:|
| 1      | 1.74x | 1.61x |
| 64     | 1.63x | 1.48x |
| 256    | 1.69x | 1.99x |
| 1024   | 2.06x | 2.55x |
| 4096   | 2.72x | 2.51x |
| 16384  | 2.82x | 2.84x |

The kernel is at the measured pure-copy bandwidth ceiling for d >= 2048.

## Accuracy

GSM8K 5-shot, full 1319, TP8 on gfx950, server config per `recipes/Kimi-K3.md`:
flexible-extract **0.9613**, strict-match **0.9621** — within the recipe's
validated range (0.9591-0.9659 / 0.9666).

Output is within 1 ULP of the fp32 reference at every shape tested.

## Dependency

Needs `situv2_and_mul_quant` from AITER: ROCm/aiter#5081.