### PR TITLE
Log the KV transfer hot path at debug, not info

### DIFF
--- a/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
+++ b/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
@@ -353,7 +353,7 @@ class MooncakeConnectorScheduler(KVConnectorSchedulerBase):
             )
 
         if self._reqs_need_recv or self._reqs_need_save:
-            logger.info(
+            logger.debug(
                 "[SCHEDULER] build_connector_meta: %d recv, %d save, " "id_map=%s",
                 len(self._reqs_need_recv),
                 len(self._reqs_need_save),
@@ -399,7 +399,7 @@ class MooncakeConnectorScheduler(KVConnectorSchedulerBase):
             elif not seq.has_per_req_cache and self.hash_block_size > 0:
                 num_computed_blocks = seq.num_cached_tokens // self.hash_block_size
             params["num_computed_blocks"] = num_computed_blocks
-            logger.info(
+            logger.debug(
                 "[SCHEDULER-CONSUMER] Queued req %s for remote KV recv "
                 "(%d blocks, %d locally cached, slot=%d), transfer_id=%s, "
                 "remote_host=%s, remote_handshake_port=%s",
@@ -919,7 +919,7 @@ class MooncakeConnector(KVConnectorBase):
                         "slot_index": meta.local_slot_index,
                     }
                     self._completed_prefills_cv.notify_all()
-                logger.info(
+                logger.debug(
                     "[PRODUCER] Cached %d prefill blocks (slot=%d) for req %s",
                     len(meta.local_block_ids),
                     meta.local_slot_index,
@@ -931,7 +931,7 @@ class MooncakeConnector(KVConnectorBase):
         if not metadata.reqs_to_recv:
             return
 
-        logger.info(
+        logger.debug(
             "[CONSUMER] start_load_kv: %d reqs_to_recv, id_map=%s",
             len(metadata.reqs_to_recv),
             metadata.request_id_to_transfer_id,
@@ -1046,7 +1046,7 @@ class MooncakeConnector(KVConnectorBase):
                             self.tp_size,
                         )
                 self._send_on_socket(remote_addr, [MSG_WRITE_REQUEST, write_request])
-                logger.info(
+                logger.debug(
                     "[CONSUMER] write_request sent for req %s (transfer_id=%s) "
                     "to stage %d/%d at %s, off=%d, dst_block_ids=%s",
                     req_id,
@@ -1102,7 +1102,7 @@ class MooncakeConnector(KVConnectorBase):
             self.done_sending.clear()
             self.done_recving.clear()
         if ds or dr:
-            logger.info(
+            logger.debug(
                 "[%s] get_finished: sending=%s, recving=%s",
                 "PRODUCER" if self.is_producer else "CONSUMER",
                 ds,
@@ -1138,7 +1138,7 @@ class MooncakeConnector(KVConnectorBase):
 
                 elif msg_type == MSG_WRITE_REQUEST:
                     request_data = msgpack.loads(parts[2])
-                    logger.info(
+                    logger.debug(
                         "[PRODUCER] Received write_request for req %s "
                         "(transfer_id=%s, consumer=%s:%s)",
                         request_data["request_id"],
@@ -1180,7 +1180,7 @@ class MooncakeConnector(KVConnectorBase):
             self.done_sending.add(transfer_id)
         with self._completed_prefills_lock:
             self._completed_prefills.pop(transfer_id, None)
-        logger.info(
+        logger.debug(
             "[PRODUCER] All %d decode ranks released transfer_id=%s; page freed",
             consumer_tp_size,
             transfer_id,
@@ -1205,7 +1205,7 @@ class MooncakeConnector(KVConnectorBase):
             write_nonce = request_data.get("write_nonce", 0)
             has_slot_data = request_data.get("has_slot_regions", False)
 
-            logger.info(
+            logger.debug(
                 "[PRODUCER] _execute_transfer: req_id=%s, transfer_id=%s, "
                 "consumer=%s:%s, dst_blocks=%d, has_slot_data=%s",
                 req_id,
@@ -1329,7 +1329,7 @@ class MooncakeConnector(KVConnectorBase):
                     # PP-prefill: this stage's write is done, but stage-0 must not
                     # reuse the shared page until ALL stages finish. Freeing is
                     # deferred to _record_release (driven by consumer releases).
-                    logger.info(
+                    logger.debug(
                         "[PRODUCER] stage pp_rank=%d served %d consumers for "
                         "transfer_id=%s; awaiting release",
                         self.pp_rank,
@@ -1341,7 +1341,7 @@ class MooncakeConnector(KVConnectorBase):
                         self.done_sending.add(transfer_id)
                     with self._completed_prefills_lock:
                         self._completed_prefills.pop(transfer_id, None)
-                    logger.info(
+                    logger.debug(
                         "[PRODUCER] All %d consumers served for transfer_id=%s",
                         consumers_per_rank,
                         transfer_id,
@@ -1439,7 +1439,7 @@ class MooncakeConnector(KVConnectorBase):
                 dst_addrs.append(dst_base + db * bpb)
                 sizes.append(bpb)
 
-        logger.info(
+        logger.debug(
             "[PRODUCER] block RDMA write: req=%s, %d regions × %d blocks, "
             "total_bytes=%d",
             req_id,
@@ -1519,7 +1519,7 @@ class MooncakeConnector(KVConnectorBase):
                 block_dst.append(dst_region.unit_addr(db))
                 block_sizes.append(src_region.unit_bytes)
 
-        logger.info(
+        logger.debug(
             "[PRODUCER] block RDMA: req=%s, %d regions × %d blocks, " "total_bytes=%d",
             req_id,
             len(self._block_regions),
@@ -1535,7 +1535,7 @@ class MooncakeConnector(KVConnectorBase):
 
         # ---- Phase 2: Slot transfer ----
         if src_slot < 0 or dst_slot < 0:
-            logger.info(
+            logger.debug(
                 "[PRODUCER] slot transfer skipped (src_slot=%d, dst_slot=%d)",
                 src_slot,
                 dst_slot,
@@ -1573,7 +1573,7 @@ class MooncakeConnector(KVConnectorBase):
             slot_dst.append(consumer_staging_addr)
             slot_sizes.append(self._staging_slot_bytes)
 
-        logger.info(
+        logger.debug(
             "[PRODUCER] slot RDMA: req=%s, %d entries, "
             "src_slot=%d → dst_slot=%d, total_bytes=%d",
             req_id,
@@ -1715,7 +1715,7 @@ class MooncakeConnector(KVConnectorBase):
             }
         )
         self._send_on_socket(path, [MSG_WRITE_DONE, notification], repeat=3)
-        logger.info("[PRODUCER] write-done sent for req %s", req_id)
+        logger.debug("[PRODUCER] write-done sent for req %s", req_id)
 
     # -----------------------------------------------------------------
     # Consumer: notification listener (ZMQ ROUTER)
@@ -1795,7 +1795,7 @@ class MooncakeConnector(KVConnectorBase):
             stages = self._pending_recv_stages.setdefault(req_id, set())
             stages.add((pp_rank, tp_rank))
             if len(stages) < expected:
-                logger.info(
+                logger.debug(
                     "[CONSUMER] Write-done req %s rank (%d,%d) (%d/%d)",
                     req_id,
                     pp_rank,
@@ -1821,7 +1821,7 @@ class MooncakeConnector(KVConnectorBase):
         with self._completion_lock:
             self.done_recving.add(req_id)
             self._pending_recv.discard(req_id)
-        logger.info(
+        logger.debug(
             "[CONSUMER] Write-done received for req %s (all stages), "
             "done_recving now: %s",
             req_id,

--- a/atom/kv_transfer/disaggregation/moriio/moriio_connector.py
+++ b/atom/kv_transfer/disaggregation/moriio/moriio_connector.py
@@ -659,7 +659,7 @@ class MoRIIOConnector(KVConnectorBase):
                 if msg == MoRIIOConstants.GET_META_MSG:
                     # Phase 1: send engine metadata
                     sock.send_multipart((identity, b"", encoded_data))
-                    logger.info("Handshake: sent engine metadata to peer")
+                    logger.debug("Handshake: sent engine metadata to peer")
                     # Phase 2: send per-layer KV cache metadata
                     buf = msgpack.dumps(layer_name_to_local_kv_cache_metadata)
                     sock.send_multipart((identity, b"", buf))
@@ -769,7 +769,7 @@ class MoRIIOConnector(KVConnectorBase):
         thread safety).  Once all complete, the request is placed on
         ``_ready_requests`` for RDMA reads.
         """
-        logger.info(
+        logger.debug(
             "Initiating background handshake for req %s -> %s",
             req_id,
             remote_engine_id,
@@ -781,7 +781,7 @@ class MoRIIOConnector(KVConnectorBase):
         remote_dp_size = int(meta.remote_dp_size)
 
         def _on_all_done(_f: Future[Any], entry=(req_id, meta)):
-            logger.info("All handshakes completed for req %s", req_id)
+            logger.debug("All handshakes completed for req %s", req_id)
             self._ready_requests.put(entry)
             self.load_ready_flag[remote_engine_id] = True
             self.write_ready_flags[remote_engine_id] = True

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -1645,7 +1645,7 @@ class Scheduler:
             )
             self.waiting.extend(skipped_waiting_requests)
 
-        if self._num_parked_remote_kv > 0 and self._schedule_tick % 100 == 0:
+        if self._num_parked_remote_kv > 0 and self._schedule_tick % 1000 == 0:
             logger.info(
                 "PD backpressure: parked=%d, waiting=%d, running=%d, "
                 "resident=%d/%d, kv_usage=%.2f",
@@ -1793,7 +1793,7 @@ class Scheduler:
                 if not is_first or has_injected_t0:
                     self.block_manager.may_append(seq, num_new_tokens)
                 if is_first:
-                    logger.info(
+                    logger.debug(
                         "[PD-FIRST-DECODE] seq %s: num_tokens=%d, "
                         "blocks=%d, injected_t0=%s, "
                         "last_block_num=%d, context_will_be=%d",
@@ -2025,7 +2025,7 @@ class Scheduler:
                 for d in drafts:
                     seq.append_token(int(d))
                 seq.spec_token_ids = np.asarray(drafts, dtype=np.int32)
-        logger.info(
+        logger.debug(
             "[PD-TRANSITION] seq %s: num_tokens=%d, "
             "num_prompt=%d, blocks=%d, first_token=%s, "
             "last_5_tids=%s",
@@ -2581,7 +2581,7 @@ class Scheduler:
                 seq.spec_token_ids = draft_token_ids[idx]
 
             if seq.num_completion_tokens <= 3 and seq.kv_transfer_params:
-                logger.info(
+                logger.debug(
                     "[PD-DECODE] seq %s: comp_tokens=%d, "
                     "new_token=%s, num_tokens=%d, blocks=%d",
                     seq.id,
@@ -2723,7 +2723,7 @@ class Scheduler:
                 )
 
                 if request_output.kv_transfer_params_output is not None:
-                    logger.info("KV transfer output present in stream output.")
+                    logger.debug("KV transfer output present in stream output.")
 
                 stream_outputs.append((seq.id, request_output))
                 logger.debug(


### PR DESCRIPTION
Every per-request and per-step step of a PD KV transfer was logged at info: the consumer's write_request, the producer's receipt of it, the RDMA write itself, the per-rank and all-stage write-done notifications, start_load_kv, get_finished, build_connector_meta, and the per-seq PD transition/first-decode/decode lines in the scheduler. At 48-way concurrency and pp=4 that is ~36 lines per request on the consumer and ~16 on the producer, which buries the startup and failure lines that actually need reading.

Move those to debug. A one-hour 4842-request run drops from 403k to 25k decode lines and from 599k to 228k prefill lines (of which 196k are LMCache's own pin-timeout and allocation warnings, not ours).

Startup and registration lines stay at info, as do every warning, error and exception on the transfer paths. PD backpressure also stays at info — it reports a real stall — but now prints every 1000 schedule ticks instead of every 100.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
