### PR TITLE
fix(mla): guard the new per-seq q-cum slice on kv_last_page_lens

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -819,13 +819,14 @@ class PagedAttentionImpl(nn.Module):
             # Raw K/V is fed as a block_size=1 flash-layout cache, never shuffled.
             shuffled_kv_cache = False
 
-        # Number of requests this step scheduled, taken from the context rather
-        # than from a companion array's shape. prepare_prefill fills exactly
-        # cu_seqlens_q[:scheduled_bs + 1] and context_lens[:scheduled_bs] and
-        # pads the tail out to running_bs, so this is that width by definition.
-        # block_tables.shape[0] was an indirect proxy for it, and one that is
-        # optional besides -- the base builder uploads a table only when
-        # `has_cached`, so the old narrowing had to special-case its absence.
+        # Requests this step scheduled: the width prepare_prefill fills in
+        # cu_seqlens_q and context_lens before padding the tail to running_bs.
+        #
+        # context.scheduled_bs is batch.total_seqs_num, while the builder sized
+        # these arrays by total_seqs_num_prefill. The two differ only on a batch
+        # carrying decode rows, and such a batch leaves total_tokens_num_prefill
+        # at 0 -- hence is_prefill False, which is the branch this method is
+        # reached from. Every is_prefill batch sets the two counts equal.
         n_seqs = fwd_ctx.context.scheduled_bs
         unified_attention(
             q,

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -819,16 +819,23 @@ class PagedAttentionImpl(nn.Module):
             # Raw K/V is fed as a block_size=1 flash-layout cache, never shuffled.
             shuffled_kv_cache = False
 
-        n_block_rows = attn_metadata.block_tables.shape[0]
+        # Number of requests this step scheduled, taken from the context rather
+        # than from a companion array's shape. prepare_prefill fills exactly
+        # cu_seqlens_q[:scheduled_bs + 1] and context_lens[:scheduled_bs] and
+        # pads the tail out to running_bs, so this is that width by definition.
+        # block_tables.shape[0] was an indirect proxy for it, and one that is
+        # optional besides -- the base builder uploads a table only when
+        # `has_cached`, so the old narrowing had to special-case its absence.
+        n_seqs = fwd_ctx.context.scheduled_bs
         unified_attention(
             q,
             k_for_attn,
             v_for_attn,
             o,
-            # Cut to the rows of the block table this indexes with them: the
-            # prefill builder pads both past the requests it scheduled.
-            cu_seqlens_q=attn_metadata.cu_seqlens_q[: n_block_rows + 1],
-            seqused_k=attn_metadata.context_lens[:n_block_rows],
+            # Cut to the requests actually scheduled: the prefill builder pads
+            # both of these past them.
+            cu_seqlens_q=attn_metadata.cu_seqlens_q[: n_seqs + 1],
+            seqused_k=attn_metadata.context_lens[:n_seqs],
             max_seqlen_q=attn_metadata.max_seqlen_q,
             max_seqlen_k=attn_metadata.max_seqlen_k,
             softmax_scale=self.scale,

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1738,19 +1738,18 @@ class MLAAttention(nn.Module):
             device=q.device,
         )
 
-        # The paged kernels take their batch from the q-cums; cut them to a
-        # per-seq array the prefill builder left unpadded.
+        # The paged kernels take their batch from the q-cums; cut them to the
+        # requests actually scheduled, which is the width prepare_prefill fills
+        # before padding the tail out to running_bs.
         #
-        # Guarded on kv_last_page_lens: AiterMLAMetadataBuilder.prepare_prefill
-        # only fills it when a drafter exists or the batch has a prefix-cache
-        # hit, so a plain first-chunk prefill leaves it None. That was harmless
-        # while the value was merely passed through -- the sparse branch below
-        # overwrites all four of these, and the dense kernels take None -- but
-        # slicing it here raised AttributeError on the first prefill batch.
-        paged_cu_seqlens_q = attn_metadata.cu_seqlens_q
-        if attn_metadata.kv_last_page_lens is not None:
-            n_seqs = attn_metadata.kv_last_page_lens.shape[0]
-            paged_cu_seqlens_q = paged_cu_seqlens_q[: n_seqs + 1]
+        # context.scheduled_bs is batch.total_seqs_num, while the builder sized
+        # these arrays by total_seqs_num_prefill. The two differ only on a batch
+        # carrying decode rows, and such a batch leaves total_tokens_num_prefill
+        # at 0 -- hence is_prefill False, which is the branch this function is
+        # reached from. Every is_prefill batch sets the two counts equal.
+        fwd_context = get_forward_context()
+        n_seqs = fwd_context.context.scheduled_bs
+        paged_cu_seqlens_q = attn_metadata.cu_seqlens_q[: n_seqs + 1]
         paged_kv_indptr = attn_metadata.kv_indptr
         paged_kv_indices = attn_metadata.kv_indices
         kv_last_page_lens = attn_metadata.kv_last_page_lens

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1740,8 +1740,17 @@ class MLAAttention(nn.Module):
 
         # The paged kernels take their batch from the q-cums; cut them to a
         # per-seq array the prefill builder left unpadded.
-        n_seqs = attn_metadata.kv_last_page_lens.shape[0]
-        paged_cu_seqlens_q = attn_metadata.cu_seqlens_q[: n_seqs + 1]
+        #
+        # Guarded on kv_last_page_lens: AiterMLAMetadataBuilder.prepare_prefill
+        # only fills it when a drafter exists or the batch has a prefix-cache
+        # hit, so a plain first-chunk prefill leaves it None. That was harmless
+        # while the value was merely passed through -- the sparse branch below
+        # overwrites all four of these, and the dense kernels take None -- but
+        # slicing it here raised AttributeError on the first prefill batch.
+        paged_cu_seqlens_q = attn_metadata.cu_seqlens_q
+        if attn_metadata.kv_last_page_lens is not None:
+            n_seqs = attn_metadata.kv_last_page_lens.shape[0]
+            paged_cu_seqlens_q = paged_cu_seqlens_q[: n_seqs + 1]
         paged_kv_indptr = attn_metadata.kv_indptr
         paged_kv_indices = attn_metadata.kv_indices
         kv_last_page_lens = attn_metadata.kv_last_page_lens

--- a/atom/plugin/vllm/attention/layer_sparse_mla.py
+++ b/atom/plugin/vllm/attention/layer_sparse_mla.py
@@ -462,11 +462,9 @@ def sparse_attn_indexer_plugin_mode(
         # only equivalent while the query rows are unpadded -- pack_seq_triton
         # above pads to a rectangle, and the kernel would then write past the
         # end. requires_padding is hardcoded False at the one construction site
-        # (attention/metadata.py), so this is unreachable today.
-        #
-        # Not an assert: this guards a buffer overrun, and asserts are stripped
-        # under `python -O`, which would silently restore the overrun exactly
-        # when someone turns padding on.
+        # (attention/metadata.py), so this is unreachable today. Raised rather
+        # than asserted because `python -O` strips asserts, which would restore
+        # the overrun silently exactly when someone turns padding on.
         if decode_metadata.requires_padding:
             raise NotImplementedError(
                 "padded decode rows need logits sized [batch_size * next_n, "

--- a/atom/plugin/vllm/attention/layer_sparse_mla.py
+++ b/atom/plugin/vllm/attention/layer_sparse_mla.py
@@ -457,6 +457,22 @@ def sparse_attn_indexer_plugin_mode(
         batch_size = padded_q_fp8_decode_tokens.shape[0]
         next_n = padded_q_fp8_decode_tokens.shape[1]
         assert batch_size == decode_metadata.seq_lens.shape[0]
+        # deepgemm_fp8_paged_mqa_logits grids over `batch_size * next_n`, so that
+        # is the height its `logits` must have. Sizing off num_decode_tokens is
+        # only equivalent while the query rows are unpadded -- pack_seq_triton
+        # above pads to a rectangle, and the kernel would then write past the
+        # end. requires_padding is hardcoded False at the one construction site
+        # (attention/metadata.py), so this is unreachable today.
+        #
+        # Not an assert: this guards a buffer overrun, and asserts are stripped
+        # under `python -O`, which would silently restore the overrun exactly
+        # when someone turns padding on.
+        if decode_metadata.requires_padding:
+            raise NotImplementedError(
+                "padded decode rows need logits sized [batch_size * next_n, "
+                f"{max_model_len}], got [{num_decode_tokens}, {max_model_len}]; "
+                "see deepgemm_fp8_paged_mqa_logits' grid"
+            )
         logits = torch.empty(
             [num_decode_tokens, max_model_len], dtype=torch.float32, device="cuda"
         )


### PR DESCRIPTION
0b4f1ddba started cutting `paged_cu_seqlens_q` down to the per-seq width by reading `attn_metadata.kv_last_page_lens.shape[0]`. That field is None on the sparse path, so every rank dies on its first prefill batch:

  File "atom/model_ops/attention_mla.py", line 1743, in _forward_prefill_mla
    n_seqs = attn_metadata.kv_last_page_lens.shape[0]
  AttributeError: 'NoneType' object has no attribute 'shape'

Reproduced on GLM-5.2-MXFP4, TP=8, DCP=8: 8 requests arrive, the first prefill batch is scheduled, and ModelRunner1/8 aborts in layer 0 with zero completions.

None is correct there, not a metadata bug. Twelve lines below, `is_sparse_mla` overwrites all four of the values this block computes -- paged_cu_seqlens_q, paged_kv_indptr, paged_kv_indices and kv_last_page_lens -- with their sparse_* counterparts, and the DCP sub-branch sizes its indptr off `sparse_cu_seqlens_q.shape[0]`. The dense per-seq array is never read on that path, so a builder that only serves sparse attention has no reason to fill it. The new line dereferences it before the branch that would have discarded it.

Keep the slice for the dense path and skip it when the array is absent.

Verified: GLM-5.2-MXFP4 TP=8 DCP=8, 65536-token inputs -- 8/8 requests, 32 prefill batches, no traceback, 34.36 s (34.38-34.50 s on the runs before 0b4f1ddba landed).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
