### PR TITLE
perf(v4): build the decode indptrs on the device, and bound compress per token

### DIFF
--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -96,10 +96,14 @@ from atom.model_ops.attentions.v4_pool_geometry import (
     UnifiedPoolGeometry,
     WindowParams,
     merge_abutting,
+    require_step_within_full_q,
+    visible_csa,
+    visible_hca,
 )
 from atom.model_ops.v4_kernels import (
     FP4_MQA_BLOCK_K,
     FP4_MQA_PARALLEL_UNIT_NUM,
+    build_v4_paged_decode_indptr,
     fp4_indexer_enabled,
     write_v4_paged_decode_indices,
     write_v4_paged_prefill_indices,
@@ -179,14 +183,11 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     state_slot_out_cpu: Any | None = None
     """[bs] np.int32 — per-seq state cache slot id (host copy)."""
     n_committed_csa_per_seq_cpu: Any | None = None
-    """[bs] np.int32 — `ctx_len // 4` (CSA committed K per seq). Built once
-    in `_attach_v4_per_fwd_meta` from `var["context_lens"].np`; consumed by
-    `_attach_v4_paged_decode_meta`, `_build_paged_prefill_meta`, and
-    `_build_v4_indexer_meta` (indptr cumsums). Single source of truth so
-    those callers don't each re-read context_lens + divide."""
-    n_committed_hca_per_seq_cpu: Any | None = None
-    """[bs] np.int32 — `ctx_len // 128` (HCA committed compress entries per
-    seq). Same lifecycle as `n_committed_csa_per_seq_cpu`."""
+    """[bs] np.int32 — `ctx_len // 4` (CSA committed K per seq). Built once in
+    `_attach_v4_per_fwd_meta` from `var["context_lens"].np`; the one consumer is
+    `_attach_v4_indexer_meta`'s `cu_committed` cumsum, which concatenates the
+    sequences' committed K and so needs the per-SEQUENCE total. Per-token counts
+    do not come from here — see `visible_csa` in `v4_pool_geometry`."""
 
     # ----- Per-seq GPU scalars (single-source-of-truth, shared by kernels) -----
     state_slot_out: torch.Tensor | None = None
@@ -201,10 +202,10 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     `state_slot_out` when nothing forked would make the distinction unreplayable
     the moment one does."""
     n_committed_csa_per_seq: torch.Tensor | None = None
-    """[bs] int32 GPU — RAW `ctx_len // 4` per-seq committed count. Consumed
-    by the indexer and csa_translate_pack. Decode additionally stages
-    `n_committed_per_token`, because the generic aiter top-k needs the exact
-    ratio-4 per-token bound rather than only this per-sequence count."""
+    """[bs] int32 GPU — RAW `ctx_len // 4` per-seq committed count. Consumed by
+    the FP4 ragged window build (`compute_varqlen_windows`), which lays out one
+    window per SEQUENCE. `csa_translate_pack` does not read it: it recovers each
+    token's `valid_k` from its own indptr delta."""
 
     # DSpark RAGGED (paper §5.2): per-request ragged verify lengths [bs] int32
     # (len_i = ell_i+1). None => regular rectangular decode. Set by
@@ -223,12 +224,6 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     tail [T:padded_T] = -1 sentinel; consumer kernels skip on `bid < 0`. All
     other per-token quantities resolved as `per_seq_data[batch_id_per_token[t]]`
     — no [T] aliases of seq data."""
-    batch_id_per_token_cpu: Any | None = None
-    """[T] int32 — CPU mirror of the unpadded batch_id slice. Built once in
-    `_attach_v4_per_fwd_meta` (host-side `np.repeat`); reused by
-    `_attach_v4_paged_decode_meta` for indptr fancy-index math. Avoids a
-    duplicate `np.repeat` per fwd. None for prefill paths that don't go
-    through paged_decode_meta (it's only consumed there)."""
     compress_plans: dict[int, Any] | None = None
     """dict[ratio:int -> CompressPlan] — packed plan tensors per
     compress_ratio (4=CSA, 128=HCA)."""
@@ -244,11 +239,13 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     """[csa_indptr[T]] int32 GPU — packed paged offsets for CSA layers
     (CSA topk compress at slice head + SWA window prefix at tail; topk section
     filled per-layer by csa_translate_pack)."""
-    n_committed_per_token: torch.Tensor | None = None
+    csa_n_committed_per_token: torch.Tensor | None = None
     """int32 GPU — uncapped CSA visibility end for each decode query row.
     Flat for rectangular decode and FP4 ragged; right-aligned `[bs*full_q]`
     for FP8 ragged. Shared by MQA logits and top-k with `next_n=1`; unlike
-    the output allocation length, this is NOT capped by `index_topk`."""
+    the output allocation length, this is NOT capped by `index_topk`. Named
+    for its class: HCA has a per-token count of its own, and the bare name read
+    as if it covered both."""
     block_tables_per_token: torch.Tensor | None = None
     """int32 GPU `[decode_rows, block_table_cols]` — compressed-cache block
     table expanded from sequences to query rows by a device-side gather. It
@@ -263,11 +260,12 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     sentinel for CG-padded slots."""
     kv_indptr_csa: torch.Tensor | None = None
     """[padded_T+1] int32 GPU — packed cumsum of per-token CSA kv_len
-    (= `min(positions[t]+1, win) + min((positions[t]+1)//4,
-    n_committed_csa[bid], index_topk)`). Padded tail = last value."""
+    (= `min(positions[t]+1, win) + min((positions[t]+1)//4, index_topk)`).
+    Padded tail = last value."""
     kv_indptr_hca: torch.Tensor | None = None
     """[padded_T+1] int32 GPU — packed cumsum of per-token HCA kv_len
-    (= `min(positions[t]+1, win) + n_committed_hca[bid]`). Padded tail = last value."""
+    (= `min(positions[t]+1, win) + (positions[t]+1)//128`). Padded tail = last
+    value."""
     envelope_rows: int = 0
     """Rows one V4 block takes across every layer of the pool — the stride from
     one block's compressed rows to the next in a layer's view of a plane. What
@@ -337,20 +335,20 @@ class AttentionMetaData_DSV4(AttentionMetaData):
     kv_indptr_prefix_swa: torch.Tensor | None = None
     """[total_tokens + 1] int32 GPU — packed cumsum of `prefix_swa_count`."""
     kv_indices_prefix_csa: torch.Tensor | None = None
-    """[sum(prefix_swa_count + min(n_csa, index_topk))] int32 GPU — CSA topk
-    (head) + SWA history (tail) per token. CSA section is filled per-layer by
+    """[sum(prefix_swa_count + min((positions[t]+1)//4, index_topk))] int32 GPU
+    — CSA topk (head) + SWA history (tail) per token. Filled per-layer by
     `csa_translate_pack`; SWA prefix section is filled by builder at the slice
     tail (head-CSA / tail-SWA convention, matching decode, #1116)."""
     kv_indptr_prefix_csa: torch.Tensor | None = None
     """[total_tokens + 1] int32 GPU — packed cumsum of
-    `prefix_swa_count + min(n_committed_csa, index_topk)`."""
+    `prefix_swa_count + min((positions[t]+1)//4, index_topk)`."""
     kv_indices_prefix_hca: torch.Tensor | None = None
-    """[sum(prefix_swa_count + n_committed_hca)] int32 GPU — SWA history
-    (head) + HCA all-committed compress entries (tail). Layer-invariant,
-    fully filled by builder."""
+    """[sum(prefix_swa_count + (positions[t]+1)//128)] int32 GPU — SWA history
+    (head) + the HCA groups closed at or before the token's own position
+    (tail). Layer-invariant, fully filled by builder."""
     kv_indptr_prefix_hca: torch.Tensor | None = None
     """[total_tokens + 1] int32 GPU — packed cumsum of
-    `prefix_swa_count + n_committed_hca`."""
+    `prefix_swa_count + (positions[t]+1)//128`."""
     kv_indices_extend: torch.Tensor | None = None
     """[sum(extend_count)] int32 GPU — flat row offsets into the per-fwd
     `kv` tensor (in-chunk SWA tail) for the extend region. Layer-invariant
@@ -2049,8 +2047,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         _ls = self._v4_fp4_ragged_local_starts[:_padded]
         _le = self._v4_fp4_ragged_local_ends[:_padded]
         compute_varqlen_windows(cu_seq_q, _ncmt, _padded, out=(_rtb, _ls, _le))
-        if attn_metadata.n_committed_per_token is not None:
-            _le.copy_(attn_metadata.n_committed_per_token[:_padded])
+        if attn_metadata.csa_n_committed_per_token is not None:
+            _le.copy_(attn_metadata.csa_n_committed_per_token[:_padded])
         # Fixed logits width (max_model_len_idx) → the scorer's [padded, W] buffer
         # is a static shape (CG-capturable), same as the rectangular decode path.
         compute_prefill_schedule(
@@ -2088,16 +2086,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         (set by `_attach_v4_per_fwd_meta`, which MUST run first) for the
         per-seq committed count and cumsums it on CPU.
 
-        Reuses two shared GPU tensors also set by `_attach_v4_per_fwd_meta`:
-          - `attn_metadata.batch_id_per_token`        [padded_T] int32
-          - `attn_metadata.n_committed_csa_per_seq`   [bs] int32
+        Reuses `attn_metadata.batch_id_per_token` ([padded_T] int32), also set
+        by `_attach_v4_per_fwd_meta`.
 
-        DECODE fast path: returns a minimal dict with only
-        `n_committed_per_seq_gpu` (the single field `_score_topk_decode`
-        reads). The cumsum + H2D + per-token GPU derivations below are all
-        prefill-only — `deepgemm_fp8_paged_mqa_logits` + `top_k_per_row_decode`
-        operate directly on paged KV via `n_committed_per_seq_gpu`, never on
-        the packed-cumsum / per-token `cu_starts/cu_ends` layout.
+        DECODE fast path: returns an empty dict, plus the FP4 schedule below
+        when that indexer is on. Everything else here is prefill-only —
+        `deepgemm_fp8_paged_mqa_logits` and `top_k_per_row_decode` read paged KV
+        through `attn_metadata.csa_n_committed_per_token`, never the
+        packed-cumsum / per-token `cu_starts/cu_ends` layout this builds.
 
         The FP8 indexer K-cache write happens inside `fused_compress_attn`
         (the unified Indexer-inner Compressor path) via the same block_tables
@@ -2109,18 +2105,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # prepare_*/CG-capture path).
         bs = scheduled_bs
 
-        # DECODE short-circuit: the only field `_score_topk_decode` consumes is
-        # `n_committed_per_seq_gpu`, which is the same tensor as
-        # `attn_metadata.n_committed_csa_per_seq` (already staged by
-        # `_attach_v4_per_fwd_meta`). The prefill-only derivations below
-        # (CPU cumsum + H2D for `cu_committed_gpu`; 7 GPU launches for
-        # `seq_base`/`visible_end`/`cu_ends`) feed `_score_topk_prefill` only
-        # (cp_gather + fp8_mqa_logits + per-row prefill top-k), so they are
+        # DECODE short-circuit: the decode scorers take no field from this dict
+        # except the FP4 schedule added below. The prefill-only derivations
+        # further down (CPU cumsum + H2D for `cu_committed_gpu`; GPU launches
+        # for `seq_base`/`visible_end`/`cu_ends`) feed `_score_topk_prefill`
+        # only (cp_gather + fp8_mqa_logits + per-row prefill top-k), so they are
         # dead work on the decode hot path. ~50μs / fwd saved at bs=1024.
         if attn_metadata.state is AttnState.DECODE:
-            meta = {
-                "n_committed_per_seq_gpu": attn_metadata.n_committed_csa_per_seq,
-            }
+            meta = {}
             # DSpark RAGGED (varlen) decode uses the varlen path
             # (`_score_topk_decode_ragged_fp4` → `flydsl_pa_mqa_logits_fp4_prefill`).
             # Its per-row windows are built HERE (layer-invariant, once per fwd)
@@ -2162,7 +2154,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 # Single-kernel schedule written straight into the fixed-address
                 # buffer (no intermediate alloc + copy). ~50 tiny torch launches
                 # -> 1 Triton launch (~300us -> ~40us per decode step).
-                _ncmt_sched = attn_metadata.n_committed_per_token[
+                _ncmt_sched = attn_metadata.csa_n_committed_per_token[
                     : positions_gpu.shape[0]
                 ]
                 compute_varctx_schedule(
@@ -2177,7 +2169,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 meta["fp4_total_ctas"] = self._fp4_parallel_unit_num
             return meta
 
-        ratio = 4  # CSA — also referenced by `visible_end_gpu` below
         n_committed_per_seq = attn_metadata.n_committed_csa_per_seq_cpu[:bs]
         cu_committed_cpu = np.concatenate(
             [
@@ -2202,15 +2193,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         cu_committed_cpu[-1] = max(int(cu_committed_cpu[-1]), 1)
         total_committed = int(cu_committed_cpu[-1])
 
-        # batch_id_per_token + n_committed_csa: reuse the shared GPU
-        # tensors set in `_attach_v4_per_fwd_meta` (which MUST run before
-        # this helper — see prepare_decode/prefill ordering). batch_id is
-        # int32 (accepted by PyTorch advanced-indexing); n_committed is int32
-        # too — it is the gather SOURCE so any dtype works, and both downstream
-        # kernels — `deepgemm_fp8_paged_mqa_logits`, `top_k_per_row_decode`
-        # — want int32 anyway.
+        # batch_id_per_token: reuse the shared GPU tensor set in
+        # `_attach_v4_per_fwd_meta` (which MUST run before this helper — see
+        # prepare_decode/prefill ordering). int32, which PyTorch accepts for
+        # advanced-indexing and both downstream kernels want anyway.
         batch_id_per_token_gpu = attn_metadata.batch_id_per_token[:total_tokens]
-        n_committed_per_seq_gpu = attn_metadata.n_committed_csa_per_seq
         # cu_committed_gpu is consumed both as `cu_starts/cu_ends` for the
         # fp8_mqa_logits per-token range AND as `cu_seq_lens` for the
         # cp_gather_indexer_k_quant_cache call (per-seq cumulative committed K).
@@ -2227,12 +2214,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # subtraction base for prefill `top_k_per_row_prefill`'s GLOBAL output
         # → seq-local conversion (the indexer kernel writes
         # `seq_base + col_in_seq`; we recover col_in_seq by subtracting).
-        visible_end_gpu = torch.minimum(
-            (positions_gpu[:total_tokens] + 1) // ratio,
-            n_committed_per_seq_gpu[batch_id_per_token_gpu],
-        ).to(
+        visible_end_gpu = visible_csa(positions_gpu[:total_tokens]).to(
             torch.int32
-        )  # [total_tokens] int32 — per-token causal upper bound
+        )  # [total_tokens] int32 — causal upper bound, see `v4_pool_geometry`
         cu_ends_gpu = (
             seq_base_per_token_gpu + visible_end_gpu
         )  # [total_tokens] int32 — fp8_mqa_logits per-token end offset
@@ -2240,7 +2224,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         meta = {
             "total_committed": total_committed,
             "cu_committed_gpu": cu_committed_gpu,
-            "n_committed_per_seq_gpu": n_committed_per_seq_gpu,  # int32, [bs]
             "batch_id_per_token_gpu": batch_id_per_token_gpu,  # int32, [total_tokens]
             # Prefill-only fields below — decode never consults them. NOT
             # in pre-allocated buffers (per-fwd derived); CG capture path
@@ -2375,7 +2358,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # `prepare_decode`.
         actual_swa = torch.clamp(positions + 1, max=win)
 
-        swa_indptr = var["v4_kv_indptr_swa"].gpu[: running_bs + 1]
+        swa_indptr = var["v4_kv_indptr_swa"][: running_bs + 1]
         # positions/actual_swa are int64 (eagle's positions buffer); cast to
         # int32 inside cumsum to match swa_indptr's int32 storage.
         torch.cumsum(actual_swa, dim=0, dtype=torch.int32, out=swa_indptr[1:])
@@ -2483,9 +2466,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # would skip ahead by `num_rejected` and the rejected slots would
         # never be overwritten with the corrected K/V. `num_rejected` is None
         # on dummy runs and on the first fwd before any sampler output.
-        # Bound n_committed_csa/hca via the rolled-back ctx (n_committed_* =
-        # ctx // 4 / 128 in `_attach_v4_paged_decode_meta`), so block_tables
-        # truncation isn't needed here — the per-token kv_len already shrinks.
+        # The rolled-back ctx is also what anchors `positions` (at `ctx -
+        # full_q`, below), and every compress count is now `visible_*(pos)`, so
+        # a rejected slot's KV falls out of range on its own — `block_tables`
+        # needs no truncation here.
         if not batch.is_dummy_run and max_seqlen_q > 1:
             num_rejected = self.model_runner.tokenID_processor.num_rejected
             if num_rejected is not None:
@@ -2501,6 +2485,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             # positions via per-seq cumsum + in-seg arange, span-head anchored:
             # token j of seq i -> (ctx_i - full_q) + j.
             lens = np.asarray(ragged_lens, dtype=np.int32)[:scheduled_bs]
+            # The last token of seq i lands on `ctx_i - full_q + len_i - 1`, so
+            # the whole invariant reduces to one comparison here.
+            require_step_within_full_q(
+                int(lens.max()) if lens.size else 0, full_q, "a DSpark ragged step"
+            )
             cu = np.zeros(scheduled_bs + 1, dtype=np.int64)
             np.cumsum(lens, out=cu[1:])
             batch_ids = np.repeat(np.arange(scheduled_bs, dtype=np.int32), lens)
@@ -2509,6 +2498,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             )
             positions_np = (context_lens_np - full_q)[batch_ids] + j_in_seq
         else:
+            # One scalar on the rectangle: every sequence forwards the same
+            # `max_seqlen_q` tokens.
+            require_step_within_full_q(
+                max_seqlen_q, full_q, "a rectangular decode step"
+            )
             positions_np = np.tile(
                 np.arange(max_seqlen_q, dtype=np.int32), scheduled_bs
             ) + np.repeat(context_lens_np - full_q, max_seqlen_q)
@@ -3039,8 +3033,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # --- rebuild indexer metadata from the sliced batch_id + positions ---
         # Its per-token fields (seq_base/cu_starts/cu_ends/visible_end) all
         # derive from batch_id_per_token + positions, so rebuilding with the
-        # sliced inputs yields the 1/W layout; per-seq fields (cu_committed,
-        # n_committed_per_seq) stay full. Skip if the model has no CSA/indexer.
+        # sliced inputs yields the 1/W layout; the per-seq field (cu_committed)
+        # stays full. Skip if the model has no CSA/indexer.
         if attn_metadata.indexer_meta is not None:
             local_tokens = owned_q.shape[0]
             attn_metadata.indexer_meta = self._build_v4_indexer_meta(
@@ -3238,8 +3232,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
                 im["cu_committed_gpu"] = im["cu_committed_gpu"].clone()
             if im.get("batch_id_per_token_gpu") is not None:
                 im["batch_id_per_token_gpu"] = im["batch_id_per_token_gpu"].clone()
-            if im.get("n_committed_per_seq_gpu") is not None:
-                im["n_committed_per_seq_gpu"] = im["n_committed_per_seq_gpu"].clone()
 
         return ub_attn
 
@@ -3300,8 +3292,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             ].contiguous()
         if src.n_committed_csa_per_seq_cpu is not None:
             ub.n_committed_csa_per_seq_cpu = src.n_committed_csa_per_seq_cpu[rs0:rs1]
-        if src.n_committed_hca_per_seq_cpu is not None:
-            ub.n_committed_hca_per_seq_cpu = src.n_committed_hca_per_seq_cpu[rs0:rs1]
 
         # ---- per-token DSV4 fields sliced by the GLOBAL token range [gts,gte) ----
         owned = torch.arange(gts, gte, device=device)
@@ -3379,7 +3369,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             for k in (
                 "cu_committed_gpu",
                 "batch_id_per_token_gpu",
-                "n_committed_per_seq_gpu",
             ):
                 if im.get(k) is not None:
                     im[k] = im[k].clone()
@@ -3410,8 +3399,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             paged-decode kernels and the indexer). `swa_write` no longer
             depends on this — it derives `src_id` from `cu_seqlens_q` inline.
           - `attn_metadata.n_committed_csa_per_seq`: [bs] int32 per-seq
-            `ctx_len // 4` (shared by csa_translate_pack + indexer; kernels
-            do their own `min(., index_topk)` clamp via mask).
+            `ctx_len // 4`, for the two consumers that are genuinely per-seq —
+            the indexer's `cu_committed` cumsum and the FP4 ragged windows.
           - `attn_metadata.state_slot_out`: [bs] int32 GPU view of
             per-seq state cache slot (already set by prepare_*; passed
             through unchanged here).
@@ -3450,28 +3439,23 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         var = self.model_runner.forward_vars
 
         # ---- CPU numpy work (all on main thread) ----
-        # Build the unpadded mapping once; the padded GPU staging buffer wraps
-        # it (head = real, tail = -1 sentinel). Stash the unpadded slice on
-        # attn_metadata so `_attach_v4_paged_decode_meta` reuses it instead of
-        # re-running `np.repeat(arange, token_num_per_seq)` (saves ~10μs/fwd
-        # at bs=1024 + one allocation).
-        batch_id_unpadded_np = np.repeat(
+        # The mapping exists on the host only to be staged: head = real, tail =
+        # -1 sentinel, and every consumer downstream is a kernel reading the
+        # device copy.
+        batch_id_per_token_np = np.full(padded_total_tokens, -1, dtype=np.int32)
+        batch_id_per_token_np[:scheduled_tokens] = np.repeat(
             np.arange(scheduled_bs, dtype=np.int32), token_num_per_seq
         )
-        batch_id_per_token_np = np.full(padded_total_tokens, -1, dtype=np.int32)
-        batch_id_per_token_np[:scheduled_tokens] = batch_id_unpadded_np
-        attn_metadata.batch_id_per_token_cpu = batch_id_unpadded_np
 
         # context_lens is int32 on the buffer; keep dtype through divide so
-        # n_committed_{csa,hca} stay int32 (max value ~max_model_len // 4 ≪ 2^31).
+        # n_committed_csa stays int32 (max value ~max_model_len // 4 ≪ 2^31).
         ctx_per_seq_np = var[f"{buf_prefix_ubatch}context_lens"].np[:scheduled_bs]
-        # Single source of truth for n_committed_{csa,hca}_per_seq on CPU.
-        # Stashed on attn_metadata so paged_decode_meta / paged_prefill_meta /
-        # v4_indexer_meta can read instead of each re-running `ctx // k`.
+        # Single source of truth for n_committed_csa_per_seq on CPU. Stashed on
+        # attn_metadata so `_attach_v4_indexer_meta` reads it instead of
+        # re-running `ctx // 4`. HCA has no twin here: every consumer wants the
+        # count a TOKEN may see, which is `(pos+1)//128`.
         n_committed_csa_per_seq_np = ctx_per_seq_np // 4
-        n_committed_hca_per_seq_np = ctx_per_seq_np // 128
         attn_metadata.n_committed_csa_per_seq_cpu = n_committed_csa_per_seq_np
-        attn_metadata.n_committed_hca_per_seq_cpu = n_committed_hca_per_seq_np
 
         # ---- Stage all buffers to GPU ----
         # window_topk used to be CPU-built here ([T, win] of ring indices with
@@ -3504,7 +3488,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.n_committed_csa_per_seq = n_csa_buf.copy_to_gpu(scheduled_bs)
         self._attach_v4_paged_decode_meta(
             attn_metadata=attn_metadata,
-            token_num_per_seq=token_num_per_seq,
             state_slot_out_cpu=state_slot_out_cpu,
             scheduled_bs=scheduled_bs,
             total_tokens=scheduled_tokens,
@@ -3515,7 +3498,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
     def _attach_v4_paged_decode_meta(
         self,
         attn_metadata,
-        token_num_per_seq,
         state_slot_out_cpu,
         scheduled_bs: int,
         total_tokens: int,
@@ -3525,10 +3507,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         """Phase B: build per-fwd paged-decode index buffers (layer-invariant).
 
         All three per-token regions are RAGGED-PACKED — same layout family as
-        the prefill path (`_build_paged_prefill_meta`). Per-token slot count:
-          SWA: actual_swa_count = min(positions[t]+1, win)
-          CSA: actual_swa_count + min(n_committed_csa, index_topk)
-          HCA: actual_swa_count + n_committed_hca
+        the prefill path (`_build_paged_prefill_meta`). Per-token slot count,
+        with `n = min(positions[t]+1, win)`:
+          SWA: n
+          CSA: n + min((pos+1)//4, index_topk)
+          HCA: n + (pos+1)//128
+        The cumsums and the CSA visibility are built by
+        `build_v4_paged_decode_indptr` — one launch, no host arithmetic, no H2D.
 
         Writes into stable forward_vars buffers (attn_metadata fields are
         the V4-namespaced counterparts on `AttentionMetaData_DSV4`):
@@ -3548,10 +3533,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         Reuses (built earlier in `_attach_v4_per_fwd_meta`):
           - batch_id_per_token : single per-token mapping (with -1 sentinel)
-          - n_committed_csa_per_seq : per-seq `ctx_len // 4`
           - var["positions"] : global token positions (already H2D-copied by
-                               the caller; consumed by the index-write kernel
-                               + CPU-side actual_swa_count cumsum here)
+                               the caller; consumed by both kernels here)
+        `n_committed_csa_per_seq` is NOT among them: every count wanted here is
+        one a TOKEN may see, and that follows from its position.
 
         Skipped when state is not DECODE. The Phase-B fields
         (kv_indices_*, kv_indptr_*, envelope_rows) stay at their dataclass
@@ -3576,46 +3561,12 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         T = total_tokens
 
-        # ----- Per-seq scalars (CPU numpy) -----
-        # The single per-token mapping. Built once in `_attach_v4_per_fwd_meta`
-        # — both the GPU staging tensor and the unpadded CPU mirror — so we
-        # just borrow both here. int32 (numpy fancy-index source dtype is
-        # irrelevant; consumers below produce int32 outputs).
-        batch_id_per_token_np = attn_metadata.batch_id_per_token_cpu  # [T] int32
+        # The single per-token mapping, staged once in `_attach_v4_per_fwd_meta`.
+        # Only the device copy is wanted here now: every consumer below is a
+        # kernel, so the host mirror this used to fancy-index has no reader.
         batch_id_per_token_gpu = attn_metadata.batch_id_per_token
 
-        # Read pre-computed `ctx // {4,128}` from attn_metadata — populated by
-        # `_attach_v4_per_fwd_meta` (always runs first). int32.
-        n_committed_csa_per_seq = attn_metadata.n_committed_csa_per_seq_cpu
-        n_committed_hca_per_seq = attn_metadata.n_committed_hca_per_seq_cpu
-
-        # ----- 3 indptr cumsums (CPU numpy, ragged) -----
-        # Per-token kv_len = actual_swa_count + n_compress. CSA length now
-        # matches Indexer's per-row visibility exactly (= csa_translate_pack
-        # kernel's per-token valid_k formula), so buffer reserves only the
-        # cells the kernel actually writes — no `-1` sentinel pre-fill, no
-        # over-allocation for tokens with per-row visibility < seq-level
-        # n_csa (which happens for early tokens in chunked-prefill verify
-        # batches and MTP draft mid-iters).
         index_topk = self.index_topk
-        positions_np_view = var[f"{buf_prefix_ubatch}positions"].np[:T]
-        n_committed_hca_per_token = n_committed_hca_per_seq[batch_id_per_token_np]
-
-        # actual_swa_count[t] = min(positions[t]+1, win). Matches the kernel's
-        # inline `n = tl.minimum(pos+1, win)` so SWA-prefix segment sizes line
-        # up perfectly. `var["positions"]` is the int64 CpuGpuBuffer populated
-        # + H2D-copied by the caller (prepare_decode / build_for_cudagraph_capture).
-        actual_swa_count_np = np.minimum(positions_np_view + 1, win).astype(np.int32)
-        # Candidate visibility and output capacity are different quantities:
-        # MQA/top-k must scan every causally visible compressed row, while the
-        # translated output reserves at most `index_topk` entries.
-        csa_visible_end_per_token = np.minimum(
-            (positions_np_view + 1) // 4,
-            n_committed_csa_per_seq[batch_id_per_token_np],
-        ).astype(np.int32)
-        csa_valid_k_per_token = np.minimum(
-            csa_visible_end_per_token, index_topk
-        ).astype(np.int32)
 
         # CG-padding-aware T_for_indptr: indptr buffer must size to the
         # captured kernel grid (= padded_total_tokens) so padded slots see
@@ -3625,42 +3576,22 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
         T_pad = max(T_pad, T)
 
-        # All three indptr cumsums output int32 directly. Values are bounded
-        # (T ≤ mnbt=8192, per-tok ≤ win + index_topk ≈ 2200 → max cumsum ~18M,
-        # well within int32).
-        # SWA: ragged, per-token len = actual_swa_count[t].
-        swa_indptr_np = np.zeros(T_pad + 1, dtype=np.int32)
-        swa_indptr_np[1 : T + 1] = np.cumsum(actual_swa_count_np, dtype=np.int32)
-        if T_pad > T:
-            swa_indptr_np[T + 1 :].fill(int(swa_indptr_np[T]))
-        # CSA: ragged, per-token len = actual_swa_count + csa_valid_k_per_token
-        csa_per_tok = actual_swa_count_np + csa_valid_k_per_token
-        csa_indptr_np = np.zeros(T_pad + 1, dtype=np.int32)
-        csa_indptr_np[1 : T + 1] = np.cumsum(csa_per_tok, dtype=np.int32)
-        if T_pad > T:
-            csa_indptr_np[T + 1 :].fill(int(csa_indptr_np[T]))
-        n_committed_per_token_np = np.zeros(T_pad, dtype=np.int32)
-        n_committed_per_token_np[:T] = csa_visible_end_per_token
+        # DSpark's fp8 indexer wants the per-token visibility laid out as one
+        # row per SLOT of a `full_q`-wide rectangle, right-aligned per sequence,
+        # rather than one row per token. It is the same number either way — only
+        # where it lands differs, which is why the rectangle is a parameter of
+        # the builder below and not a second builder.
         full_q = int(getattr(attn_metadata, "dspark_full_q", 0))
-        if full_q > 0 and not self._indexer_fp4:
-            ragged_lens_np = np.asarray(
-                token_num_per_seq[:scheduled_bs], dtype=np.int32
-            )
+        rect_full_q = full_q if (full_q > 0 and not self._indexer_fp4) else 0
+        if rect_full_q:
             ragged_lens_gpu = getattr(attn_metadata, "dspark_ragged_lens_gpu", None)
             rect_bs = max(
                 scheduled_bs,
                 int(ragged_lens_gpu.shape[0]) if ragged_lens_gpu is not None else 0,
             )
-            n_committed_per_token_np = np.zeros(rect_bs * full_q, dtype=np.int32)
-            cu = np.zeros(scheduled_bs + 1, dtype=np.int32)
-            np.cumsum(ragged_lens_np, out=cu[1:], dtype=np.int32)
-            token_ids = np.arange(T, dtype=np.int32)
-            bids = batch_id_per_token_np[:T]
-            in_seq = token_ids - cu[bids]
-            rect_dst = bids * full_q + (full_q - ragged_lens_np[bids]) + in_seq
-            n_committed_per_token_np[rect_dst] = csa_visible_end_per_token
             # Rows are `full_q` slots per sequence, so row r serves seq
             # r // full_q, and the rows past the batch are the tail.
+            mqa_rows = rect_bs * full_q
             mqa_valid_rows = scheduled_bs * full_q
             mqa_row_to_batch_gpu = torch.arange(
                 mqa_valid_rows, dtype=torch.int32, device=self.device
@@ -3668,15 +3599,65 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         else:
             # One row per query token, so the row -> seq map is the one
             # already staged for this forward.
+            mqa_rows = T_pad
             mqa_valid_rows = T
             mqa_row_to_batch_gpu = batch_id_per_token_gpu[:T]
+
+        # A `[:n]` slice past the end truncates silently, so the bounds are
+        # checked rather than relied on — `_stage` used to carry them. Two host
+        # scalars cover every buffer below, because `_alloc_v4_metadata_buffers`
+        # sizes all of them off `max_decode_tokens` times a per-token worst case
+        # no token can exceed. Checking a pool's actual sum would need a D2H —
+        # the one sync this build exists to avoid.
+        #
+        # `ValueError`, not `assert`, for the reason `require_step_within_full_q`
+        # gives: a truncated slice is a device-side out-of-bounds write, and
+        # `python -O` strips asserts. The rect `mqa_rows` has no second line of
+        # defence — `build_v4_paged_decode_indptr` recomputes its band count from
+        # whatever length it is handed, so a short buffer looks well-formed.
+        if T_pad > self.max_decode_tokens:
+            raise ValueError(
+                f"V4 decode built {T_pad} tokens but the index buffers are sized "
+                f"for {self.max_decode_tokens} (max_bs * (1 + max_spec_steps))."
+            )
+        if mqa_rows > self.max_decode_tokens:
+            raise ValueError(
+                f"V4 decode wants {mqa_rows} indexer rows but the per-token "
+                f"buffers hold {self.max_decode_tokens}. Increase "
+                f"max_decode_tokens."
+            )
+
+        # The three ragged cumsums and the CSA per-token visibility, in one
+        # launch off buffers already resident, replacing three numpy cumsums and
+        # four H2D copies of arrays whose inputs never left the device.
+        swa_indptr_gpu = var[f"{buf_prefix_ubatch}v4_kv_indptr_swa"][: T_pad + 1]
+        csa_indptr_gpu = var[f"{buf_prefix_ubatch}v4_kv_indptr_csa"][: T_pad + 1]
+        hca_indptr_gpu = var[f"{buf_prefix_ubatch}v4_kv_indptr_hca"][: T_pad + 1]
+        csa_ncmt_gpu = var[f"{buf_prefix_ubatch}v4_csa_n_committed_per_token"][
+            :mqa_rows
+        ]
+        build_v4_paged_decode_indptr(
+            batch_id_per_token=batch_id_per_token_gpu,
+            positions=var[f"{buf_prefix_ubatch}positions"].gpu,
+            swa_indptr=swa_indptr_gpu,
+            csa_indptr=csa_indptr_gpu,
+            hca_indptr=hca_indptr_gpu,
+            csa_n_committed_per_token=csa_ncmt_gpu,
+            T_pad=T_pad,
+            win=win,
+            index_topk=index_topk,
+            rect_full_q=rect_full_q,
+            ragged_lens=attn_metadata.dspark_ragged_lens_gpu if rect_full_q else None,
+            cu_q_per_seq=(
+                var[f"{buf_prefix_ubatch}cu_seqlens_q"].gpu if rect_full_q else None
+            ),
+        )
 
         # Expand block tables per query row so the unchanged aiter paged-MQA
         # kernels can run once with shape `[decode_rows, 1, ...]`. Source and
         # index are both on the device, so the gather runs there instead of the
         # host shipping the expansion; the rows it skips are the tail.
         mqa_bt = var[f"{buf_prefix_ubatch}v4_block_tables_per_token"]
-        mqa_rows = n_committed_per_token_np.shape[0]
         block_tables_per_token_gpu = mqa_bt[:mqa_rows]
         torch.index_select(
             var[f"{buf_prefix_ubatch}block_tables"].gpu,
@@ -3686,43 +3667,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         )
         if mqa_valid_rows < mqa_rows:  # an empty `zero_` still costs a dispatch
             block_tables_per_token_gpu[mqa_valid_rows:].zero_()
-        # HCA: ragged, per-token len = actual_swa_count + n_committed_hca
-        hca_per_tok = actual_swa_count_np + n_committed_hca_per_token
-        hca_indptr_np = np.zeros(T_pad + 1, dtype=np.int32)
-        hca_indptr_np[1 : T + 1] = np.cumsum(hca_per_tok, dtype=np.int32)
-        if T_pad > T:
-            hca_indptr_np[T + 1 :].fill(int(hca_indptr_np[T]))
 
-        swa_indptr_gpu = self._stage(
-            f"{buf_prefix_ubatch}v4_kv_indptr_swa", swa_indptr_np
-        )
-        csa_indptr_gpu = self._stage(
-            f"{buf_prefix_ubatch}v4_kv_indptr_csa", csa_indptr_np
-        )
-        n_committed_per_token_gpu = self._stage(
-            f"{buf_prefix_ubatch}v4_n_committed_per_token",
-            n_committed_per_token_np,
-        )
-        hca_indptr_gpu = self._stage(
-            f"{buf_prefix_ubatch}v4_kv_indptr_hca", hca_indptr_np
-        )
-        # batch_id_per_token + n_committed_csa_per_seq already staged in
-        # `_attach_v4_per_fwd_meta`.
-
-        # `ctx/128` HCA entries per token: building this section in numpy and
-        # shipping it was the largest host cost here. The kernel below fills it
-        # from block tables already on the device, tiling each slice exactly
+        # HCA compress section: the kernel below fills it from block tables
+        # already on the device, tiling each slice exactly
         # with the SWA prefix, so nothing pre-fills the buffer.
         hca_indices_buf = var[f"{buf_prefix_ubatch}v4_kv_indices_hca"]
-        hca_total_indices = int(hca_indptr_np[T])
-        # `_stage` carried this bound; without it an over-long slice would be a
-        # silent out-of-bounds device write.
-        assert hca_total_indices <= hca_indices_buf.shape[0], (
-            f"V4 buffer 'v4_kv_indices_hca' too small: need {hca_total_indices}, "
-            f"have {hca_indices_buf.shape[0]}. Increase the bound in "
-            f"_alloc_v4_metadata_buffers."
-        )
-        hca_indices_gpu = hca_indices_buf[:hca_total_indices]
 
         # ----- Write SWA / CSA / HCA window-prefix paged offsets (1 kernel) -----
         # Kernel computes `n = min(positions[t]+1, win)` and ring-index
@@ -3755,7 +3704,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             hca_indptr=hca_indptr_gpu,
             swa_indices=swa_indices_gpu,
             csa_indices=csa_indices_gpu,
-            hca_indices=hca_indices_gpu,
+            hca_indices=hca_indices_buf,
             dest_rows=dest_rows,
             T=T,
             win=win,
@@ -3768,11 +3717,11 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         # `skip_prefix_len_csa` is not materialized on the decode path —
         # `csa_translate_pack` is invoked with `window_size = self.window_size`
-        # so the kernel derives `skip = min(positions[t]+1, win)` inline,
-        # which is identical to the value this used to write
-        # (`actual_swa_count_np`). Saves a CPU write + H2D per fwd. Prefill
-        # cannot derive it from positions (skip depends on `chunk_start`) and
-        # uploads its own tensor in `_build_paged_prefill_meta`.
+        # so the kernel derives `skip = min(positions[t]+1, win)` inline, which
+        # is the same `n` the indptr build above sizes each SWA prefix by.
+        # Saves a CPU write + H2D per fwd. Prefill cannot derive it from
+        # positions (skip depends on `chunk_start`) and uploads its own tensor
+        # in `_build_paged_prefill_meta`.
 
         # ----- Stash on attn_metadata for V4Attention.forward consumption -----
         # batch_id_per_token + n_committed_csa_per_seq already set in
@@ -3792,11 +3741,12 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # and `csa_translate_pack`'s grid comes from `topk_local.shape`. Both now
         # sit in a dense piece keyed on num_tokens alone, so this matters under
         # plain PIECEWISE too. `prepare_mtp_decode` (~:2381) and the sglang
-        # bridge already publish these whole. HCA keeps its slice as the
-        # write-side bound above, where the capacity assert can catch an overrun.
+        # bridge already publish these whole. HCA is published the same way: its
+        # capacity is checked on the premises (`T_pad` against the per-token
+        # worst case the pool is sized for) rather than on the sum.
         attn_metadata.kv_indices_swa = swa_indices_gpu
         attn_metadata.kv_indices_csa = csa_indices_gpu
-        attn_metadata.n_committed_per_token = n_committed_per_token_gpu
+        attn_metadata.csa_n_committed_per_token = csa_ncmt_gpu
         attn_metadata.block_tables_per_token = block_tables_per_token_gpu
         attn_metadata.kv_indices_hca = hca_indices_buf
         attn_metadata.kv_indptr_swa = swa_indptr_gpu
@@ -3839,9 +3789,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         """Build per-fwd index buffers consumed by sparse_attn_v4_paged_prefill.
 
         Two-source layout:
-          - prefix region (per-ratio): SWA history from prior chunks +
-            CSA topk OR HCA all-committed from `unified_kv`. Three buffers
-            (Dense / CSA / HCA) per fwd.
+          - prefix region (per-ratio): SWA history from prior chunks + CSA topk
+            OR the HCA groups closed at or before the token's own position,
+            from `unified_kv`. Three buffers (Dense / CSA / HCA) per fwd.
           - extend region (shared): in-chunk SWA tail from per-fwd `kv`
             tensor. One buffer.
 
@@ -3852,8 +3802,8 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         Per-ratio prefix kv_len:
           Dense:  prefix_swa_count[t]
-          CSA:    prefix_swa_count[t] + min(n_committed_csa[bid], index_topk)
-          HCA:    prefix_swa_count[t] + n_committed_hca[bid]
+          CSA:    prefix_swa_count[t] + min((p_global+1)//4, index_topk)
+          HCA:    prefix_swa_count[t] + (p_global+1)//128
 
         Eager-only (chunked prefill is dynamic-shaped; no CG capture). Per-fwd
         `torch.from_numpy(...).to(device, non_blocking=True)` avoids stream drain.
@@ -3911,31 +3861,14 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         extend_count_np = np.minimum(token_pos_in_chunk + 1, win).astype(np.int32)
         prefix_swa_count_np = np.maximum(chunk_start_pt - swa_low, 0).astype(np.int32)
-        n_committed_csa_per_seq_np = attn_metadata.n_committed_csa_per_seq_cpu
-        n_committed_hca_per_seq_np = attn_metadata.n_committed_hca_per_seq_cpu
-        # Per-token CSA valid_k = Indexer's per-row visibility, matching
-        # `_attach_v4_indexer_meta`'s `visible_end_gpu` formula and the
-        # `csa_translate_pack` kernel's inline computation. Buffer size ↔
-        # kernel-writes match exactly, so no `-1` sentinel pre-fill is needed.
+        # These SIZE each slice while `_v4_paged_prefill_indices_kernel` FILLS
+        # it, so both must stay the geometry's spelling or the tail is
+        # uninitialized. Buffer size ↔ kernel-writes then match exactly and no
+        # `-1` sentinel pre-fill is needed.
         csa_valid_k_per_token_np = np.minimum(
-            np.minimum(
-                (positions_arr + 1) // 4,
-                n_committed_csa_per_seq_np[batch_id_per_token_np],
-            ),
-            index_topk,
+            visible_csa(positions_arr), index_topk
         ).astype(np.int32)
-        # Per-token CAUSAL HCA visibility (mirrors CSA above and the reference
-        # `get_compress_topk_idxs` prefill mask): token at `pos` sees only the
-        # `(pos+1)//128` HCA groups committed up to its own position, capped by
-        # the per-seq committed count. Without `(pos+1)//128`, every token used
-        # the per-seq `ctx_end//128`, over-reading FUTURE groups and making a
-        # token's output depend on the forward's total length (chunked breaks).
-        # MUST stay in sync with the kernel's inline cap in
-        # `_v4_paged_prefill_indices_kernel` (HCA_RATIO).
-        n_hca_per_token_np = np.minimum(
-            (positions_arr + 1) // 128,
-            n_committed_hca_per_seq_np[batch_id_per_token_np],
-        ).astype(np.int32)
+        n_hca_per_token_np = visible_hca(positions_arr).astype(np.int32)
 
         # 4 indptrs on CPU; last element = total (no D2H to size buffers).
         ext_indptr_np = np.zeros(T + 1, dtype=np.int32)
@@ -3962,10 +3895,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # the indptrs are `T + 1` long: 64 KB at mnbt 16384, over the pageable
         # cliff at mnbt 131072.
         chunk_start_per_seq_gpu = upload_numpy(chunk_start_per_seq_np, device)
-        n_committed_hca_per_seq_gpu = upload_numpy(
-            np.asarray(n_committed_hca_per_seq_np[:scheduled_bs], dtype=np.int32),
-            device,
-        )
         ext_indptr = upload_numpy(ext_indptr_np, device)
         swa_indptr = upload_numpy(swa_indptr_np, device)
         csa_indptr = upload_numpy(csa_indptr_np, device)
@@ -4016,7 +3945,6 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             chunk_start_per_seq=chunk_start_per_seq_gpu,
             cu_seqlens_q_per_seq=cu_q_per_seq_gpu,
             state_slot_per_seq=state_slot_per_seq_gpu,
-            n_committed_hca_per_seq=n_committed_hca_per_seq_gpu,
             block_tables=block_tables_gpu,
             extend_indptr=ext_indptr,
             prefix_swa_indptr=swa_indptr,
@@ -4354,6 +4282,15 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             and drafter.uses_confidence_schedule
         ):
             full_q_real = drafter.mtp_k + 1
+            # `max_q_len` is the bucket loop's parameter and these lengths are
+            # derived from it, so nothing here ties them to the drafter's
+            # `full_q` -- the same check `prepare_decode` makes on the batch it
+            # was handed.
+            require_step_within_full_q(
+                int(extend_lens_np.max()) if extend_lens_np.size else 0,
+                full_q_real,
+                "a captured DSpark graph",
+            )
             pad_to = self._dspark_ragged_lens_pad_to(bs)
             if pad_to is not None:
                 # AF + DP: the core captured here bakes this tensor's address, so
@@ -4529,10 +4466,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         bufs["v4_kv_indices_hca"] = torch.zeros(
             T_dec * (win + self.max_committed_hca), **i32
         )
-        bufs["v4_kv_indptr_swa"] = CpuGpuBuffer(T_dec + 1, **i32)
-        bufs["v4_kv_indptr_csa"] = CpuGpuBuffer(T_dec + 1, **i32)
-        bufs["v4_kv_indptr_hca"] = CpuGpuBuffer(T_dec + 1, **i32)
-        bufs["v4_n_committed_per_token"] = CpuGpuBuffer(T_dec, **i32)
+        # Device-only for the same reason: `build_v4_paged_decode_indptr` writes
+        # all four from tensors already resident, so a host mirror would only
+        # ever hold whatever the last host-built forward left in it.
+        bufs["v4_kv_indptr_swa"] = torch.zeros(T_dec + 1, **i32)
+        bufs["v4_kv_indptr_csa"] = torch.zeros(T_dec + 1, **i32)
+        bufs["v4_kv_indptr_hca"] = torch.zeros(T_dec + 1, **i32)
+        bufs["v4_csa_n_committed_per_token"] = torch.zeros(T_dec, **i32)
         # Device-only, and as wide as the `block_tables` it gathers from: a host
         # mirror would be `T_dec * cols * 4` of pinned memory nothing writes.
         bufs["v4_block_tables_per_token"] = torch.zeros(
@@ -4549,16 +4489,15 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         # (`mla_decode_fwd_v4_nm`, page_size=1). Values are CONSTANT — they
         # depend only on the (padded) decode token count N, not the batch:
         #   qo_indptr        = arange(N+1)   (per-token q indptr, max_seqlen_q=1)
-        # Built the SAME way as `kv_indptr_*`: a CpuGpuBuffer re-staged via
-        # `self._stage(...)` EVERY fwd, which is what makes them CUDAGraph-safe
-        # (re-copied into the captured buffer before graph.replay). The constant
-        # numpy sources are precomputed once so the per-fwd cost is a slice + H2D.
+        # A CpuGpuBuffer re-staged via `self._stage(...)` EVERY fwd, which is
+        # what makes it CUDAGraph-safe (re-copied into the captured buffer
+        # before graph.replay). The constant numpy source is precomputed once so
+        # the per-fwd cost is a slice + H2D.
         bufs["v4_qo_indptr"] = CpuGpuBuffer(T_dec + 1, **i32)
         self._v4_qo_indptr_np = np.arange(T_dec + 1, dtype=np.int32)
-        # Per-seq `ctx_len // 4` (raw, no clamp). Consumed by csa_translate_pack
-        # (kernel masks `(k < n_committed) & (k < index_topk)`) AND by the
-        # indexer (cast to int64 inline). Built unconditionally in
-        # `_attach_v4_per_fwd_meta`.
+        # Per-seq `ctx_len // 4` (raw, no clamp). Consumed by the indexer's
+        # `cu_committed` cumsum and the FP4 ragged windows — both per-SEQUENCE.
+        # Built unconditionally in `_attach_v4_per_fwd_meta`.
         bufs["v4_n_committed_csa_per_seq"] = CpuGpuBuffer(bs, **i32)
         # Single per-token mapping shared across ALL V4 consumers:
         #   - swa_write / csa_translate_pack (triton kernels)
@@ -4697,10 +4636,10 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             bufs[f"{p}v4_kv_indices_hca"] = torch.zeros(
                 T_dec * (win + self.max_committed_hca), **i32
             )
-            bufs[f"{p}v4_kv_indptr_swa"] = CpuGpuBuffer(T_dec + 1, **i32)
-            bufs[f"{p}v4_kv_indptr_csa"] = CpuGpuBuffer(T_dec + 1, **i32)
-            bufs[f"{p}v4_kv_indptr_hca"] = CpuGpuBuffer(T_dec + 1, **i32)
-            bufs[f"{p}v4_n_committed_per_token"] = CpuGpuBuffer(T_dec, **i32)
+            bufs[f"{p}v4_kv_indptr_swa"] = torch.zeros(T_dec + 1, **i32)
+            bufs[f"{p}v4_kv_indptr_csa"] = torch.zeros(T_dec + 1, **i32)
+            bufs[f"{p}v4_kv_indptr_hca"] = torch.zeros(T_dec + 1, **i32)
+            bufs[f"{p}v4_csa_n_committed_per_token"] = torch.zeros(T_dec, **i32)
             bufs[f"{p}v4_block_tables_per_token"] = torch.zeros(
                 T_dec, self.block_table_cols, **i32
             )

--- a/atom/model_ops/attentions/v4_pool_geometry.py
+++ b/atom/model_ops/attentions/v4_pool_geometry.py
@@ -72,6 +72,50 @@ DENSE_RATIO = 0
 CSA_RATIO = 4
 HCA_RATIO = 128
 
+# A token sees the compressed groups closed at or before its OWN position. The
+# per-sequence `ctx // ratio` is the LAST token's count, and an MTP or DSpark
+# sequence hands `1 + k` tokens to one forward, so the earlier ones would read
+# groups holding their own future drafts. It is not a second cap either: it
+# cannot bind while `pos < ctx`, which `require_step_within_full_q` keeps true
+# at ATOM's producers of per-seq step lengths. The plugin bridges inherit the
+# same premise from the host engine's `positions` and do not check it.
+#
+# Every host-side count comes from these two. The Triton kernels take the ratio
+# as a `constexpr` and divide inline; keep the spellings identical.
+
+
+def visible_csa(pos):
+    """CSA groups visible to the token at `pos` — int, numpy array or tensor."""
+    return (pos + 1) // CSA_RATIO
+
+
+def visible_hca(pos):
+    """HCA groups visible to the token at `pos` — int, numpy array or tensor."""
+    return (pos + 1) // HCA_RATIO
+
+
+def require_step_within_full_q(longest: int, full_q: int, source: str) -> None:
+    """A sequence may not forward more tokens in one step than `full_q`.
+
+    This is what `pos < ctx` reduces to, so ATOM's three producers of per-seq
+    forward lengths check it rather than assume it. Two things break together
+    when it fails. `positions` are anchored at `ctx - full_q`, so a longer step
+    puts its last token at or past `ctx` -- the one case where the per-sequence
+    bound the rule above drops would have bound something. And the DSpark
+    rectangle's `lead = full_q - len` goes negative, so
+    `_v4_decode_indptr_kernel` maps a whole band and reads tokens past the
+    sequence's span, stamping one sequence's visibility onto another's rows.
+
+    `ValueError`, not `assert`: the second failure is a device-side
+    out-of-bounds read, and `python -O` strips asserts.
+    """
+    if longest > full_q:
+        raise ValueError(
+            f"{source} forwards {longest} tokens for some sequence but full_q "
+            f"is {full_q}, which would place a token past its own context"
+        )
+
+
 # Not a compress ratio: a layer whose KV this row space does not hold at all.
 # A DSpark draft layer wants its window at a width the planes do not offer —
 # unquantized where the pool is packed — so the window becomes a state field

--- a/atom/model_ops/v4_kernels/__init__.py
+++ b/atom/model_ops/v4_kernels/__init__.py
@@ -35,6 +35,8 @@ from atom.model_ops.v4_kernels.paged_decode import (
     sparse_attn_v4_paged_decode_reference,
 )
 from atom.model_ops.v4_kernels.paged_decode_indices import (
+    build_v4_paged_decode_indptr,
+    build_v4_paged_decode_indptr_reference,
     hca_compress_paged_offsets,
     write_v4_paged_decode_indices,
     write_v4_paged_decode_indices_reference,
@@ -64,6 +66,8 @@ __all__ = [
     "FP4_MQA_PARALLEL_UNIT_NUM",
     "CompressPlan",
     "QKNormRopeOut",
+    "build_v4_paged_decode_indptr",
+    "build_v4_paged_decode_indptr_reference",
     "csa_translate_pack",
     "csa_translate_pack_reference",
     "fp4_indexer_enabled",

--- a/atom/model_ops/v4_kernels/csa_translate_pack.py
+++ b/atom/model_ops/v4_kernels/csa_translate_pack.py
@@ -82,11 +82,11 @@ def _csa_translate_pack_kernel(
     # Per-token valid_k is derived from the indptr delta we already need to
     # load anyway:
     #   kv_indptr_csa[t+1] - kv_indptr_csa[t] = skip[t] + valid_k[t]
-    # (CPU builder packs `(prefix_swa_count_or_actual_swa) + csa_valid_k`
-    # per token — see `_attach_v4_paged_decode_meta` / `_build_paged_prefill_meta`).
+    # (both builders pack `(prefix_swa_count_or_actual_swa) + csa_valid_k` per
+    # token — `build_v4_paged_decode_indptr` on the device for decode,
+    # `_build_paged_prefill_meta` on the host for prefill).
     # Reading the delta replaces the previous chain
-    # `min(min((pos+1)//ratio, n_csa_seq), index_topk)` — eliminates the
-    # `n_csa_seq` load and the `(pos+1)//ratio` compute, and stays
+    # `min((pos+1)//ratio, index_topk)` — eliminates that compute, and stays
     # CORRECT under the aiter `top_k_per_row_*` contract which only writes
     # `[0, min(k, row_length))` (the tail is uninitialized garbage from
     # `torch.empty`, never -1 — aiter tests confirm via `compare_topk_results`
@@ -158,9 +158,10 @@ def csa_translate_pack(
 
     Per-token `valid_k` is recovered from `kv_indptr_csa[t+1] - kv_indptr_csa[t]
     - skip[t]`, which equals the Indexer's per-row visibility
-    (`min((pos+1)//ratio, n_committed_csa[bid], index_topk)`) by construction
-    of the CPU-side indptr builders (see `_attach_v4_paged_decode_meta`,
-    `_build_paged_prefill_meta`). aiter's `top_k_per_row_*` writes only
+    (`min((pos+1)//ratio, index_topk)`) by construction of the indptr builders
+    (`build_v4_paged_decode_indptr` on the device for decode,
+    `_build_paged_prefill_meta` on the host for prefill). aiter's
+    `top_k_per_row_*` writes only
     `[0, valid_k)` and leaves the tail UNINITIALIZED (`torch.empty`, no
     `-1` fill), so the explicit `k_offs < valid_k` mask is what keeps the
     kernel correct — the previous `topk >= 0` check would NOT have been a

--- a/atom/model_ops/v4_kernels/paged_decode_indices.py
+++ b/atom/model_ops/v4_kernels/paged_decode_indices.py
@@ -1,9 +1,13 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
 
-"""V4 paged-decode index scatter — single Triton kernel writes SWA window-
-prefix paged offsets into the three ragged-packed destination buffers
-(`kv_indices_swa` / `kv_indices_csa` / `kv_indices_hca`).
+"""V4 paged-decode index scatter — two Triton kernels, one per half of the job.
+
+`build_v4_paged_decode_indptr` sizes each token's slice and prefix-sums the
+three ragged layouts; `write_v4_paged_decode_indices` then fills the SWA
+window-prefix paged offsets into the three destination buffers
+(`kv_indices_swa` / `kv_indices_csa` / `kv_indices_hca`). Call them in that
+order — the writer reads the indptrs the builder wrote.
 
 The window row is computed inline inside the kernel from `positions[t]` via
 `pool_index.window_row` — no `[T, win]` window_topk staging buffer, no separate
@@ -23,9 +27,10 @@ Caller contract:
 - `batch_id_per_token[:T]` may carry `-1` sentinels in the CG-padded tail —
   kernel checks and bails (matches `_attach_v4_per_fwd_meta` convention).
 - `swa_indptr` / `csa_indptr` / `hca_indptr` must reflect the ragged-packed
-  sizing: per-token slot count = `min(positions[t]+1, win) + n_compress[t]`
-  where `n_compress[t]` is 0 for SWA, `min(n_committed_csa, index_topk)`
-  for CSA, `n_committed_hca` for HCA.
+  sizing: per-token slot count = `min(positions[t]+1, win) + n_compress[t]`,
+  where `n_compress[t]` is 0 for SWA, `min((pos+1)//4, index_topk)` for CSA and
+  `(pos+1)//128` for HCA — per-token counts, see `v4_pool_geometry`. The
+  builder above does that; a caller supplying its own indptrs owes the same.
 - `swa_indices` / `csa_indices` / `hca_indices` capacity ≥ corresponding
   indptr[T]; this kernel writes the SWA-prefix segment at the slice tail
   `[indptr[t+1] - n, indptr[t+1])` per token, and — given
@@ -234,8 +239,8 @@ def _v4_paged_decode_indices_kernel(
         )
         if HCA_FROM_BT:
             # Compress section, at the slice HEAD. Its length is not passed in:
-            # the slice was sized `n + n_committed_hca[bid]`, so what the SWA
-            # prefix leaves is exactly the committed count — the two tile the
+            # the slice was sized `n + (positions[t]+1)//HCA_RATIO`, so what the SWA
+            # prefix leaves is exactly that count — the two tile the
             # slice, which is why nothing pre-fills it.
             hca_start = tl.load(hca_indptr_ptr + t)
             n_hca = hca_end - hca_start - n
@@ -479,3 +484,290 @@ def write_v4_paged_decode_indices_reference(
             rows = [params[ratio].index(slot, int(q)) for q in abs_pos]
             buf[end - n : end] = torch.tensor(rows, dtype=buf.dtype, device=buf.device)
             dest_rows[ratio][t] = params[ratio].index(slot, p)
+
+
+# ---------------------------------------------------------------------------
+# The three indptr cumsums the writer above consumes, plus the CSA per-token
+# visibility the indexer consumes. One launch, no host arithmetic and no H2D:
+# every input already lives on the device for other reasons.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _v4_decode_indptr_kernel(
+    batch_id_per_token_ptr,  # [T_pad] int — -1 sentinel in the CG-padded tail
+    positions_ptr,  # [T_pad] int — global token position (int64 in production)
+    ragged_lens_ptr,  # [bs] int32 — DSpark per-seq query count (RECT only)
+    cu_q_ptr,  # [bs] int32 — per-seq first token index (RECT only)
+    swa_indptr_ptr,  # [T_pad+1] int32 OUT
+    csa_indptr_ptr,  # [T_pad+1] int32 OUT
+    hca_indptr_ptr,  # [T_pad+1] int32 OUT
+    csa_n_committed_ptr,  # [T_pad] or [rect_bs*rect_full_q] int32 OUT
+    t_pad,  # token count including the CG pad — RUNTIME, see below
+    n_committed_rows,  # length of the visibility output, whichever layout
+    rect_full_q,  # rectangle width; only read when IS_RECT
+    WIN: tl.constexpr,
+    CSA_R: tl.constexpr,
+    HCA_R: tl.constexpr,
+    INDEX_TOPK: tl.constexpr,
+    IS_RECT: tl.constexpr,  # False = token-indexed output; True = DSpark rect
+    BLOCK: tl.constexpr,
+):
+    """One program: a running offset per class over `t_pad` tokens, then the
+    CSA visibility over `n_committed_rows` destination rows.
+
+    A prefix sum has to see every earlier token, so this is one serial scan
+    rather than a grid. Against a 1.7us launch floor every multi-launch
+    alternative loses on the floor alone, and the whole path is launch-bound
+    anyway (host 13-15us vs 3.5-5.7us on device), so the parallel rewrites that
+    look tempting here buy stream time nobody is waiting on. Measurements in
+    `/app/logs_claude/v4_indptr_scan_measure.md`.
+
+    `t_pad` is a runtime argument on purpose: eager decode hands a fresh token
+    count almost every step, and a `constexpr` would make each one its own JIT
+    variant -- a build meant to save host work paying for it in recompiles.
+
+    Both compress counts come from the token's own position; the rule and why
+    the per-sequence one was dropped live next to `CSA_RATIO` in
+    `v4_pool_geometry`. The draft mid-step never gets here -- `prepare_mtp_decode`
+    rebuilds SWA alone.
+    """
+    tl.store(swa_indptr_ptr, 0)
+    tl.store(csa_indptr_ptr, 0)
+    tl.store(hca_indptr_ptr, 0)
+    acc_swa = 0
+    acc_csa = 0
+    acc_hca = 0
+    for base in tl.range(0, t_pad, BLOCK):
+        idx = base + tl.arange(0, BLOCK)
+        in_range = idx < t_pad
+        bid = tl.load(batch_id_per_token_ptr + idx, mask=in_range, other=-1)
+        # A padded slot contributes 0 to every class, which is what makes the
+        # tail of each indptr flat — the `kv_len == 0` the readers bail on.
+        live = in_range & (bid >= 0)
+        pos = tl.load(positions_ptr + idx, mask=live, other=0).to(tl.int32)
+        n = tl.minimum(pos + 1, WIN)
+        n_csa = (pos + 1) // CSA_R
+        n_hca = (pos + 1) // HCA_R
+        # Visibility and output capacity are different quantities: the indexer
+        # scans every causally visible row, the translated output reserves at
+        # most `index_topk` of them.
+        cnt_swa = tl.where(live, n, 0)
+        cnt_csa = tl.where(live, n + tl.minimum(n_csa, INDEX_TOPK), 0)
+        cnt_hca = tl.where(live, n + n_hca, 0)
+        tl.store(
+            swa_indptr_ptr + idx + 1,
+            acc_swa + tl.cumsum(cnt_swa, axis=0),
+            mask=in_range,
+        )
+        tl.store(
+            csa_indptr_ptr + idx + 1,
+            acc_csa + tl.cumsum(cnt_csa, axis=0),
+            mask=in_range,
+        )
+        tl.store(
+            hca_indptr_ptr + idx + 1,
+            acc_hca + tl.cumsum(cnt_hca, axis=0),
+            mask=in_range,
+        )
+        acc_swa += tl.sum(cnt_swa)
+        acc_csa += tl.sum(cnt_csa)
+        acc_hca += tl.sum(cnt_hca)
+
+        if not IS_RECT:
+            # row == token, so the lane that owns a slot here owns it in the
+            # destination too, and the CG pad takes its 0 from the same store.
+            tl.store(csa_n_committed_ptr + idx, tl.where(live, n_csa, 0), mask=in_range)
+
+    if IS_RECT:
+        # ----- CSA visibility, one pass over the DESTINATION -----
+        # DSpark fp8 lays this out as a `full_q`-wide rectangle with each
+        # sequence's tokens flushed right, so token -> row is a scatter and some
+        # rows hold no token. Walking rows writes every one exactly once from
+        # its owning lane; walking tokens would leave the rest to a clearing
+        # pass another warp could still be in -- a hazard to fence rather than
+        # one that cannot arise. They do get read: the indexer runs the captured
+        # grid and takes this as each row's end.
+        for row_base in tl.range(0, n_committed_rows, BLOCK):
+            row = row_base + tl.arange(0, BLOCK)
+            in_range = row < n_committed_rows
+            seq = row // rect_full_q
+            offset = row % rect_full_q
+            # A row holds a token only past its band's leading slack; bands past
+            # the batch read a zero `ragged_lens`, so the whole band is slack.
+            lead = rect_full_q - tl.load(ragged_lens_ptr + seq, mask=in_range, other=0)
+            token = tl.load(cu_q_ptr + seq, mask=in_range, other=0) + offset - lead
+            mapped = in_range & (offset >= lead)
+            # `mapped` already implies a token inside this sequence's span, so
+            # this gather is redundant WHILE `cu_q` is the cumsum of
+            # `ragged_lens`. Nothing here can check that, and the two now come
+            # from different arrays built in different files, so it stays.
+            bid = tl.load(batch_id_per_token_ptr + token, mask=mapped, other=-1)
+            live = mapped & (bid >= 0)
+            pos = tl.load(positions_ptr + token, mask=live, other=0).to(tl.int32)
+            tl.store(
+                csa_n_committed_ptr + row,
+                tl.where(live, (pos + 1) // CSA_R, 0),
+                mask=in_range,
+            )
+
+
+@mark_trace
+def build_v4_paged_decode_indptr(
+    *,
+    batch_id_per_token: torch.Tensor,
+    positions: torch.Tensor,
+    swa_indptr: torch.Tensor,
+    csa_indptr: torch.Tensor,
+    hca_indptr: torch.Tensor,
+    csa_n_committed_per_token: torch.Tensor,
+    T_pad: int,
+    win: int,
+    index_topk: int,
+    rect_full_q: int = 0,
+    ragged_lens: torch.Tensor | None = None,
+    cu_q_per_seq: torch.Tensor | None = None,
+) -> None:
+    """Fill the three ragged indptr cumsums and the CSA per-token visibility.
+
+    Every argument is a persistent forward_vars buffer already on the device,
+    so this replaces the host's per-token arithmetic, three numpy cumsums and
+    four H2D copies with one launch. Call it before
+    `write_v4_paged_decode_indices`, which reads all three indptrs.
+
+    A token's compress counts follow from its position alone -- see the kernel
+    on why the sequence-level `ctx // ratio` is not a second bound.
+
+    `csa_n_committed_per_token` is the visibility `(pos+1)//CSA_RATIO`, NOT
+    capped by `index_topk`: that bounds what the CSA slice reserves, not what
+    the indexer may look at.
+
+    `rect_full_q > 0` switches the output to DSpark's right-aligned
+    `[bs, full_q]` rectangle; `ragged_lens` / `cu_q_per_seq` are then required.
+
+    The whole of `csa_n_committed_per_token` is this call's to fill, however it
+    is laid out: pass the slice you want written and the rows no token maps to
+    are set to 0. That filler is right only because the decode scorers pass
+    `next_n=1`, making `row_len == rowEnds[r]`; the per-seq twin pads with
+    `index_topk` for the opposite reason (`_attach_v4_per_fwd_meta` -- there,
+    too SMALL hangs the radix loop).
+    """
+    # Every bound below fixes a device-side index, so violating one is an
+    # out-of-bounds read rather than a wrong number -- `ValueError` for the same
+    # reason `write_v4_paged_decode_indices` gives above: it holds under
+    # `python -O`.
+    for name, buf, want in (
+        ("batch_id_per_token", batch_id_per_token, T_pad),
+        ("positions", positions, T_pad),
+        ("swa_indptr", swa_indptr, T_pad + 1),
+        ("csa_indptr", csa_indptr, T_pad + 1),
+        ("hca_indptr", hca_indptr, T_pad + 1),
+    ):
+        if buf.shape[0] < want:
+            raise ValueError(
+                f"{name} holds {buf.shape[0]} entries but this build indexes "
+                f"{want} of them (T_pad={T_pad})"
+            )
+    n_rows = csa_n_committed_per_token.shape[0]
+    if rect_full_q > 0:
+        if ragged_lens is None or cu_q_per_seq is None:
+            raise ValueError(
+                "the DSpark rectangle needs the per-seq query counts and starts"
+            )
+        # The rows carry `seq = row // full_q` straight into both per-seq
+        # tensors, so their length is what bounds that index. Nothing else does:
+        # `rect_bs` is decided by the caller, and a short `ragged_lens` would be
+        # an unmasked device read of whatever follows it.
+        bands = -(-n_rows // rect_full_q)
+        for name, buf in (("ragged_lens", ragged_lens), ("cu_q_per_seq", cu_q_per_seq)):
+            if buf.shape[0] < bands:
+                raise ValueError(
+                    f"{name} has {buf.shape[0]} entries but the rectangle spans "
+                    f"{bands} bands ({n_rows} rows of {rect_full_q})"
+                )
+    elif n_rows != T_pad:
+        # Token-indexed: the destination IS the token axis, one row each. A
+        # longer buffer would leave its tail reading tokens this forward never
+        # declared -- live values from the last one, on a persistent buffer.
+        raise ValueError(
+            f"token-indexed output must be exactly T_pad={T_pad} rows, got "
+            f"{n_rows}; slice it, or pass the rectangle's parameters"
+        )
+    _v4_decode_indptr_kernel[(1,)](
+        batch_id_per_token,
+        positions,
+        # Triton takes a pointer per parameter whatever the constexpr says; the
+        # rect-only ones borrow a buffer of the right dtype when switched off.
+        ragged_lens if rect_full_q > 0 else batch_id_per_token,
+        cu_q_per_seq if rect_full_q > 0 else batch_id_per_token,
+        swa_indptr,
+        csa_indptr,
+        hca_indptr,
+        csa_n_committed_per_token,
+        T_pad,
+        # The destination's own length, so the kernel fills exactly what it was
+        # handed: `T_pad` rows token-indexed, `rect_bs * full_q` as a rectangle.
+        csa_n_committed_per_token.shape[0],
+        rect_full_q,
+        WIN=win,
+        CSA_R=CSA_RATIO,
+        HCA_R=HCA_RATIO,
+        INDEX_TOPK=index_topk,
+        IS_RECT=rect_full_q > 0,
+        BLOCK=1024,
+    )
+
+
+def build_v4_paged_decode_indptr_reference(
+    *,
+    batch_id_per_token: torch.Tensor,
+    positions: torch.Tensor,
+    swa_indptr: torch.Tensor,
+    csa_indptr: torch.Tensor,
+    hca_indptr: torch.Tensor,
+    csa_n_committed_per_token: torch.Tensor,
+    T_pad: int,
+    win: int,
+    index_topk: int,
+    rect_full_q: int = 0,
+    ragged_lens: torch.Tensor | None = None,
+    cu_q_per_seq: torch.Tensor | None = None,
+) -> None:
+    """Pure-PyTorch equivalent of `build_v4_paged_decode_indptr`, for the
+    kernel-vs-reference tests. Same argument contract, including owning the
+    whole of `csa_n_committed_per_token`.
+
+    Stated as a scatter where the kernel walks the destination, so the parity
+    test compares two derivations of the layout rather than one twice.
+    """
+    bid = batch_id_per_token[:T_pad].long()
+    live = bid >= 0
+    safe_bid = torch.where(live, bid, torch.zeros_like(bid))
+    pos = positions[:T_pad].long()
+    n = torch.minimum(pos + 1, torch.full_like(pos, win))
+    n_csa = (pos + 1) // CSA_RATIO
+    n_hca = (pos + 1) // HCA_RATIO
+    zero = torch.zeros_like(n)
+    counts = {
+        "swa": torch.where(live, n, zero),
+        "csa": torch.where(
+            live, n + torch.minimum(n_csa, torch.full_like(n_csa, index_topk)), zero
+        ),
+        "hca": torch.where(live, n + n_hca, zero),
+    }
+    for key, out in (("swa", swa_indptr), ("csa", csa_indptr), ("hca", hca_indptr)):
+        out[0] = 0
+        out[1 : T_pad + 1] = torch.cumsum(counts[key], dim=0).to(out.dtype)
+    if rect_full_q > 0:
+        assert ragged_lens is not None and cu_q_per_seq is not None
+        dst = (
+            safe_bid * rect_full_q
+            + (rect_full_q - ragged_lens[safe_bid].long())
+            + (torch.arange(T_pad, device=bid.device) - cu_q_per_seq[safe_bid].long())
+        )
+    else:
+        dst = torch.arange(T_pad, device=bid.device)
+    csa_n_committed_per_token.zero_()
+    csa_n_committed_per_token[dst[live]] = n_csa[live].to(
+        csa_n_committed_per_token.dtype
+    )

--- a/atom/model_ops/v4_kernels/paged_prefill.py
+++ b/atom/model_ops/v4_kernels/paged_prefill.py
@@ -14,7 +14,8 @@ Caller contract:
     decode kernel: one row space holding a request's sliding windows and the
     compressed blocks alike (see `v4_pool_geometry`). For prefill, prefix
     indices select
-    (a) prior-chunk SWA history, (b) CSA topk, (c) HCA all-committed.
+    (a) prior-chunk SWA history, (b) CSA topk, (c) the HCA groups closed at or
+    before the token's own position.
   kv_indices_prefix: [total_prefix_indices] int32 — flat per-token slot
     lists. Per-token entries live in
     `kv_indices_prefix[kv_indptr_prefix[t] : kv_indptr_prefix[t+1]]`.

--- a/atom/model_ops/v4_kernels/paged_prefill_indices.py
+++ b/atom/model_ops/v4_kernels/paged_prefill_indices.py
@@ -12,9 +12,9 @@ per-fwd index buffers consumed by `sparse_attn_v4_paged_prefill`:
                                   slice TAIL; the CSA topk HEAD section is filled
                                   per layer by ``csa_translate_pack`` (head-CSA /
                                   tail-SWA convention, matching decode, #1116).
-  - ``kv_indices_prefix_hca``   : HCA path — SWA prefix segment + HCA
-                                  all-committed compress section, both fully
-                                  written.
+  - ``kv_indices_prefix_hca``   : HCA path — SWA prefix segment + the HCA
+                                  groups closed at or before the token's own
+                                  position, both fully written.
 
 Replaces the CPU numpy build in
 ``DeepseekV4AttentionMetadataBuilder._build_paged_prefill_meta`` (per-fwd
@@ -73,7 +73,6 @@ def _v4_paged_prefill_indices_kernel(
     chunk_start_per_seq_ptr,  # [bs] int — current chunk's absolute start position
     cu_seqlens_q_per_seq_ptr,  # [bs] int — per-seq prefix sum start in per-fwd kv tensor
     state_slot_per_seq_ptr,  # [bs] int — per-seq SWA ring slot
-    n_committed_hca_per_seq_ptr,  # [bs] int — per-seq HCA compress entry count
     block_tables_ptr,  # [bs, MAX_BLOCKS] int — compressed pool block ids (HCA)
     bt_stride_bs,  # row stride of block_tables
     # Indptrs (already cumsum'd by caller, all length [T+1]).
@@ -129,15 +128,11 @@ def _v4_paged_prefill_indices_kernel(
     pos = tl.load(positions_ptr + t)
     chunk_start = tl.load(chunk_start_per_seq_ptr + bid)
     cu_q = tl.load(cu_seqlens_q_per_seq_ptr + bid)
-    # Per-token CAUSAL HCA visibility: token at `pos` may see only the
-    # `(pos+1)//HCA_RATIO` compressed groups committed up to its own position
-    # (matches the reference `get_compress_topk_idxs` prefill mask, and mirrors
-    # the CSA `(pos+1)//4` cap). Without this cap every token saw the per-seq
-    # `n_committed_hca = ctx_end//128`, which over-reads FUTURE groups and makes
-    # a token's output depend on the forward's total length (chunked != single).
-    n_hca = tl.minimum(
-        (pos + 1) // HCA_RATIO, tl.load(n_committed_hca_per_seq_ptr + bid)
-    )
+    # Per-token causal HCA visibility (see `v4_pool_geometry`; matches the
+    # reference `get_compress_topk_idxs` prefill mask). Here specifically, the
+    # sequence's `ctx_end//128` would make a token's output depend on the
+    # forward's total length -- chunked and single-shot would disagree.
+    n_hca = (pos + 1) // HCA_RATIO
 
     # Per-token derived quantities (single-pass arithmetic).
     token_pos_in_chunk = pos - chunk_start
@@ -248,7 +243,6 @@ def write_v4_paged_prefill_indices(
     chunk_start_per_seq: torch.Tensor,
     cu_seqlens_q_per_seq: torch.Tensor,
     state_slot_per_seq: torch.Tensor,
-    n_committed_hca_per_seq: torch.Tensor,
     block_tables: torch.Tensor,
     extend_indptr: torch.Tensor,
     prefix_swa_indptr: torch.Tensor,
@@ -296,7 +290,6 @@ def write_v4_paged_prefill_indices(
                                             — caller passes the leading
                                             ``bs`` entries).
       state_slot_per_seq:        ``[bs]``   int — per-seq SWA ring slot.
-      n_committed_hca_per_seq:   ``[bs]``   int — per-seq HCA compress count.
       block_tables:              ``[bs, mnbs]`` int — per-seq paged blocks.
       extend_indptr:             ``[T+1]``  int.
       prefix_swa_indptr:         ``[T+1]``  int.
@@ -328,7 +321,6 @@ def write_v4_paged_prefill_indices(
     assert chunk_start_per_seq.dim() == 1
     assert cu_seqlens_q_per_seq.dim() == 1
     assert state_slot_per_seq.dim() == 1
-    assert n_committed_hca_per_seq.dim() == 1
     assert block_tables.dim() == 2
     for idp in (extend_indptr, prefix_swa_indptr, prefix_csa_indptr, prefix_hca_indptr):
         assert idp.dim() == 1 and idp.shape[0] >= T + 1
@@ -363,7 +355,6 @@ def write_v4_paged_prefill_indices(
         chunk_start_per_seq,
         cu_seqlens_q_per_seq,
         state_slot_per_seq,
-        n_committed_hca_per_seq,
         block_tables,
         block_tables.stride(0),
         extend_indptr,
@@ -396,7 +387,6 @@ def write_v4_paged_prefill_indices_reference(
     chunk_start_per_seq: torch.Tensor,
     cu_seqlens_q_per_seq: torch.Tensor,
     state_slot_per_seq: torch.Tensor,
-    n_committed_hca_per_seq: torch.Tensor,
     block_tables: torch.Tensor,
     extend_indptr: torch.Tensor,
     prefix_swa_indptr: torch.Tensor,
@@ -430,7 +420,6 @@ def write_v4_paged_prefill_indices_reference(
     pos_cpu = positions[:T].cpu().tolist()
     cs_per_seq_cpu = chunk_start_per_seq.cpu().tolist()
     cu_q_cpu = cu_seqlens_q_per_seq.cpu().tolist()
-    n_hca_cpu = n_committed_hca_per_seq.cpu().tolist()
     block_tables_cpu = block_tables.cpu()
     ext_indptr_cpu = extend_indptr.cpu().tolist()
     swa_indptr_cpu = prefix_swa_indptr.cpu().tolist()
@@ -443,8 +432,9 @@ def write_v4_paged_prefill_indices_reference(
         pos = pos_cpu[t]
         chunk_start = cs_per_seq_cpu[bid]
         cu_q = cu_q_cpu[bid]
-        # Per-token causal HCA cap (mirrors kernel + reference get_compress_topk_idxs).
-        n_hca = min((pos + 1) // hca_ratio, n_hca_cpu[bid])
+        # Per-token causal HCA visibility (mirrors kernel + reference
+        # get_compress_topk_idxs).
+        n_hca = (pos + 1) // hca_ratio
 
         token_pos_in_chunk = pos - chunk_start
         swa_low = max(pos - win + 1, 0)

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -1967,7 +1967,7 @@ class Indexer(nn.Module):
             kv_cache_4d,
             weights,
             logits,
-            attn_md.n_committed_per_token[:total_tokens],
+            attn_md.csa_n_committed_per_token[:total_tokens],
             attn_md.block_tables_per_token[:total_tokens],
             self._max_model_len_idx,
             KVBlockSize=self.kv_cache.size(1),  # csa_rows_per_block = 64
@@ -1982,7 +1982,7 @@ class Indexer(nn.Module):
         top_k_per_row_decode(
             logits,
             1,
-            attn_md.n_committed_per_token[:total_tokens],
+            attn_md.csa_n_committed_per_token[:total_tokens],
             topk_local,
             total_tokens,
             logits.stride(0),
@@ -2199,7 +2199,7 @@ class Indexer(nn.Module):
             self.kv_scale,
             attn_md.block_tables_per_token[:total_tokens],
             weights,
-            attn_md.n_committed_per_token[:total_tokens],
+            attn_md.csa_n_committed_per_token[:total_tokens],
             max_seq_len,
             weight_scale=self._weights_scale,
             next_n=1,
@@ -2220,7 +2220,7 @@ class Indexer(nn.Module):
         top_k_per_row_decode(
             logits,
             1,
-            attn_md.n_committed_per_token[:total_tokens],
+            attn_md.csa_n_committed_per_token[:total_tokens],
             topk_local,
             total_tokens,
             logits.stride(0),
@@ -2413,7 +2413,7 @@ class Indexer(nn.Module):
             kv_cache_4d,
             w_rect[:R],
             logits,
-            attn_md.n_committed_per_token[:R],
+            attn_md.csa_n_committed_per_token[:R],
             attn_md.block_tables_per_token[:R],
             self._max_model_len_idx,
             KVBlockSize=self.kv_cache.size(1),
@@ -2428,7 +2428,7 @@ class Indexer(nn.Module):
         top_k_per_row_decode(
             logits,
             1,
-            attn_md.n_committed_per_token[:R],
+            attn_md.csa_n_committed_per_token[:R],
             topk_rect[:R],
             R,
             logits.stride(0),
@@ -3521,10 +3521,10 @@ class DeepseekV4Attention(nn.Module):
 
         Fully fused into one triton kernel — no [T, index_topk] intermediates,
         no PyTorch fancy index. CG sentinel (batch_id=-1) and OOB clamp are
-        handled in-kernel. The kernel derives per-token `valid_k` inline from
-        `(positions[t]+1)//ratio` clamped by `n_committed_csa[bid]` and
-        `index_topk`, matching Indexer's per-row visibility — so every
-        reserved CSA cell gets written and no `-1` sentinel pre-fill is needed.
+        handled in-kernel. The kernel takes each token's `valid_k` from its own
+        `kv_indptr_csa` delta, which the builders sized as
+        `min(visible_csa(pos), index_topk)` — Indexer's per-row visibility — so
+        every reserved CSA cell gets written and no `-1` pre-fill is needed.
 
         Args:
           topk_local_raw: [total_tokens, index_topk] int32 — RAW seq-local

--- a/atom/plugin/sglang/deepseek_v4_bridge.py
+++ b/atom/plugin/sglang/deepseek_v4_bridge.py
@@ -9,6 +9,7 @@ from typing import Any
 import numpy as np
 import torch
 
+from atom.model_ops.attentions.v4_pool_geometry import visible_csa, visible_hca
 from atom.plugin.sglang.runtime.context import is_draft_extend_mode
 
 ATOM_DEEPSEEK_V4_BLOCK_SIZE = 128
@@ -1004,7 +1005,6 @@ class _V4SGLangDecodeGraphBuffers:
         self.cu_q = i32(t + 1)
         self.state_slot = i32(s)
         self.n_csa = i32(s)
-        self.n_hca = i32(s)
         self.batch_id = CpuGpuBuffer(t, dtype=torch.int32, device=device)
         self.block_tables = i32(s, self.max_blocks)
         self.indptr_swa = i32(t + 1)
@@ -1088,7 +1088,6 @@ class _V4SGLangVerifyGraphBuffers:
         self.cu_q = i32(s + 1)
         self.state_slot = i32(s)
         self.n_csa = i32(s)
-        self.n_hca = i32(s)
         self.batch_id = i32(t)
         self.block_tables = i32(s, self.max_blocks)
 
@@ -1463,24 +1462,18 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
     md.reset_slots = set()
     md.state_slot_mapping_cpu = slot_arr
     md.state_slot_mapping = bufs.stage(bufs.state_slot, slot_arr, bs)
-    md.batch_id_per_token_cpu = batch_np
     md.batch_id_per_token = bufs.stage(bufs.batch_id, batch_pad, t_pad)
     n_csa = (seq_np // 4).astype(np.int32)
-    n_hca = (seq_np // 128).astype(np.int32)
     md.n_committed_csa_per_seq_cpu = n_csa
-    md.n_committed_hca_per_seq_cpu = n_hca
     md.n_committed_csa_per_seq = bufs.stage(bufs.n_csa, n_csa, bs)
-    md.n_committed_hca_per_seq = bufs.stage(bufs.n_hca, n_hca, bs)
     md.compress_plans = _make_decode_graph_compress_plans(lens, seq_np, bufs)
 
     win = int(md.swa_window)
     index_topk = int(md.index_topk)
     if total:
         actual_swa = np.minimum(pos_np + 1, win).astype(np.int32)
-        csa_valid = np.minimum(
-            np.minimum((pos_np + 1) // 4, n_csa[batch_np]), index_topk
-        ).astype(np.int32)
-        hca_valid = n_hca[batch_np].astype(np.int32)
+        csa_valid = np.minimum(visible_csa(pos_np), index_topk).astype(np.int32)
+        hca_valid = visible_hca(pos_np).astype(np.int32)
     else:
         actual_swa = csa_valid = hca_valid = np.zeros(0, dtype=np.int32)
 
@@ -1518,7 +1511,6 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
         batch_id_per_token=md.batch_id_per_token,
         positions=positions_gpu,
         hca_indptr=hca_indptr,
-        n_committed_hca_per_seq=md.n_committed_hca_per_seq,
         block_tables=md.block_tables,
         hca_indices=bufs.idx_hca.gpu,
         T=t_pad,
@@ -1545,10 +1537,7 @@ def build_atom_v4_decode_graph_metadata_from_sglang(
     )
     safe_batch_id = md.batch_id_per_token.clamp_min(0)
     seq_base = cu_committed_gpu[safe_batch_id].to(torch.int32)
-    visible_end = seq_base + torch.minimum(
-        (positions_gpu.to(torch.int32) + 1) // 4,
-        md.n_committed_csa_per_seq[safe_batch_id],
-    ).to(torch.int32)
+    visible_end = seq_base + visible_csa(positions_gpu.to(torch.int32))
     md.indexer_meta = {
         "total_committed": int(cu_committed_cpu[-1]),
         "cu_committed_gpu": cu_committed_gpu,
@@ -1718,15 +1707,11 @@ def build_atom_v4_verify_graph_metadata_from_sglang(
     md.reset_slots = set()
     md.state_slot_mapping_cpu = slot_arr
     md.state_slot_mapping = bufs.state_slot.gpu[:bs]
-    md.batch_id_per_token_cpu = batch_np
     md.batch_id_per_token = bufs.stage(bufs.batch_id, batch_np, total)
 
     n_csa = (seq_np // 4).astype(np.int32)
-    n_hca = (seq_np // 128).astype(np.int32)
     md.n_committed_csa_per_seq_cpu = n_csa
-    md.n_committed_hca_per_seq_cpu = n_hca
     md.n_committed_csa_per_seq = bufs.stage(bufs.n_csa, n_csa, bs)
-    md.n_committed_hca_per_seq = bufs.stage(bufs.n_hca, n_hca, bs)
     md.compress_plans = (
         _make_verify_graph_compress_plans(lens, seq_np, bufs)
         if is_draft_extend
@@ -1743,11 +1728,8 @@ def build_atom_v4_verify_graph_metadata_from_sglang(
     swa_low = np.maximum(pos_np - win + 1, 0)
     extend_count = np.minimum(token_pos_in_chunk + 1, win).astype(np.int32)
     prefix_swa_count = np.maximum(chunk_start_pt - swa_low, 0).astype(np.int32)
-    csa_valid_k = np.minimum(
-        np.minimum((pos_np + 1) // 4, md.n_committed_csa_per_seq_cpu[batch_np]),
-        int(md.index_topk),
-    ).astype(np.int32)
-    hca_count = md.n_committed_hca_per_seq_cpu[batch_np].astype(np.int32)
+    csa_valid_k = np.minimum(visible_csa(pos_np), int(md.index_topk)).astype(np.int32)
+    hca_count = visible_hca(pos_np).astype(np.int32)
 
     ext_indptr_np = _counts_to_indptr(extend_count)
     swa_indptr_np = _counts_to_indptr(prefix_swa_count)
@@ -1769,7 +1751,6 @@ def build_atom_v4_verify_graph_metadata_from_sglang(
         chunk_start_per_seq=chunk_start_gpu,
         cu_seqlens_q_per_seq=cu_q[:-1],
         state_slot_per_seq=md.state_slot_mapping,
-        n_committed_hca_per_seq=md.n_committed_hca_per_seq,
         block_tables=block_tables,
         extend_indptr=ext_indptr,
         prefix_swa_indptr=swa_indptr,
@@ -1801,8 +1782,11 @@ def build_atom_v4_verify_graph_metadata_from_sglang(
     cu_committed_cpu[-1] = max(int(cu_committed_cpu[-1]), 1)
     cu_committed_gpu = bufs.stage(bufs.indexer_cu_committed, cu_committed_cpu, bs + 1)
     seq_base_cpu = cu_committed_cpu[batch_np].astype(np.int32)
+    # NOTE: the only surviving per-sequence bound on this axis. It disagrees
+    # with the `csa_valid_k` sizing above, which drops it -- resolve before
+    # trusting either.
     visible_end_cpu = seq_base_cpu + np.minimum(
-        (pos_np + 1) // 4, n_csa[batch_np]
+        visible_csa(pos_np), n_csa[batch_np]
     ).astype(np.int32)
     seq_base_gpu = bufs.stage(bufs.indexer_seq_base, seq_base_cpu, total)
     visible_end_gpu = bufs.stage(bufs.indexer_cu_ends, visible_end_cpu, total)
@@ -1947,20 +1931,15 @@ def build_atom_v4_attention_metadata_from_sglang(
         md.state_slot_mapping = torch.from_numpy(slot_arr).to(
             device=device, dtype=torch.int32
         )
-    md.batch_id_per_token_cpu = batch_np
     md.batch_id_per_token = torch.from_numpy(batch_np).to(device=device)
     md.n_committed_csa_per_seq_cpu = (seq_np // 4).astype(np.int32)
-    md.n_committed_hca_per_seq_cpu = (seq_np // 128).astype(np.int32)
     md.n_committed_csa_per_seq = torch.from_numpy(md.n_committed_csa_per_seq_cpu).to(
-        device=device
-    )
-    md.n_committed_hca_per_seq = torch.from_numpy(md.n_committed_hca_per_seq_cpu).to(
         device=device
     )
     md.compress_plans = _make_compress_plans(lens, seq_np, device)
 
     if is_decode:
-        _populate_decode_indices(md, block_tables, pos_np, device)
+        _populate_decode_indices(md, block_tables, batch_np, pos_np, device)
         if proxy_pool.use_fp8_kv:
             _stage_decode_fp8_page_metadata(md, total, total)
     else:
@@ -1969,12 +1948,11 @@ def build_atom_v4_attention_metadata_from_sglang(
     return md
 
 
-def _populate_decode_indices(md, block_tables, pos_np, device) -> None:
+def _populate_decode_indices(md, block_tables, batch_np, pos_np, device) -> None:
     from atom.model_ops.v4_kernels import write_v4_paged_decode_indices
 
     win = int(md.swa_window)
     cs = int(md.swa_cs)
-    batch_np = md.batch_id_per_token_cpu
     if len(batch_np) == 0:
         empty = torch.empty(0, dtype=torch.int32, device=device)
         zero = torch.zeros(1, dtype=torch.int32, device=device)
@@ -1982,16 +1960,10 @@ def _populate_decode_indices(md, block_tables, pos_np, device) -> None:
         md.kv_indptr_swa = md.kv_indptr_csa = md.kv_indptr_hca = zero
         return
     swa_counts = np.minimum(pos_np + 1, win).astype(np.int32)
-    csa_counts = np.minimum(
-        np.minimum((pos_np + 1) // 4, int(md.index_topk)),
-        md.n_committed_csa_per_seq_cpu[batch_np],
-    ).astype(np.int32)
-    # Per-token causal cap, mirroring CSA above and the prefill kernel
-    # (n_hca = min((pos+1)//128, committed)); without it the indptr over-reserves
-    # vs the kernel's actual writes -> uninitialized HCA tail garbage.
-    hca_counts = np.minimum(
-        (pos_np + 1) // 128, md.n_committed_hca_per_seq_cpu[batch_np]
-    ).astype(np.int32)
+    # These SIZE each slice; the index kernels FILL it from the same two counts.
+    # Reserve exactly what they write or the slice tail is garbage.
+    csa_counts = np.minimum(visible_csa(pos_np), int(md.index_topk)).astype(np.int32)
+    hca_counts = visible_hca(pos_np).astype(np.int32)
     swa_indptr_np = _counts_to_indptr(swa_counts)
     csa_indptr_np = _counts_to_indptr(swa_counts + csa_counts)
     hca_indptr_np = _counts_to_indptr(swa_counts + hca_counts)
@@ -2072,16 +2044,8 @@ def _populate_prefill_indices(md, block_tables, batch_np, pos_np, q_np, device) 
     swa_low = np.maximum(pos_np - win + 1, 0)
     extend_count = np.minimum(token_pos_in_chunk + 1, win).astype(np.int32)
     prefix_swa_count = np.maximum(chunk_start_pt - swa_low, 0).astype(np.int32)
-    csa_valid_k = np.minimum(
-        np.minimum((pos_np + 1) // 4, md.n_committed_csa_per_seq_cpu[batch_np]),
-        int(md.index_topk),
-    ).astype(np.int32)
-    # Per-token causal cap, mirroring CSA above and the prefill kernel
-    # (n_hca = min((pos+1)//128, committed)); without it the indptr over-reserves
-    # vs the kernel's actual writes -> uninitialized HCA tail garbage.
-    hca_count = np.minimum(
-        (pos_np + 1) // 128, md.n_committed_hca_per_seq_cpu[batch_np]
-    ).astype(np.int32)
+    csa_valid_k = np.minimum(visible_csa(pos_np), int(md.index_topk)).astype(np.int32)
+    hca_count = visible_hca(pos_np).astype(np.int32)
     ext_indptr_np = _counts_to_indptr(extend_count)
     swa_indptr_np = _counts_to_indptr(prefix_swa_count)
     csa_indptr_np = _counts_to_indptr(prefix_swa_count + csa_valid_k)
@@ -2110,7 +2074,6 @@ def _populate_prefill_indices(md, block_tables, batch_np, pos_np, q_np, device) 
         chunk_start_per_seq=t(chunk_start_per_seq),
         cu_seqlens_q_per_seq=t(q_np[:-1]),
         state_slot_per_seq=md.state_slot_mapping,
-        n_committed_hca_per_seq=md.n_committed_hca_per_seq,
         block_tables=block_tables,
         extend_indptr=t(ext_indptr_np),
         prefix_swa_indptr=t(swa_indptr_np),
@@ -2155,10 +2118,7 @@ def _populate_indexer(md, batch_np, positions, device) -> None:
         }
         return
     base = cu_gpu[bid].to(torch.int32)
-    end = base + torch.minimum(
-        (positions.to(torch.int32) + 1) // 4,
-        md.n_committed_csa_per_seq[bid],
-    ).to(torch.int32)
+    end = base + visible_csa(positions.to(torch.int32))
     md.indexer_meta = {
         "total_committed": int(cu[-1]),
         "cu_committed_gpu": cu_gpu,

--- a/atom/plugin/sglang/models/deepseek_v4_attention.py
+++ b/atom/plugin/sglang/models/deepseek_v4_attention.py
@@ -326,7 +326,6 @@ def patch_deepseek_v4_attention_for_sglang(attn: nn.Module) -> None:
 
                 for name in (
                     "batch_id_per_token",
-                    "batch_id_per_token_cpu",
                     "skip_prefix_len_csa",
                 ):
                     slice_attr(name, num_real)

--- a/atom/plugin/sglang/runtime/forward_context.py
+++ b/atom/plugin/sglang/runtime/forward_context.py
@@ -236,7 +236,6 @@ def _slice_v4_graph_metadata_for_capture(
 
     for name in (
         "batch_id_per_token",
-        "batch_id_per_token_cpu",
         "slot_mapping",
         "kv_indices_swa",
         "kv_indices_csa",
@@ -265,8 +264,6 @@ def _slice_v4_graph_metadata_for_capture(
         "state_slot_mapping_cpu",
         "n_committed_csa_per_seq",
         "n_committed_csa_per_seq_cpu",
-        "n_committed_hca_per_seq",
-        "n_committed_hca_per_seq_cpu",
         "context_lens",
     ):
         _slice_attr(name, bs)

--- a/atom/plugin/vllm/deepseek_v4_bridge.py
+++ b/atom/plugin/vllm/deepseek_v4_bridge.py
@@ -16,6 +16,8 @@ from vllm.v1.attention.backend import (
 )
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
 
+from atom.model_ops.attentions.v4_pool_geometry import visible_csa, visible_hca
+
 ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME = "model.layers.0.atom_deepseek_v4_proxy"
 ATOM_DEEPSEEK_V4_DRAFT_PROXY_LAYER_PREFIX = "atom_deepseek_v4_draft_proxy"
 ATOM_DEEPSEEK_V4_BLOCK_SIZE = 128
@@ -793,13 +795,12 @@ class _V4DecodeMetaBuffers:
         self.state_slot_in = i32(S)
         self.state_slot_out = i32(S)
         self.n_csa = i32(S)
-        self.n_hca = i32(S)
         # Per-token mapping (sized to padded token count). int32: accepted by
         # torch advanced-indexing AND by the fused flydsl SWA scatter (which
         # loads batch_id as int32); matches the in-tree model_runner path.
         self.batch_id = CpuGpuBuffer(T, dtype=torch.int32, device=device)
         self.swa_dest_rows = {ratio: i32(T) for ratio in _V4_SWA_DEST_RATIOS}
-        self.n_committed_per_token = i32(T)
+        self.csa_n_committed_per_token = i32(T)
         self.block_tables_per_token = i32(T, self.max_blocks)
         # Ragged cumsums (T + 1) and ragged index pools (worst-case per-token
         # slot counts): SWA = win, CSA = win + index_topk, HCA = win + hca.
@@ -1449,10 +1450,7 @@ def build_atom_v4_attention_metadata(
     md.reset_slots = {md.pool_geometry.physical_slot(int(slot)) for slot in reset_slots}
 
     n_csa_cpu = (seq_np // 4).astype(np.int32)
-    n_hca_cpu = (seq_np // 128).astype(np.int32)
     md.n_committed_csa_per_seq_cpu = n_csa_cpu
-    md.n_committed_hca_per_seq_cpu = n_hca_cpu
-    md.batch_id_per_token_cpu = batch_np
     index_topk = int(md.index_topk)
 
     if decode_persistent:
@@ -1477,9 +1475,7 @@ def build_atom_v4_attention_metadata(
         bufs.n_csa.np[:num_reqs] = n_csa_cpu
         if num_reqs > scheduled_bs:
             bufs.n_csa.np[scheduled_bs:num_reqs] = index_topk
-        bufs.n_hca.np[:num_reqs] = n_hca_cpu
         md.n_committed_csa_per_seq = bufs.n_csa.copy_to_gpu(num_reqs)
-        md.n_committed_hca_per_seq = bufs.n_hca.copy_to_gpu(num_reqs)
         md.compress_plans = _make_decode_compress_plans(
             lens[:scheduled_bs], seq_np[:scheduled_bs], bufs
         )
@@ -1497,10 +1493,10 @@ def build_atom_v4_attention_metadata(
             pos_np = np.zeros(0, dtype=np.int32)
         visible_np = np.zeros(T_pad, dtype=np.int32)
         if total:
-            visible_np[:total] = np.minimum(
-                (pos_np + 1) // 4, n_csa_cpu[batch_np]
-            ).astype(np.int32)
-        md.n_committed_per_token = bufs.stage(bufs.n_committed_per_token, visible_np)
+            visible_np[:total] = visible_csa(pos_np).astype(np.int32)
+        md.csa_n_committed_per_token = bufs.stage(
+            bufs.csa_n_committed_per_token, visible_np
+        )
         block_cols = int(common_attn_metadata.block_table_tensor.shape[1])
         block_rows = bufs.block_tables_per_token.gpu[:T_pad, :block_cols]
         safe_batch_ids = md.batch_id_per_token[:T_pad].clamp_min(0).long()
@@ -1514,10 +1510,8 @@ def build_atom_v4_attention_metadata(
         _populate_decode_persistent(
             md,
             common_attn_metadata,
-            batch_np,
             pos_np,
             bufs,
-            scheduled_bs,
             total,
             T_pad,
             positions,
@@ -1557,7 +1551,6 @@ def build_atom_v4_attention_metadata(
     md.state_slot_mapping_cpu = physical_slot_arr
     md.batch_id_per_token = torch.from_numpy(batch_np).to(device)
     md.n_committed_csa_per_seq = torch.from_numpy(n_csa_cpu).to(device)
-    md.n_committed_hca_per_seq = torch.from_numpy(n_hca_cpu).to(device)
     md.compress_plans = _make_compress_plans(
         lens, seq_np, [(4, True), (128, False)], device, is_decode
     )
@@ -1566,8 +1559,8 @@ def build_atom_v4_attention_metadata(
         positions = torch.arange(total, dtype=torch.int64, device=device)
     pos_np = positions[:total].detach().cpu().numpy().astype(np.int32)
     if is_decode:
-        visible_np = np.minimum((pos_np + 1) // 4, n_csa_cpu[batch_np]).astype(np.int32)
-        md.n_committed_per_token = torch.from_numpy(visible_np).to(device)
+        visible_np = visible_csa(pos_np).astype(np.int32)
+        md.csa_n_committed_per_token = torch.from_numpy(visible_np).to(device)
         batch_ids = torch.from_numpy(batch_np).to(device=device, dtype=torch.long)
         md.block_tables_per_token = common_attn_metadata.block_table_tensor[batch_ids]
         _populate_decode(md, common_attn_metadata, batch_np, pos_np, positions)
@@ -1654,9 +1647,7 @@ def _make_decode_compress_plans(extend_lens_cpu, context_lens_cpu, bufs):
     )
 
 
-def _populate_decode_persistent(
-    md, common, batch_np, pos_np, bufs, scheduled_bs, total, T_pad, positions_gpu
-):
+def _populate_decode_persistent(md, common, pos_np, bufs, total, T_pad, positions_gpu):
     """Decode index/indptr build into persistent fixed-address buffers.
 
     Faithful port of ATOM's ``_attach_v4_paged_decode_meta`` for plugin mode:
@@ -1674,15 +1665,11 @@ def _populate_decode_persistent(
 
     win = int(md.swa_window)
     index_topk = int(md.index_topk)
-    n_csa_cpu = md.n_committed_csa_per_seq_cpu
-    n_hca_cpu = md.n_committed_hca_per_seq_cpu
 
     # Per-token slot counts over the real tokens [0:total].
     actual_swa = np.minimum(pos_np + 1, win).astype(np.int32)
-    csa_valid_k = np.minimum(
-        np.minimum((pos_np + 1) // 4, n_csa_cpu[batch_np]), index_topk
-    ).astype(np.int32)
-    n_h_per_token = n_hca_cpu[batch_np].astype(np.int32)
+    csa_valid_k = np.minimum(visible_csa(pos_np), index_topk).astype(np.int32)
+    n_h_per_token = visible_hca(pos_np).astype(np.int32)
 
     def _indptr(counts):
         out = np.zeros(T_pad + 1, dtype=np.int32)
@@ -1729,7 +1716,6 @@ def _populate_decode_persistent(
         batch_id_per_token=md.batch_id_per_token,
         positions=positions_gpu,
         hca_indptr=hca_indptr_gpu,
-        n_committed_hca_per_seq=md.n_committed_hca_per_seq,
         block_tables=common.block_table_tensor,
         hca_indices=bufs.idx_hca.gpu,
         T=total,
@@ -1773,12 +1759,9 @@ def _populate_indexer(
     bid = (md.batch_id_per_token[num_decode_tokens:] - num_decodes).to(
         md.batch_id_per_token.dtype
     )
-    n_committed_pref = md.n_committed_csa_per_seq[num_decodes:]
     pos_pref = positions[num_decode_tokens:]
     base = cu_gpu[bid].to(torch.int32)
-    end = base + torch.minimum((pos_pref + 1) // 4, n_committed_pref[bid]).to(
-        torch.int32
-    )
+    end = base + visible_csa(pos_pref).to(torch.int32)
     md.indexer_meta = {
         "total_committed": int(cu[-1]),
         "cu_committed_gpu": cu_gpu,
@@ -1871,17 +1854,10 @@ def _populate_prefill(md, common, batch_np, pos_np, q_np, positions_gpu):
     swa_low = np.maximum(pos_np - win + 1, 0)
     extend_count = np.minimum(token_pos_in_chunk + 1, win).astype(np.int32)
     prefix_swa_count = np.maximum(chunk_start_pt - swa_low, 0).astype(np.int32)
-    n_csa_pt = md.n_committed_csa_per_seq_cpu[batch_np]
-    csa_valid_k = np.minimum(
-        np.minimum((pos_np + 1) // 4, n_csa_pt), index_topk
-    ).astype(np.int32)
-    # Per-token causal cap, mirroring CSA above and the kernel
-    # (write_v4_paged_prefill_indices: n_hca = min((pos+1)//128, committed)).
-    # Without it the indptr reserves `committed` HCA slots but the kernel only
-    # writes min((pos+1)//128, committed), leaving uninitialized tail garbage.
-    n_hca_pt = np.minimum(
-        (pos_np + 1) // 128, md.n_committed_hca_per_seq_cpu[batch_np]
-    ).astype(np.int32)
+    # These SIZE each slice; `write_v4_paged_prefill_indices` FILLS it from the
+    # same two counts. Reserve exactly what it writes or the tail is garbage.
+    csa_valid_k = np.minimum(visible_csa(pos_np), index_topk).astype(np.int32)
+    n_hca_pt = visible_hca(pos_np).astype(np.int32)
 
     ext_indptr_np = _counts_to_indptr(extend_count)
     swa_indptr_np = _counts_to_indptr(prefix_swa_count)
@@ -1910,16 +1886,12 @@ def _populate_prefill(md, common, batch_np, pos_np, q_np, positions_gpu):
         np.ascontiguousarray(md.chunk_start_per_seq_cpu[:num_reqs])
     ).to(device)
     cu_q_g = torch.from_numpy(np.ascontiguousarray(q_np[:num_reqs])).to(device)
-    n_hca_seq_g = torch.from_numpy(
-        np.ascontiguousarray(md.n_committed_hca_per_seq_cpu[:num_reqs])
-    ).to(device)
     write_v4_paged_prefill_indices(
         positions=positions_gpu[:T].to(torch.int32),
         bid_per_token=md.batch_id_per_token[:T],
         chunk_start_per_seq=chunk_start_g,
         cu_seqlens_q_per_seq=cu_q_g,
         state_slot_per_seq=md.state_slot_out[:num_reqs],
-        n_committed_hca_per_seq=n_hca_seq_g,
         block_tables=common.block_table_tensor[:num_reqs],
         extend_indptr=ext_indptr,
         prefix_swa_indptr=swa_indptr,
@@ -1951,11 +1923,8 @@ def _populate_decode(md, common, batch_np, pos_np, positions_gpu):
     win = int(md.swa_window)
     index_topk = int(md.index_topk)
     swa_counts = np.minimum(pos_np + 1, win).astype(np.int32)
-    csa_counts = np.minimum(
-        np.minimum((pos_np + 1) // 4, index_topk),
-        md.n_committed_csa_per_seq_cpu[batch_np],
-    ).astype(np.int32)
-    hca_counts = md.n_committed_hca_per_seq_cpu[batch_np].astype(np.int32)
+    csa_counts = np.minimum(visible_csa(pos_np), index_topk).astype(np.int32)
+    hca_counts = visible_hca(pos_np).astype(np.int32)
     swa_indptr_np = _counts_to_indptr(swa_counts)
     csa_indptr_np = _counts_to_indptr(swa_counts + csa_counts)
     hca_indptr_np = _counts_to_indptr(swa_counts + hca_counts)
@@ -1999,7 +1968,6 @@ def _populate_decode(md, common, batch_np, pos_np, positions_gpu):
         batch_id_per_token=md.batch_id_per_token,
         positions=positions_gpu,
         hca_indptr=hca_indptr,
-        n_committed_hca_per_seq=md.n_committed_hca_per_seq,
         block_tables=common.block_table_tensor,
         hca_indices=hca_indices,
         T=T,

--- a/atom/plugin/vllm/deepseek_v4_ops.py
+++ b/atom/plugin/vllm/deepseek_v4_ops.py
@@ -25,17 +25,19 @@ import torch
 import triton
 import triton.language as tl
 
+from atom.model_ops.attentions.v4_pool_geometry import HCA_RATIO
+
 
 @triton.jit
 def _v4_decode_hca_compress_tail_kernel(
     batch_id_per_token_ptr,  # [>=T] int — sentinel -1 in CG pad tail
     positions_ptr,  # [>=T] int — global token position
     hca_indptr_ptr,  # [>=T+1] int32 — ragged (SWA prefix + HCA committed)
-    n_committed_hca_per_seq_ptr,  # [num_reqs] int32 — per-seq HCA entry count
     block_tables_ptr,  # [num_reqs, MAX_BLOCKS] int — per-seq paged block ids
     bt_stride_bs,  # block_tables row stride (elements)
     hca_indices_ptr,  # [>=hca_indptr[T]] int32 OUT — HCA compress section (head)
     envelope_rows,  # rows occupied by one physical proxy block
+    HCA_R: tl.constexpr,  # HCA compress ratio — one group per this many tokens
     win: tl.constexpr,  # SWA window — per-token prefix length cap
     BLOCK_J: tl.constexpr,  # next_pow2(win) — HCA loop chunk size
 ):
@@ -58,7 +60,9 @@ def _v4_decode_hca_compress_tail_kernel(
     bid = tl.load(batch_id_per_token_ptr + t)
     if bid < 0:
         return  # CG-padded sentinel — leave outputs untouched
-    n_hca = tl.load(n_committed_hca_per_seq_ptr + bid)
+    # Groups closed at or before this token's own position -- see the rule next
+    # to `CSA_RATIO` in `v4_pool_geometry`.
+    n_hca = (tl.load(positions_ptr + t) + 1) // HCA_R
     # HCA compress section occupies the slice HEAD (offset 0); the SWA window
     # prefix sits at the tail, written by `write_v4_paged_decode_indices`.
     base = tl.load(hca_indptr_ptr + t)
@@ -82,11 +86,11 @@ def _v4_decode_indices_fused_kernel(
     swa_indices_ptr,  # [swa_total] int32 OUT
     csa_indices_ptr,  # [csa_total] int32 OUT (SWA-prefix segment only)
     hca_indices_ptr,  # [hca_total] int32 OUT (SWA prefix tail + HCA head)
-    n_committed_hca_per_seq_ptr,  # [num_reqs] int32 — per-seq HCA entry count
     block_tables_ptr,  # [num_reqs, MAX_BLOCKS] int — per-seq paged block ids
     bt_stride_bs,  # block_tables row stride (elements)
     cs,  # win_with_spec — ring-index modulo / SWA-region stride
     swa_pages,  # num_slots * cs — boundary into compress region
+    HCA_R: tl.constexpr,  # HCA compress ratio — one group per this many tokens
     win: tl.constexpr,  # SWA window — max prefix slots
     BLOCK_N: tl.constexpr,  # next_pow2(win)
 ):
@@ -120,7 +124,8 @@ def _v4_decode_indices_fused_kernel(
     tl.store(hca_indices_ptr + hca_end - n + i, paged, mask=mask)
 
     # --- HCA compress section (slice HEAD of hca) ---
-    n_hca = tl.load(n_committed_hca_per_seq_ptr + bid)
+    # Groups closed at or before this token's own position, as above.
+    n_hca = (pos + 1) // HCA_R
     base = tl.load(hca_indptr_ptr + t)
     bt_row_base = bid * bt_stride_bs
     for j in tl.range(0, n_hca, BLOCK_N):
@@ -141,7 +146,6 @@ def write_v4_decode_indices_fused(
     swa_indices: torch.Tensor,
     csa_indices: torch.Tensor,
     hca_indices: torch.Tensor,
-    n_committed_hca_per_seq: torch.Tensor,
     block_tables: torch.Tensor,
     T: int,
     win: int,
@@ -167,7 +171,6 @@ def write_v4_decode_indices_fused(
     assert swa_indices.dim() == 1
     assert csa_indices.dim() == 1
     assert hca_indices.dim() == 1
-    assert n_committed_hca_per_seq.dim() == 1
     assert block_tables.dim() == 2
 
     BLOCK_N = triton.next_power_of_2(win)
@@ -181,11 +184,11 @@ def write_v4_decode_indices_fused(
         swa_indices,
         csa_indices,
         hca_indices,
-        n_committed_hca_per_seq,
         block_tables,
         block_tables.stride(0),
         cs,
         swa_pages,
+        HCA_R=HCA_RATIO,
         win=win,
         BLOCK_N=BLOCK_N,
     )
@@ -196,7 +199,6 @@ def write_v4_decode_hca_compress_tail(
     batch_id_per_token: torch.Tensor,
     positions: torch.Tensor,
     hca_indptr: torch.Tensor,
-    n_committed_hca_per_seq: torch.Tensor,
     block_tables: torch.Tensor,
     hca_indices: torch.Tensor,
     T: int,
@@ -221,12 +223,11 @@ def write_v4_decode_hca_compress_tail(
 
     Args:
       batch_id_per_token:      ``[>=T]``   int — token→seq map; -1 skipped.
-      positions:               ``[>=T]``   int — global token positions (unused
-                                           since the compress section moved to the
-                                           slice head; kept for call-site parity).
+      positions:               ``[>=T]``   int — global token positions; each
+                                           token's HCA count is
+                                           ``(positions[t]+1)//128``.
       hca_indptr:              ``[>=T+1]`` int32 — ragged HCA indptr (same one
                                            passed to ``write_v4_paged_decode_indices``).
-      n_committed_hca_per_seq: ``[num_reqs]`` int32 — per-seq HCA entry count.
       block_tables:            ``[num_reqs, mnbs]`` int — per-seq paged blocks.
       hca_indices:             ``[>=hca_indptr[T]]`` int32 OUT — compress section
                                            (slice head) written; SWA prefix
@@ -240,7 +241,6 @@ def write_v4_decode_hca_compress_tail(
     assert batch_id_per_token.dim() == 1 and batch_id_per_token.shape[0] >= T
     assert positions.dim() == 1 and positions.shape[0] >= T
     assert hca_indptr.dim() == 1 and hca_indptr.shape[0] >= T + 1
-    assert n_committed_hca_per_seq.dim() == 1
     assert block_tables.dim() == 2
     assert hca_indices.dim() == 1
 
@@ -249,11 +249,11 @@ def write_v4_decode_hca_compress_tail(
         batch_id_per_token,
         positions,
         hca_indptr,
-        n_committed_hca_per_seq,
         block_tables,
         block_tables.stride(0),
         hca_indices,
         envelope_rows,
+        HCA_R=HCA_RATIO,
         win=win,
         BLOCK_J=BLOCK_J,
     )

--- a/atom/plugin/vllm/models/deepseek_v4.py
+++ b/atom/plugin/vllm/models/deepseek_v4.py
@@ -130,12 +130,13 @@ class IndexerVllm(IndexerBase):
         """Paged decode top-k, extended for the DECODE slice of a mixed batch.
 
         Native ATOM only ever calls this for a *pure* decode forward, where the
-        step size is the batch-wide ``max_seqlen_q`` and the committed tensor is
-        the whole ``indexer_meta["n_committed_per_seq_gpu"]``. Under vLLM
-        continuous batching this also runs on the leading decode slice of a
-        MIXED batch, where neither holds: ``max_seqlen_q`` is the prefill max
-        (not the decode step size) and the committed tensor must be sliced to
-        the decode sub-batch. So ``indexer_score_topk`` passes ``next_n`` and
+        step size is the batch-wide ``max_seqlen_q`` and the bound is per TOKEN
+        (``csa_n_committed_per_token``); it puts no per-seq committed tensor in
+        ``indexer_meta`` at all. This bridge still stages one, because under
+        vLLM continuous batching the call also runs on the leading decode slice
+        of a MIXED batch, where ``max_seqlen_q`` is the prefill max (not the
+        decode step size) and the committed tensor must be sliced to the decode
+        sub-batch. So ``indexer_score_topk`` passes ``next_n`` and
         ``n_committed_per_seq`` explicitly for that case.
 
         When both are ``None`` (the pure-decode / spec-verify step) this is

--- a/tests/test_decode_indices_paged.py
+++ b/tests/test_decode_indices_paged.py
@@ -258,7 +258,8 @@ ROWS_PER_BLOCK = 2
 
 def _hca_case(bs, n_hca_per_seq, positions, geometry=GEOMETRY):
     """One decode token per seq plus a `-1` pad token, with HCA heads sized
-    from `n_hca_per_seq` — the same `n + n_committed_hca` the builder uses."""
+    from `n_hca_per_seq` — the same `n + <HCA count>` slice the builder sizes,
+    parametrized here so a case can pick the count directly."""
     t_total = bs + 1
     batch_id = list(range(bs)) + [-1]
     rng = np.random.default_rng(bs * 17 + sum(n_hca_per_seq))

--- a/tests/test_decode_indptr_build.py
+++ b/tests/test_decode_indptr_build.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Gate for the V4 decode indptr builder: kernel vs reference, and both vs the
+one rule neither of them may be free to restate.
+
+The rule is that a token's compress counts follow from ITS OWN position. A
+sequence hands `1 + k` tokens to one MTP or DSpark forward, so a per-sequence
+count is the last token's; giving it to the earlier ones lets them read
+compressed groups holding their own future drafts.
+`_v4_paged_prefill_indices_kernel` derives per-token for exactly this reason,
+and the decode side did not until this builder replaced its host arithmetic.
+
+Kernel-vs-reference cannot settle that on its own -- both compute the count from
+the same expression, so a regression moves the pair together. So the counts are
+also checked against a batch whose answer is written out here: a group
+straddling an HCA group boundary, where per-token and per-sequence differ by
+exactly one for the tokens before it.
+"""
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip(
+        "compares a Triton kernel against its reference; needs a real GPU",
+        allow_module_level=True,
+    )
+
+from atom.model_ops.attentions.v4_pool_geometry import CSA_RATIO, HCA_RATIO
+from atom.model_ops.v4_kernels.paged_decode_indices import (
+    build_v4_paged_decode_indptr,
+    build_v4_paged_decode_indptr_reference,
+)
+
+DEV = "cuda"
+WIN = 128
+INDEX_TOPK = 16  # far below the visible counts below, so the CSA cap is live
+
+
+# Every destination arrives poisoned, never zeroed. The builder owns all four
+# whole, and 0 is exactly what an unmapped row is supposed to end up holding --
+# so on a zero-filled buffer the tests below would pass whether the builder
+# wrote those rows or nobody did.
+POISON = -7
+
+
+def _outputs(n_rows, t_pad):
+    def poison(n):
+        return torch.full((n,), POISON, dtype=torch.int32, device=DEV)
+
+    return {
+        "swa_indptr": poison(t_pad + 1),
+        "csa_indptr": poison(t_pad + 1),
+        "hca_indptr": poison(t_pad + 1),
+        "csa_n_committed_per_token": poison(n_rows),
+    }
+
+
+def _run(builder, *, positions, batch_id, t_pad, n_rows=None, **rect):
+    """Drive one builder over a batch and hand back its four outputs."""
+    out = _outputs(n_rows if n_rows is not None else t_pad, t_pad)
+    builder(
+        batch_id_per_token=torch.tensor(batch_id, dtype=torch.int32, device=DEV),
+        # int64, as the production `positions` buffer is.
+        positions=torch.tensor(positions, dtype=torch.int64, device=DEV),
+        T_pad=t_pad,
+        win=WIN,
+        index_topk=INDEX_TOPK,
+        **out,
+        **rect,
+    )
+    return out
+
+
+def _per_token(out, cls):
+    """Recover each token's compress-section length from the two indptrs."""
+    swa, other = out["swa_indptr"], out[f"{cls}_indptr"]
+    return ((other[1:] - other[:-1]) - (swa[1:] - swa[:-1])).tolist()
+
+
+# One MTP-4 group per sequence. Seq 0 straddles the boundary at 128: its first
+# token may see zero HCA groups and the rest exactly one. Seq 1 sits well past a
+# boundary so it exercises the un-straddled case in the same batch. The two
+# trailing `-1` rows are the CG pad. Sequence context ends one past each group's
+# last position (130 and 304) -- the `pos + 1 <= ctx` the builders rely on.
+POSITIONS = [126, 127, 128, 129, 300, 301, 302, 303, 0, 0]
+BATCH_ID = [0, 0, 0, 0, 1, 1, 1, 1, -1, -1]
+T_PAD = len(BATCH_ID)
+BATCH = {"positions": POSITIONS, "batch_id": BATCH_ID, "t_pad": T_PAD}
+
+
+def test_kernel_matches_reference():
+    kern = _run(build_v4_paged_decode_indptr, **BATCH)
+    ref = _run(build_v4_paged_decode_indptr_reference, **BATCH)
+    for name in kern:
+        assert torch.equal(kern[name], ref[name]), name
+
+
+def test_hca_count_comes_from_the_token_s_own_position():
+    """The straddling group is the whole point: seq 0's tokens differ."""
+    per_token_hca = _per_token(_run(build_v4_paged_decode_indptr, **BATCH), "hca")
+    # pos 126 -> (126+1)//128 == 0 groups; the next three -> 1. Reading the
+    # sequence's `ctx//128 == 1` instead would give all four a 1, and the token
+    # at 126 would see the group covering positions 128..255 -- its own drafts.
+    assert per_token_hca[:4] == [0, 1, 1, 1]
+    # Seq 1 never straddles, so every one of its tokens lands on 304//128 == 2.
+    assert per_token_hca[4:8] == [2, 2, 2, 2]
+
+
+def test_csa_count_comes_from_the_position_and_the_slice_is_capped_at_topk():
+    out = _run(build_v4_paged_decode_indptr, **BATCH)
+    # Visible ends are 31/32/32/32 for seq 0, all far above INDEX_TOPK, so the
+    # reserved slice length is the cap for every token.
+    assert _per_token(out, "csa")[:8] == [INDEX_TOPK] * 8
+    # The visibility itself is NOT capped by index_topk -- that bounds what the
+    # slice reserves, not what the indexer may scan.
+    assert out["csa_n_committed_per_token"][:4].tolist() == [31, 32, 32, 32]
+
+
+def test_padded_tail_is_flat_and_zero():
+    out = _run(build_v4_paged_decode_indptr, **BATCH)
+    for name in ("swa_indptr", "csa_indptr", "hca_indptr"):
+        ind = out[name]
+        assert ind[0].item() == 0
+        # `-1` rows contribute nothing, which is the `kv_len == 0` every reader
+        # bails on. Anything else and a padded slot walks a live token's slice.
+        assert ind[-1].item() == ind[-3].item()
+    assert out["csa_n_committed_per_token"][8:].tolist() == [0, 0]
+
+
+def test_a_position_past_its_sequence_is_not_clamped():
+    """Positive control for a bound that was deleted, not a behaviour anyone
+    wants. `min(per-token, ctx//ratio)` used to sit in both builders; it never
+    fired, because every caller derives `positions` FROM `context_lens` --
+    `prepare_decode` on both its ragged and rectangular branches, and
+    `build_for_cudagraph_capture` -- so `pos + 1 <= ctx`. (Named, not cited by
+    line: a line number in a docstring is stale the next time anyone edits
+    above it, and these three were already wrong.)
+
+    Feeding a position past its sequence's context is therefore off-contract,
+    and this pins what the builders now do with it: answer from the position.
+    A reader who re-adds the clamp on the theory that it guarded something will
+    find this red, with the count it would have produced spelled out.
+    """
+    out = _run(
+        build_v4_paged_decode_indptr,
+        positions=[1000],  # a sequence whose ctx was, say, 130
+        batch_id=[0],
+        t_pad=1,
+    )
+    assert _per_token(out, "hca") == [1000 // HCA_RATIO]  # 7, not min(7, 130//128)=1
+    assert out["csa_n_committed_per_token"].tolist() == [1001 // CSA_RATIO]
+
+
+def test_dspark_rectangle_right_aligns_and_leaves_holes_at_zero():
+    """DSpark fp8 wants `[bs, full_q]` rows, each sequence's tokens flushed
+    right. The slack that leaves belongs to no token and must read 0 -- the
+    indexer scores those rows too, and the destination arrives poisoned, so a
+    builder that only wrote the mapped slots would show `POISON` in the holes."""
+    full_q = 4
+    # Seq 0 brings 3 tokens, seq 1 brings 1 -- so both bands have holes, on a
+    # layout where a hole-free band would hide an off-by-one in the alignment.
+    rect = {
+        "rect_full_q": full_q,
+        "ragged_lens": torch.tensor([3, 1], dtype=torch.int32, device=DEV),
+        "cu_q_per_seq": torch.tensor([0, 3], dtype=torch.int32, device=DEV),
+    }
+    common = {
+        "positions": [126, 127, 128, 300, 0, 0],
+        "batch_id": [0, 0, 0, 1, -1, -1],
+        "t_pad": 6,
+        "n_rows": 2 * full_q,
+    }
+    kern = _run(build_v4_paged_decode_indptr, **common, **rect)
+    ref = _run(build_v4_paged_decode_indptr_reference, **common, **rect)
+    assert torch.equal(
+        kern["csa_n_committed_per_token"], ref["csa_n_committed_per_token"]
+    )
+    # Band 0 = [hole, 127//4, 128//4, 129//4]; band 1 = [hole, hole, hole, 301//4].
+    assert kern["csa_n_committed_per_token"].tolist() == [0, 31, 32, 32, 0, 0, 0, 75]
+
+
+# --- The cases above are all narrower than one iteration of the kernel's loop.
+#
+# `tl.arange(0, BLOCK)` is 1024 lanes wide whatever `t_pad` is, so a batch of ten
+# tokens leaves every lane past the tenth masked off: one loop trip, live lanes in
+# the first wave only. That reaches neither the running offsets carried BETWEEN
+# trips nor any interaction between waves. The two cases below are sized past both
+# -- several trips, live lanes throughout -- and are checked against the reference
+# rather than a written-out answer, because at this width nobody can read one.
+
+
+def test_a_token_indexed_destination_must_be_exactly_the_token_axis():
+    """Off the rectangle the destination IS the token axis, so a longer buffer
+    has a tail holding tokens this forward never declared -- and on a persistent
+    forward_vars buffer those are the last forward's live ids, not zeros. Caught
+    on the host rather than answered from them.
+
+    `ValueError`, so the check survives `python -O`."""
+    out = _outputs(8, 4)
+    with pytest.raises(ValueError, match="exactly T_pad"):
+        build_v4_paged_decode_indptr(
+            batch_id_per_token=torch.zeros(8, dtype=torch.int32, device=DEV),
+            positions=torch.arange(8, device=DEV),
+            T_pad=4,
+            win=WIN,
+            index_topk=INDEX_TOPK,
+            **out,
+        )
+
+
+def test_a_rectangle_must_carry_a_per_seq_entry_for_every_band():
+    """`seq = row // full_q` goes straight into `ragged_lens` and `cu_q_per_seq`
+    with nothing else bounding it, so their length is the bound. A short one
+    would be an unmasked device read of whatever follows -- which is why this
+    raises `ValueError` rather than asserting: `python -O` strips asserts."""
+    out = _outputs(4 * 4, 4)
+    with pytest.raises(ValueError, match="spans 4 bands"):
+        build_v4_paged_decode_indptr(
+            batch_id_per_token=torch.zeros(4, dtype=torch.int32, device=DEV),
+            positions=torch.arange(4, device=DEV),
+            T_pad=4,
+            win=WIN,
+            index_topk=INDEX_TOPK,
+            rect_full_q=4,
+            ragged_lens=torch.tensor([4, 4], dtype=torch.int32, device=DEV),
+            cu_q_per_seq=torch.tensor([0, 4], dtype=torch.int32, device=DEV),
+            **out,
+        )
+
+
+def _mtp_batch(num_seqs, group, first_pos):
+    """`num_seqs` sequences of `group` consecutive positions, one per MTP step."""
+    positions, batch_id = [], []
+    for s in range(num_seqs):
+        start = first_pos + s * 37  # a stride that is coprime with both ratios
+        positions += list(range(start, start + group))
+        batch_id += [s] * group
+    return positions, batch_id
+
+
+def test_wide_token_indexed_batch_matches_reference():
+    positions, batch_id = _mtp_batch(num_seqs=900, group=4, first_pos=125)
+    t_pad = 4096  # > 3 loop trips, and the tail is CG pad
+    batch = {
+        "positions": positions + [0] * (t_pad - len(positions)),
+        "batch_id": batch_id + [-1] * (t_pad - len(batch_id)),
+        "t_pad": t_pad,
+    }
+    kern = _run(build_v4_paged_decode_indptr, **batch)
+    ref = _run(build_v4_paged_decode_indptr_reference, **batch)
+    for name in kern:
+        assert torch.equal(kern[name], ref[name]), name
+    # An offset dropped between trips would still leave each trip internally
+    # consistent, so assert the total the readers size their pools by.
+    assert kern["swa_indptr"][-1].item() == sum(min(p + 1, WIN) for p in positions)
+
+
+def test_wide_dspark_rectangle_matches_reference():
+    full_q = 8
+    bs = 96  # 768 rows: past one trip in the destination loop as well
+    lens = [1 + (s * 5) % full_q for s in range(bs)]  # every band width appears
+    positions, batch_id, cu = [], [], [0]
+    for s, n in enumerate(lens):
+        start = 200 + s * 41
+        positions += list(range(start, start + n))
+        batch_id += [s] * n
+        cu.append(cu[-1] + n)
+    t_pad = len(positions)
+    common = {
+        "positions": positions,
+        "batch_id": batch_id,
+        "t_pad": t_pad,
+        "n_rows": bs * full_q,
+    }
+    rect = {
+        "rect_full_q": full_q,
+        "ragged_lens": torch.tensor(lens, dtype=torch.int32, device=DEV),
+        "cu_q_per_seq": torch.tensor(cu[:-1], dtype=torch.int32, device=DEV),
+    }
+    kern = _run(build_v4_paged_decode_indptr, **common, **rect)
+    ref = _run(build_v4_paged_decode_indptr_reference, **common, **rect)
+    for name in kern:
+        assert torch.equal(kern[name], ref[name]), name
+    # Holes outnumber mapped rows here, so a builder that wrote only the mapped
+    # ones would leave most of the destination poisoned.
+    assert (kern["csa_n_committed_per_token"] == 0).sum().item() == bs * full_q - t_pad

--- a/tests/test_decode_indptr_qlen_invariance.py
+++ b/tests/test_decode_indptr_qlen_invariance.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""A decode token's SWA / CSA / HCA metadata must not depend on its batch.
+
+`test_decode_indptr_build.py` pins the builder to its reference and to a stated
+answer. Neither settles the property this file is about, because both compare a
+batch against a number rather than a batch against another batch.
+
+The property: the token at absolute position `p` owns one SWA prefix length,
+one CSA visibility and one HCA group count, and all three follow from `p`. They
+may not move when the same token arrives on a step with a different **query
+length**. Speculative decode makes qlen vary step to step by acceptance, so a
+count that tracks qlen tracks something the model never authorised.
+
+Which token is probed is the whole design. The rule this replaced took the
+sequence's `ctx // ratio`, and `ctx` is the position of the group's LAST token
+plus one -- so on that rule the last token is the one that stays right and every
+EARLIER token inherits a count belonging to positions it may not see. A fixture
+that pins the group's end and varies its start therefore probes the one token
+both rules agree on, and passes either way. So `_group` holds the probed token
+fixed and varies how many drafts trail BEHIND it, which is what a change in
+acceptance actually does to a sequence.
+"""
+
+import itertools
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip(
+        "drives a Triton builder on real tensors; needs a GPU",
+        allow_module_level=True,
+    )
+
+from atom.model_ops.attentions.v4_pool_geometry import CSA_RATIO, HCA_RATIO
+from atom.model_ops.v4_kernels.paged_decode_indices import (
+    build_v4_paged_decode_indptr,
+)
+
+DEV = "cuda"
+WIN = 128
+INDEX_TOPK = 1024  # above every visibility here, so it never masks a difference
+
+
+def _build(groups, t_pad=None):
+    """Run the builder over `groups`, a list of per-sequence position lists.
+
+    Returns `{position: (swa, csa_head, hca_head, visibility)}` for every token,
+    so two batches can be compared token by token however they were packed.
+    """
+    positions = [p for g in groups for p in g]
+    batch_id = [i for i, g in enumerate(groups) for _ in g]
+    t = len(positions)
+    t_pad = t if t_pad is None else t_pad
+    positions = positions + [0] * (t_pad - t)
+    batch_id = batch_id + [-1] * (t_pad - t)
+
+    out = {
+        k: torch.full((t_pad + 1,), -7, dtype=torch.int32, device=DEV)
+        for k in ("swa_indptr", "csa_indptr", "hca_indptr")
+    }
+    out["csa_n_committed_per_token"] = torch.zeros(t_pad, dtype=torch.int32, device=DEV)
+    build_v4_paged_decode_indptr(
+        batch_id_per_token=torch.tensor(batch_id, dtype=torch.int32, device=DEV),
+        positions=torch.tensor(positions, dtype=torch.int64, device=DEV),
+        T_pad=t_pad,
+        win=WIN,
+        index_topk=INDEX_TOPK,
+        **out,
+    )
+    span = {}
+    for name in ("swa", "csa", "hca"):
+        d = out[f"{name}_indptr"]
+        span[name] = (d[1:] - d[:-1]).tolist()
+    vis = out["csa_n_committed_per_token"].tolist()
+    return {
+        positions[i]: (
+            span["swa"][i],
+            span["csa"][i] - span["swa"][i],
+            span["hca"][i] - span["swa"][i],
+            vis[i],
+        )
+        for i in range(t)
+    }
+
+
+def _group(probe, trailing):
+    """One sequence whose FIRST token is `probe`, with `trailing` drafts after."""
+    return [list(range(probe, probe + trailing + 1))]
+
+
+# Probes chosen so the drafts behind them cross a boundary of one ratio or the
+# other: 128 is the HCA group size, 4 the CSA one. 126 is the sharp one -- its
+# own count is 0 HCA groups, and any group of 2+ pushes the sequence past 128.
+PROBES = [1, 2, 3, 126, 127, 128, 129, 253, 254, 255, 1000]
+TRAILING = [0, 1, 2, 3, 4, 5]
+
+
+@pytest.mark.parametrize("probe", PROBES)
+def test_a_token_reads_the_same_counts_however_many_drafts_trail_it(probe):
+    seen = {n: _build(_group(probe, n))[probe] for n in TRAILING}
+    assert len(set(seen.values())) == 1, (
+        f"position {probe} changed its (swa, csa, hca, visibility) with the "
+        f"number of trailing drafts: {seen}"
+    )
+
+
+@pytest.mark.parametrize(
+    "probe,trailing", itertools.product([126, 128, 254], [0, 3, 5])
+)
+def test_a_token_reads_the_same_counts_next_to_any_batch_mate(probe, trailing):
+    """Nor does it care what the other sequences on the step look like."""
+    mine = _group(probe, trailing)
+    alone = _build(mine)[probe]
+    for mate, mate_trailing in ((1000, 0), (1000, 5), (5, 2)):
+        mates = _group(mate, mate_trailing)
+        assert _build(mine + mates)[probe] == alone, "a batch-mate moved it"
+        assert _build(mates + mine)[probe] == alone, "so did the packing order"
+
+
+def test_padding_the_step_to_a_captured_size_moves_nothing():
+    """A CUDAGraph step is padded to a capture size; the real tokens' counts
+    must equal those of the unpadded step they stand for."""
+    groups = _group(126, 4) + _group(1000, 1)
+    tight = _build(groups)
+    for pad in (8, 16, 64):
+        assert _build(groups, t_pad=pad) == tight, f"t_pad={pad} changed a count"
+
+
+@pytest.mark.parametrize("probe", PROBES)
+def test_the_slice_a_token_owns_is_exactly_what_it_uses(probe):
+    """Head and tail must tile each slice: compress section plus SWA prefix, no
+    gap. A gap is uninitialised memory the attention kernel goes on to read."""
+    swa, csa_head, hca_head, vis = _build(_group(probe, 5))[probe]
+    assert swa == min(probe + 1, WIN)
+    assert vis == (probe + 1) // CSA_RATIO
+    assert csa_head == min(vis, INDEX_TOPK)
+    assert hca_head == (probe + 1) // HCA_RATIO
+
+
+def test_the_fixtures_can_tell_the_two_rules_apart():
+    """Teeth check for everything above.
+
+    The rule this file guards against is `ctx // ratio`, the group's last
+    position plus one. If no fixture makes that disagree with the per-token
+    count, the invariance tests would hold on either rule and prove nothing.
+    Assert some fixture does disagree, and that the builder picks the token's.
+    """
+    disagree = [
+        (probe, n)
+        for probe in PROBES
+        for n in TRAILING
+        if (probe + 1) // HCA_RATIO != (probe + n + 1) // HCA_RATIO
+    ]
+    assert disagree, "no fixture separates the per-token rule from the per-sequence one"
+    for probe, n in disagree:
+        assert (
+            _build(_group(probe, n))[probe][2] == (probe + 1) // HCA_RATIO
+        ), f"probe {probe} with {n} trailing drafts took the sequence's count"

--- a/tests/test_deepseek_v4_transfer_regions.py
+++ b/tests/test_deepseek_v4_transfer_regions.py
@@ -74,6 +74,7 @@ def _stub_v4_runtime_imports():
     kernels.FP4_MQA_BLOCK_K = 128
     kernels.FP4_MQA_PARALLEL_UNIT_NUM = 1
     for name in (
+        "build_v4_paged_decode_indptr",
         "fp4_indexer_enabled",
         "hca_compress_paged_offsets",
         "write_v4_paged_decode_indices",

--- a/tests/test_prefill_indices_composition.py
+++ b/tests/test_prefill_indices_composition.py
@@ -75,11 +75,10 @@ def _run(seqs):
     bid = np.repeat(np.arange(len(seqs), dtype=np.int32), lens)
     pos = np.concatenate([np.arange(s, s + n) for s, n in zip(starts, lens)])
     cs_pt = np.asarray(starts, dtype=np.int64)[bid]
-    n_hca_seq = np.asarray([max(s // HCA_RATIO, 0) for s in starts], dtype=np.int32)
 
     extend_count = np.minimum(pos - cs_pt + 1, WIN)
     prefix_swa_count = np.maximum(cs_pt - np.maximum(pos - WIN + 1, 0), 0)
-    n_hca = np.minimum((pos + 1) // HCA_RATIO, n_hca_seq[bid])
+    n_hca = (pos + 1) // HCA_RATIO
     csa_head = np.asarray([_csa_head(p) for p in pos])
 
     total = len(pos)
@@ -109,7 +108,6 @@ def _run(seqs):
         chunk_start_per_seq=torch.tensor(starts, dtype=torch.int32, device=DEV),
         cu_seqlens_q_per_seq=torch.tensor(cu, dtype=torch.int32, device=DEV),
         state_slot_per_seq=torch.tensor(slots, dtype=torch.int32, device=DEV),
-        n_committed_hca_per_seq=torch.tensor(n_hca_seq, dtype=torch.int32, device=DEV),
         block_tables=torch.tensor(bts, dtype=torch.int32, device=DEV),
         T=total,
         win=WIN,

--- a/tests/test_prefill_indices_paged.py
+++ b/tests/test_prefill_indices_paged.py
@@ -57,7 +57,6 @@ def build(geometry):
     )
     chunk_start = torch.tensor([0, 16], dtype=torch.int32, device=DEV)
     state_slot = torch.tensor([3, 0], dtype=torch.int32, device=DEV)
-    n_hca_per_seq = torch.tensor([0, 2], dtype=torch.int32, device=DEV)
     block_tables = torch.randint(1, 40, (2, 8), dtype=torch.int32, device=DEV)
     total = positions.shape[0]
 
@@ -67,7 +66,7 @@ def build(geometry):
     cs_pt = chunk_start.cpu().numpy()[bid]
     extend_count = np.minimum(pos - cs_pt + 1, WIN)
     prefix_swa_count = np.maximum(cs_pt - np.maximum(pos - WIN + 1, 0), 0)
-    n_hca = np.minimum((pos + 1) // HCA_RATIO, n_hca_per_seq.cpu().numpy()[bid])
+    n_hca = (pos + 1) // HCA_RATIO
     csa_head = np.array([2, 1, 0, 3, 2, 1, 0, 2, 1])  # arbitrary; not written here
 
     ptrs = {
@@ -90,7 +89,6 @@ def build(geometry):
             chunk_start_per_seq=chunk_start,
             cu_seqlens_q_per_seq=torch.tensor([0, 5], dtype=torch.int32, device=DEV),
             state_slot_per_seq=state_slot,
-            n_committed_hca_per_seq=n_hca_per_seq,
             block_tables=block_tables,
             T=total,
             win=WIN,
@@ -195,7 +193,6 @@ def _run_k2(fn, out_hca):
         chunk_start_per_seq=one(0),
         cu_seqlens_q_per_seq=one(0),
         state_slot_per_seq=one(0),
-        n_committed_hca_per_seq=one(4),
         block_tables=torch.tensor([_BT_K2], dtype=torch.int32, device=DEV),
         extend_indptr=torch.tensor([0, WIN], dtype=torch.int32, device=DEV),
         prefix_swa_indptr=zero_ptr,

--- a/tests/test_v4_block_tables_per_token.py
+++ b/tests/test_v4_block_tables_per_token.py
@@ -10,7 +10,7 @@ tensors that are already there.
 That swap rests on one property of the row -> seq map: **the rows it marks
 invalid are a contiguous tail**. If they were interior, `index_select` over a
 prefix would fill the wrong rows and only the padding rows -- which the kernel
-skips because their `n_committed_per_token` is 0 -- would hide it. So the tail
+skips because their `csa_n_committed_per_token` is 0 -- would hide it. So the tail
 property is asserted directly, for both row layouts, before the gather is
 compared against the host expansion it replaces.
 

--- a/tests/test_v4_compress_visibility_lemma.py
+++ b/tests/test_v4_compress_visibility_lemma.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""The arithmetic behind dropping `min(per-token, ctx // ratio)`, exhausted.
+
+The V4 index builders used to bound a token's compress-group count twice: by
+the token's own position and again by its sequence's context length. The second
+bound is dropped on the grounds that it can never be the binding one.
+
+Only those grounds are settled here. Whether every site that applied it was
+actually visited is a property of the change, not of anything this file checks
+-- it belongs to review and to the commit message, and a test that went looking
+for the leftovers would be reading the source it is supposed to be testing.
+
+The grounds are pure arithmetic over two integers, so this file settles them by
+enumeration rather than by sampling, and it does so on the CPU with no aiter,
+no Triton and no GPU -- which is what lets it run in CI, where every
+kernel-vs-reference test in this repo skips itself.
+
+What enumeration CANNOT settle is the premise `pos < ctx`. That is a property
+of the code that BUILDS positions, not of the builders that consume them, and
+those live in the scheduler, in three metadata paths, and in two out-of-tree
+bridges. `test_decode_indptr_qlen_invariance.py` pins the consumer side; the
+premise itself is enforced by `require_step_within_full_q`, whose own tests are
+at the bottom of this file -- next to the lemma it exists to keep true.
+"""
+
+import numpy as np
+import pytest
+
+from atom.model_ops.attentions.v4_pool_geometry import (
+    CSA_RATIO,
+    HCA_RATIO,
+    require_step_within_full_q,
+)
+
+RATIOS = [CSA_RATIO, HCA_RATIO]
+# Past two HCA groups and 1024 CSA groups: every residue of both ratios appears
+# many times over, and so does every carry across a group boundary.
+LIMIT = 4096
+
+
+def _grid():
+    """Every `(ctx, pos)` pair with `1 <= ctx <= LIMIT` and `0 <= pos < LIMIT`."""
+    return np.meshgrid(
+        np.arange(1, LIMIT + 1, dtype=np.int64),
+        np.arange(LIMIT, dtype=np.int64),
+        indexing="ij",
+    )
+
+
+@pytest.mark.parametrize("ratio", RATIOS)
+def test_the_dropped_bound_never_binds_for_a_legal_position(ratio):
+    """Exhaustive over every `(ctx, pos)` with `0 <= pos < ctx <= LIMIT`."""
+    ctx, pos = _grid()
+    legal = pos < ctx
+    per_token = (pos + 1) // ratio
+    per_sequence = ctx // ratio
+    # Where a position is legal, the sequence's bound is never the smaller, so
+    # taking `min` of the two returns the per-token one unchanged.
+    assert np.array_equal(
+        np.minimum(per_token, per_sequence)[legal], per_token[legal]
+    ), f"ratio {ratio}: some legal (ctx, pos) has ctx//r < (pos+1)//r"
+
+
+@pytest.mark.parametrize("ratio", RATIOS)
+def test_the_bound_does_bind_once_a_position_runs_past_its_sequence(ratio):
+    """Teeth check. If the two expressions agreed everywhere, the test above
+    would hold for reasons having nothing to do with the premise, and deleting
+    the premise's guard would look safe when it is not."""
+    ctx, pos = _grid()
+    illegal = pos >= ctx
+    differs = (pos + 1) // ratio > ctx // ratio
+    assert np.any(differs & illegal), (
+        f"ratio {ratio}: no illegal position separates the two rules, so the "
+        f"exhaustive test above proves nothing about the premise"
+    )
+    # And every disagreement is on the illegal side -- none on the legal one.
+    assert not np.any(differs & ~illegal)
+
+
+@pytest.mark.parametrize("topk", [16, 64, 512])
+def test_the_index_topk_cap_is_not_redundant_and_must_stay(topk):
+    """CSA carries a third bound, `index_topk`. Unlike the sequence's count it
+    is a property of the OUTPUT buffer, so it does bind and had to be kept.
+    Asserted separately so a later cleanup does not sweep it up with the other.
+
+    CSA only: `index_topk` never reaches the HCA section, whose slice length is
+    the committed group count itself.
+    """
+    visible = (np.arange(LIMIT, dtype=np.int64) + 1) // CSA_RATIO
+    assert np.any(visible > topk), (
+        f"index_topk={topk} never binds within {LIMIT} positions, so this file "
+        f"says nothing about it"
+    )
+    assert np.any(visible <= topk), "and it must not bind everywhere either"
+
+
+# --- the premise's guard ----------------------------------------------------
+# Everything above is conditional on `pos < ctx`. `require_step_within_full_q`
+# is where that becomes true rather than assumed, so what these check is that
+# its accept/reject line is the SAME line as the premise's -- not that some
+# inequality raises.
+
+FULL_Q = 8
+
+
+def _last_position(ctx, length):
+    """Where a step's last token lands. `< ctx` is the whole premise."""
+    return ctx - FULL_Q + length - 1
+
+
+@pytest.mark.parametrize("length", range(1, 2 * FULL_Q + 1))
+def test_the_guard_accepts_exactly_the_steps_that_keep_a_position_legal(length):
+    """The guard's line and the premise's line are one line, checked at every
+    context long enough to hold a full step."""
+    legal = all(_last_position(ctx, length) < ctx for ctx in range(FULL_Q, 4 * FULL_Q))
+    assert legal == (length <= FULL_Q), "the position arithmetic moved"
+    if legal:
+        require_step_within_full_q(length, FULL_Q, "a step")
+    else:
+        with pytest.raises(ValueError, match="past its own context"):
+            require_step_within_full_q(length, FULL_Q, "a step")
+
+
+def test_the_guard_survives_python_dash_O():
+    """`assert` would not: the rectangle failure is a device-side out-of-bounds
+    read, so the check has to outlive the optimizer that strips asserts."""
+    with pytest.raises(ValueError) as excinfo:
+        require_step_within_full_q(FULL_Q + 1, FULL_Q, "a named source")
+    assert not isinstance(excinfo.value, AssertionError)
+    # The source is in the message: three producers call this, and "some
+    # sequence forwarded too much" is not actionable without knowing which.
+    assert "a named source" in str(excinfo.value)
+
+
+def test_an_empty_batch_is_not_a_violation():
+    """Callers pass 0 for an empty batch rather than branching around the call;
+    `max()` of nothing is what they would otherwise have to special-case."""
+    require_step_within_full_q(0, FULL_Q, "an empty step")


### PR DESCRIPTION
## What

Two intertwined moves on the DeepSeek-V4 decode metadata path.

**The indptr build leaves the host.** The three ragged cumsums (SWA / CSA / HCA) and
the CSA per-token visibility were rebuilt every decode step as three numpy cumsums
plus four H2D copies — of arrays whose every input already lived on the device.
`build_v4_paged_decode_indptr` replaces them with one Triton launch reading
`batch_id_per_token` and `positions` in place, so `v4_kv_indptr_{swa,csa,hca}` and
`v4_csa_n_committed_per_token` lose their host mirrors and become device-only.
`t_pad` stays a runtime argument on purpose: eager decode hands a fresh token count
almost every step, and a `constexpr` would make each one its own JIT variant.

**Compress visibility is bounded per token, not per sequence.** `ctx // ratio` is the
LAST token's count. An MTP or DSpark sequence hands `1 + k` tokens to one forward, so
giving that count to the earlier ones lets them read compressed groups holding their
own future drafts. Every site now uses `(pos + 1) // ratio`: ATOM decode and prefill,
both plugin bridges, and the two kernels in `deepseek_v4_ops`.

It was never a second cap on top of the per-token one either — it cannot bind while
`pos < ctx`. That premise reduces to "a sequence may not forward more tokens in one
step than `full_q`", which `require_step_within_full_q` now checks at ATOM's three
producers of per-seq step lengths instead of leaving it assumed.

`n_committed_hca_per_seq` disappears with its last reader. The CSA twin survives for
the two uses that are genuinely per-sequence: the indexer's `cu_committed` cumsum and
the FP4 ragged windows.

**One home for the rule.** `visible_csa` / `visible_hca` in `v4_pool_geometry`. The
twenty host-side sites that used to spell it inline call them instead — that is what
keeps the axis from drifting again, and it removes twenty-two hardcoded `4` / `128`
literals. The Triton kernels take the ratio as a `constexpr` and divide inline; the
reference implementations stay hand-written, so they can still fail a kernel that
restates the rule wrongly.

Guards on a buffer bound raise `ValueError` rather than assert: a truncated `[:n]`
slice is a device-side out-of-bounds write, and `python -O` strips asserts.

## Known gap, deliberately left in this PR

`atom/plugin/sglang/deepseek_v4_bridge.py` `build_atom_v4_verify_graph_metadata_from_sglang`
still bounds the indexer's `visible_end` by the per-sequence `n_csa[batch_np]`, while
the `csa_valid_k` sizing 58 lines above it in the same function drops it. It carries a
`NOTE` marking it as the one surviving instance on this axis.

Resolving it needs a fact I could not settle locally: whether sglang's
`forward_batch.seq_lens` during `TARGET_VERIFY` already includes the draft tokens.
The sibling backend `minimax_m3_sparse.py:77` compensates with
`seq_lens + spec_info.draft_token_num`, which suggests it does not — and if so, `pos < ctx`
is false on that path and the residual bound is load-bearing rather than vestigial.
sglang is not installed on the box this was developed on and `tests/plugin` is
`--ignore`d by the unit-test script, so this wants a reviewer who can run that path.

## Test plan

- [x] `bash .github/scripts/run_unit_tests.sh` — **4844 passed / 0 failed / 88 skipped / 3 xfailed**, on this branch rebased onto current `main`
- [x] `black --check atom/ tests/` clean
- [x] `ruff check` on all touched files: 11 == 11 against `main` (all pre-existing)
- [x] New: `test_decode_indptr_build.py` pins kernel against reference, and both against a written-out answer — kernel-vs-reference alone cannot settle the rule, since both compute the count from the same expression
- [x] New: `test_decode_indptr_qlen_invariance.py` pins a token's SWA / CSA / HCA counts across steps of differing query length, holding the probed token fixed and varying the drafts trailing behind it
- [x] New: `test_v4_compress_visibility_lemma.py` enumerates the arithmetic behind dropping the per-sequence bound — CPU only, no aiter / Triton / GPU, so it actually runs in CI
- [ ] **GSM8K accuracy gate on DeepSeek-V4-Flash-DSpark, n>=3** — not run on this branch
- [ ] **Decode throughput A/B** — not run; the host-side saving is three numpy cumsums and four H2D copies per step, against one added grid-(1,) Triton launch, and that trade has not been measured end to end at the largest real `T_pad`
- [ ] sglang verify-graph path (see the known gap above)
