### PR TITLE
fix(loader): zero packed fp4x2 dummy weights via byte-view fallback

### DIFF
--- a/atom/model_loader/loader.py
+++ b/atom/model_loader/loader.py
@@ -200,10 +200,17 @@ def initialize_dummy_weights(model: nn.Module, mode: str) -> None:
     for name, param in model.named_parameters():
         data = param.data
         if mode == "zero":
-            # zero_() works in place for every dtype (incl. fp4x2/fp8/int) and
-            # every shape; a uint8 byte-view would crash on 0-dim scalar or
-            # non-contiguous params (view requires stride(-1)==1, dim>0).
-            data.zero_()
+            # zero_() is the fast path: valid for every shape and every
+            # standard dtype (fp8/int/bf16/...). Packed sub-byte dtypes
+            # (e.g. Float4_e2m1fn_x2) have no CUDA fill kernel, so zero_()
+            # raises ("fill_cuda" not implemented for that dtype); fall back
+            # to zeroing the raw bytes instead (all-zero bytes == zero-valued
+            # weights). Only packed weights reach the fallback, and those are
+            # contiguous and >=1D, so the uint8 view is always valid there.
+            try:
+                data.zero_()
+            except (NotImplementedError, RuntimeError):
+                data.view(torch.uint8).zero_()
             continue
         # mode == "xavier"
         dt = data.dtype

--- a/tests/test_dummy_weight_init.py
+++ b/tests/test_dummy_weight_init.py
@@ -107,6 +107,42 @@ class TestDummyWeightInit(unittest.TestCase):
         for name, p in m.named_parameters():
             self.assertTrue((p == 0).all(), f"{name} not all-zero in zero mode")
 
+    def test_zero_mode_packed_dtype_fallback(self):
+        # Regression guard: real packed sub-byte weights (Float4_e2m1fn_x2) have
+        # no CUDA fill kernel, so data.zero_() raises RuntimeError ("fill_cuda"
+        # not implemented). initialize_dummy_weights must catch that and zero the
+        # raw bytes via the uint8 view. We simulate the missing kernel by making
+        # the first zero_() call raise, then confirm the bytes end up zeroed.
+        from unittest import mock
+
+        import torch
+        from torch import nn
+
+        from atom.model_loader.loader import initialize_dummy_weights
+
+        m = nn.Module()
+        packed = nn.Parameter(
+            torch.full((2, 4), 7, dtype=torch.uint8), requires_grad=False
+        )
+        m.register_parameter("packed_weight", packed)
+
+        orig_zero = torch.Tensor.zero_
+        state = {"raised": False}
+
+        def flaky_zero(self):
+            # Fail once on the direct data.zero_() to mimic the missing fp4x2
+            # CUDA fill kernel; the byte-view fallback then uses the real impl.
+            if not state["raised"]:
+                state["raised"] = True
+                raise RuntimeError('"fill_cuda" not implemented for packed dtype')
+            return orig_zero(self)
+
+        with mock.patch.object(torch.Tensor, "zero_", flaky_zero):
+            initialize_dummy_weights(m, "zero")
+
+        self.assertTrue(state["raised"], "primary zero_() path was not exercised")
+        self.assertTrue((m.packed_weight == 0).all(), "byte-view fallback did not zero")
+
     def test_e8m0_unit_code_matches_target_std(self):
         # _E8M0_UNIT_CODE must decode (2^(code-127)) to _DUMMY_WEIGHT_STD so the
         # fp4 effective magnitude (fp4=1.0 * 2^(code-127)) matches the intended


### PR DESCRIPTION
## Summary
- `initialize_dummy_weights(mode="zero")` in `atom/model_loader/loader.py` zeroed every param with `data.zero_()`, but packed sub-byte dtypes (`Float4_e2m1fn_x2`) have no CUDA fill kernel — `zero_()` raises `RuntimeError: "fill_cuda" not implemented for ...`. This crashed `--load_dummy=zero` on MXFP4 checkpoints.
- Keep `data.zero_()` as the fast path (valid for all shapes and standard dtypes) and fall back to `data.view(torch.uint8).zero_()` when it raises. All-zero bytes == zero-valued weights; only packed weights (contiguous, ≥1D) reach the fallback, so the uint8 view is always valid there.
- Catch both `RuntimeError` (ATen dtype-dispatch miss) and `NotImplementedError` (backend-dispatch miss) to cover both ways PyTorch surfaces a missing fill kernel.

## Why the byte-view is only in the fallback
The prior comment on the `zero` branch already noted a raw `view(torch.uint8)` crashes on 0-dim scalars / non-contiguous params. Keeping `zero_()` primary preserves correct behavior for scales and odd shapes; the byte-view runs only for the packed weights that actually lack a fill kernel, which are always contiguous ≥1D.

## Test plan
- [x] `black` + `ruff check` clean on both files
- [x] Fix + test-mock logic validated in isolation on CPU (primary `zero_()` forced to raise → byte-view fallback zeroes the tensor)
- [x] Added `test_zero_mode_packed_dtype_fallback` regression guard (forces the fallback path; existing `test_zero_mode` only mocked fp4x2 as plain uint8, which never exercised the failing branch)
- [ ] GPU CI runs `tests/test_dummy_weight_init.py` (module is `importorskip("aiter")`-gated, skipped on the non-GPU gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)