### PR TITLE
[DCP] Fix sparse indexer local context metadata for CUDA graphs

### DIFF
--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -575,6 +575,12 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # Per-ubatch global (un-sharded) kv_indptr for round-robin CP (see the
             # shared "g_kv_indptr" buffer). Filled in _build_ubatch when dcp>1.
             var[f"{p}g_kv_indptr"] = CpuGpuBuffer(ub_max_bs + 1, **i32_kwargs)
+            if self.is_sparse and self.dcp_world_size > 1:
+                # Keep the layer-invariant local lengths available to the opaque
+                # sparse-indexer op in TBO, just like the full-batch metadata.
+                var[f"{p}dcp_local_context_lens"] = CpuGpuBuffer(
+                    ub_max_bs, **i32_kwargs
+                )
             var[f"{p}kv_indices"] = CpuGpuBuffer(
                 self.max_bs * self.max_num_blocks_per_seq,
                 **i32_kwargs,
@@ -1737,6 +1743,32 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             + dcp_local_index(pos, W, S) % block_size
         )
 
+    def _attach_dcp_local_context_lens(
+        self,
+        attn_metadata: AttentionMetaData,
+        rows: int,
+        *,
+        prefix: str = "",
+        copy_to_gpu: bool = False,
+    ) -> None:
+        """Attach the precomputed local KV lengths on every decode metadata path.
+
+        The sparse indexer is an opaque custom op, so CUDA graph capture fixes
+        the branch selected by ``dcp_local_context_lens`` at capture time. Keep
+        eager, graph-capture, and TBO metadata construction in one helper to
+        prevent any path from silently recording the elementwise fallback.
+        """
+        if not self.is_sparse or self.dcp_world_size <= 1:
+            attn_metadata.dcp_local_context_lens = None
+            return
+
+        buffer = self.model_runner.forward_vars[
+            f"{prefix}dcp_local_context_lens"
+        ]
+        attn_metadata.dcp_local_context_lens = (
+            buffer.copy_to_gpu(rows) if copy_to_gpu else buffer.gpu[:rows]
+        )
+
     def prepare_decode(
         self,
         batch: ScheduledBatch,
@@ -2001,12 +2033,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             if self.dcp_world_size > 1
             else None
         )
-        # Layer-invariant local KV lengths for the DCP sparse indexer (see the
-        # buffer's declaration). None off DCP so the consumer falls back.
-        attn_metadata.dcp_local_context_lens = (
-            var["dcp_local_context_lens"].copy_to_gpu(running_bs)
-            if self.dcp_world_size > 1
-            else None
+        self._attach_dcp_local_context_lens(
+            attn_metadata, running_bs, copy_to_gpu=True
         )
 
         if ctx_mla_ps_sparse is not None:
@@ -2123,6 +2151,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                     var[f"{p}g_kv_indptr"].np[ub_real_reqs] if ub_real_reqs > 0 else 0
                 )
                 var[f"{p}g_kv_indptr"].np[ub_real_reqs + 1 : running_bs + 1] = g_last
+                if self.is_sparse:
+                    var[f"{p}dcp_local_context_lens"].np[:ub_real_reqs] = var[
+                        "dcp_local_context_lens"
+                    ].np[req_start : req_start + ub_real_reqs]
+                    var[f"{p}dcp_local_context_lens"].np[
+                        ub_real_reqs:running_bs
+                    ] = 0
 
             if self.is_sparse:
                 full_sparse = var["sparse_kv_indptr"].np
@@ -2161,6 +2196,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             ]
             if self.dcp_world_size > 1:
                 vars_used.append((f"{p}g_kv_indptr", running_bs + 1))
+            if self.is_sparse and self.dcp_world_size > 1:
+                vars_used.append((f"{p}dcp_local_context_lens", running_bs))
             if self.is_sparse:
                 vars_used.append((f"{p}sparse_kv_indptr", running_bs + 1))
 
@@ -2273,6 +2310,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 np.arange(bs + 1, dtype=np.int32) * self.dcp_world_size
             )
             var["g_kv_indptr"].copy_to_gpu(bs + 1)
+        if self.is_sparse and self.dcp_world_size > 1:
+            # Capture uses one synthetic local KV token per request. Replay
+            # overwrites this same backing buffer with the real per-step values.
+            var["dcp_local_context_lens"].np[:bs] = 1
+            var["dcp_local_context_lens"].copy_to_gpu(bs)
         if is_sparse_mtp:
             # Two sets: normal for dense layers, sparse_mtp for sparse layers
             ctx_mla_ps = self.set_mla_persistent_worker_buffers(bs, max_q_len)
@@ -2303,6 +2345,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         attn_matadata.g_kv_indptr = (
             var["g_kv_indptr"].gpu[: bs + 1] if self.dcp_world_size > 1 else None
         )
+        self._attach_dcp_local_context_lens(attn_matadata, bs)
         if ctx_mla_ps_sparse is not None:
             for k, v in ctx_mla_ps_sparse.items():
                 setattr(attn_matadata, k, v)
@@ -2389,6 +2432,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             var[f"{p}g_kv_indptr"].gpu[: running_bs + 1]
             if self.dcp_world_size > 1
             else None
+        )
+        self._attach_dcp_local_context_lens(
+            attn, running_bs, prefix=p
         )
         return attn
 

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -248,6 +248,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
         self.dcp_world_size = get_dcp_world_size()
         self.dcp_rank = get_dcp_rank()
+        self._publishes_dcp_local_lens = self.is_sparse and self.dcp_world_size > 1
+        self._tbo_full_running_bs = 0
 
         # DCP decode all-gathers Q on the head dim, so the head count reaching
         # mla_decode_fwd (and thus the persistent decode metadata) is the padded
@@ -329,18 +331,18 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # mla_decode_fwd(g_kv_indptr=...) to apply the global-position causal
             # mask for MTP (max_q_len > 1).
             "g_kv_indptr": CpuGpuBuffer(self.max_bs + 1, **i32_kwargs),
-            # Per-request LOCAL (this rank's shard) KV length under DCP. Same
-            # quantity `get_dcp_local_seq_lens` already produces here on the host;
-            # published so the sparse indexer does not recompute it on device once
-            # per full-index layer (21 layers on GLM-5.2). Layer-invariant: it
-            # depends only on context_lens / S / W / dcp_rank.
-            "dcp_local_context_lens": CpuGpuBuffer(self.max_bs, **i32_kwargs),
             "kv_indices": CpuGpuBuffer(
                 self.max_bs * self.max_num_blocks_per_seq,
                 **i32_kwargs,
             ),
             "kv_last_page_lens": CpuGpuBuffer(self.max_bs, **i32_kwargs),
         }
+        if self._publishes_dcp_local_lens:
+            # Layer-invariant qlen=1 sparse-DSA indexer metadata. It is derived
+            # from context_lens once per step and reused by every full layer.
+            mla_metadata["dcp_local_context_lens"] = CpuGpuBuffer(
+                self.max_bs, **i32_kwargs
+            )
         mla_metadata["kv_last_page_lens"].cpu.fill_(1)
         mla_metadata["kv_last_page_lens"].copy_to_gpu()
         if self.is_sparse:
@@ -575,12 +577,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # Per-ubatch global (un-sharded) kv_indptr for round-robin CP (see the
             # shared "g_kv_indptr" buffer). Filled in _build_ubatch when dcp>1.
             var[f"{p}g_kv_indptr"] = CpuGpuBuffer(ub_max_bs + 1, **i32_kwargs)
-            if self.is_sparse and self.dcp_world_size > 1:
-                # Keep the layer-invariant local lengths available to the opaque
-                # sparse-indexer op in TBO, just like the full-batch metadata.
-                var[f"{p}dcp_local_context_lens"] = CpuGpuBuffer(
-                    ub_max_bs, **i32_kwargs
-                )
             var[f"{p}kv_indices"] = CpuGpuBuffer(
                 self.max_bs * self.max_num_blocks_per_seq,
                 **i32_kwargs,
@@ -1743,30 +1739,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             + dcp_local_index(pos, W, S) % block_size
         )
 
-    def _attach_dcp_local_context_lens(
-        self,
-        attn_metadata: AttentionMetaData,
-        rows: int,
-        *,
-        prefix: str = "",
-        copy_to_gpu: bool = False,
-    ) -> None:
-        """Attach the precomputed local KV lengths on every decode metadata path.
-
-        The sparse indexer is an opaque custom op, so CUDA graph capture fixes
-        the branch selected by ``dcp_local_context_lens`` at capture time. Keep
-        eager, graph-capture, and TBO metadata construction in one helper to
-        prevent any path from silently recording the elementwise fallback.
-        """
-        if not self.is_sparse or self.dcp_world_size <= 1:
-            attn_metadata.dcp_local_context_lens = None
-            return
-
-        buffer = self.model_runner.forward_vars[f"{prefix}dcp_local_context_lens"]
-        attn_metadata.dcp_local_context_lens = (
-            buffer.copy_to_gpu(rows) if copy_to_gpu else buffer.gpu[:rows]
-        )
-
     def prepare_decode(
         self,
         batch: ScheduledBatch,
@@ -1842,10 +1814,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 self.dcp_rank,
                 self.cp_kv_cache_interleave_size,
             )
-            # Publish it: the sparse indexer used to re-derive this on device with
-            # 8 elementwise kernels per full-index layer.
-            var["dcp_local_context_lens"].np[:scheduled_bs] = local_context_lens
-            var["dcp_local_context_lens"].np[scheduled_bs:running_bs] = 0
+            if self._publishes_dcp_local_lens:
+                # Publish once per step instead of launching 7 elementwise
+                # kernels in every full sparse-indexer layer.
+                var["dcp_local_context_lens"].np[:scheduled_bs] = local_context_lens
+                var["dcp_local_context_lens"].np[scheduled_bs:running_bs] = 0
             num_blocks_per_seq = cdiv(local_context_lens, self.block_size)
         elif any(batch.is_first_decode_without_local_prefill):
             num_blocks_per_seq = [
@@ -1899,6 +1872,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             ("kv_last_page_lens", running_bs),
             ("block_tables", running_bs),
         ]
+        if self._publishes_dcp_local_lens:
+            vars_used.append(("dcp_local_context_lens", running_bs))
         metadata_deps = {
             "cu_seqlens_q",
             "kv_last_page_lens",
@@ -2031,7 +2006,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             if self.dcp_world_size > 1
             else None
         )
-        self._attach_dcp_local_context_lens(attn_metadata, running_bs, copy_to_gpu=True)
 
         if ctx_mla_ps_sparse is not None:
             for k, v in ctx_mla_ps_sparse.items():
@@ -2083,6 +2057,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         Splits the full-batch data into per-ubatch .
         """
         var = self.model_runner.forward_vars
+        self._tbo_full_running_bs = bs
         N = self._NUM_TBO_UBATCHES
         half = bs // N
 
@@ -2147,11 +2122,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                     var[f"{p}g_kv_indptr"].np[ub_real_reqs] if ub_real_reqs > 0 else 0
                 )
                 var[f"{p}g_kv_indptr"].np[ub_real_reqs + 1 : running_bs + 1] = g_last
-                if self.is_sparse:
-                    var[f"{p}dcp_local_context_lens"].np[:ub_real_reqs] = var[
-                        "dcp_local_context_lens"
-                    ].np[req_start : req_start + ub_real_reqs]
-                    var[f"{p}dcp_local_context_lens"].np[ub_real_reqs:running_bs] = 0
 
             if self.is_sparse:
                 full_sparse = var["sparse_kv_indptr"].np
@@ -2190,8 +2160,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             ]
             if self.dcp_world_size > 1:
                 vars_used.append((f"{p}g_kv_indptr", running_bs + 1))
-            if self.is_sparse and self.dcp_world_size > 1:
-                vars_used.append((f"{p}dcp_local_context_lens", running_bs))
             if self.is_sparse:
                 vars_used.append((f"{p}sparse_kv_indptr", running_bs + 1))
 
@@ -2261,6 +2229,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
 
     def build_for_cudagraph_capture(self, bs: int) -> AttentionMetaData:
         var = self.model_runner.forward_vars
+        self._tbo_full_running_bs = bs
         # Self-consistent minimal KV metadata for capture: give every sequence
         # exactly 1 page (kv_indptr = [0,1,...,bs]) pointing at block 0, with a
         # 1-token last page. The split-KV stage1 asm kernel computes per batch
@@ -2304,11 +2273,12 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 np.arange(bs + 1, dtype=np.int32) * self.dcp_world_size
             )
             var["g_kv_indptr"].copy_to_gpu(bs + 1)
-        if self.is_sparse and self.dcp_world_size > 1:
-            # Capture uses one synthetic local KV token per request. Replay
-            # overwrites this same backing buffer with the real per-step values.
+        dcp_local_context_lens = None
+        if self._publishes_dcp_local_lens:
+            # The warmup forward reads this buffer before replay overwrites it.
+            # One local token matches the synthetic capture KV metadata above.
             var["dcp_local_context_lens"].np[:bs] = 1
-            var["dcp_local_context_lens"].copy_to_gpu(bs)
+            dcp_local_context_lens = var["dcp_local_context_lens"].copy_to_gpu(bs)
         if is_sparse_mtp:
             # Two sets: normal for dense layers, sparse_mtp for sparse layers
             ctx_mla_ps = self.set_mla_persistent_worker_buffers(bs, max_q_len)
@@ -2330,6 +2300,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             kv_indices=var["kv_indices"].gpu,
             kv_last_page_lens=var["kv_last_page_lens"].gpu[:bs],
             sparse_kv_indptr=sparse_kv_indptr,
+            dcp_local_context_lens=dcp_local_context_lens,
             **ctx_mla_ps,
         )
         attn_matadata.dtype_q = self.dtype_q
@@ -2339,7 +2310,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         attn_matadata.g_kv_indptr = (
             var["g_kv_indptr"].gpu[: bs + 1] if self.dcp_world_size > 1 else None
         )
-        self._attach_dcp_local_context_lens(attn_matadata, bs)
         if ctx_mla_ps_sparse is not None:
             for k, v in ctx_mla_ps_sparse.items():
                 setattr(attn_matadata, k, v)
@@ -2384,6 +2354,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         var = self.model_runner.forward_vars
         p = f"ub{ubatch_idx}_"
         max_q_len = var["mtp_k"] + 1 if "mtp_k" in var else 1
+        dcp_local_context_lens = None
+        if self._publishes_dcp_local_lens:
+            requests_per_ubatch = self._tbo_full_running_bs // self._NUM_TBO_UBATCHES
+            request_start = ubatch_idx * requests_per_ubatch
+            dcp_local_context_lens = var["dcp_local_context_lens"].gpu[
+                request_start : request_start + running_bs
+            ]
 
         # Compute MLA work buffers for this ubatch
         self._set_ubatch_mla_buffers(
@@ -2402,6 +2379,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             kv_indptr=var[f"{p}kv_indptr"].gpu[: running_bs + 1],
             kv_indices=var[f"{p}kv_indices"].gpu,
             kv_last_page_lens=var[f"{p}kv_last_page_lens"].gpu[:running_bs],
+            dcp_local_context_lens=dcp_local_context_lens,
             sparse_kv_indptr=(
                 var[f"{p}sparse_kv_indptr"].gpu[: running_bs + 1]
                 if self.is_sparse
@@ -2427,7 +2405,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             if self.dcp_world_size > 1
             else None
         )
-        self._attach_dcp_local_context_lens(attn, running_bs, prefix=p)
         return attn
 
     def build_ubatch_prefill_metadata(

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -1762,9 +1762,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.dcp_local_context_lens = None
             return
 
-        buffer = self.model_runner.forward_vars[
-            f"{prefix}dcp_local_context_lens"
-        ]
+        buffer = self.model_runner.forward_vars[f"{prefix}dcp_local_context_lens"]
         attn_metadata.dcp_local_context_lens = (
             buffer.copy_to_gpu(rows) if copy_to_gpu else buffer.gpu[:rows]
         )
@@ -2033,9 +2031,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             if self.dcp_world_size > 1
             else None
         )
-        self._attach_dcp_local_context_lens(
-            attn_metadata, running_bs, copy_to_gpu=True
-        )
+        self._attach_dcp_local_context_lens(attn_metadata, running_bs, copy_to_gpu=True)
 
         if ctx_mla_ps_sparse is not None:
             for k, v in ctx_mla_ps_sparse.items():
@@ -2155,9 +2151,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                     var[f"{p}dcp_local_context_lens"].np[:ub_real_reqs] = var[
                         "dcp_local_context_lens"
                     ].np[req_start : req_start + ub_real_reqs]
-                    var[f"{p}dcp_local_context_lens"].np[
-                        ub_real_reqs:running_bs
-                    ] = 0
+                    var[f"{p}dcp_local_context_lens"].np[ub_real_reqs:running_bs] = 0
 
             if self.is_sparse:
                 full_sparse = var["sparse_kv_indptr"].np
@@ -2433,9 +2427,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             if self.dcp_world_size > 1
             else None
         )
-        self._attach_dcp_local_context_lens(
-            attn, running_bs, prefix=p
-        )
+        self._attach_dcp_local_context_lens(attn, running_bs, prefix=p)
         return attn
 
     def build_ubatch_prefill_metadata(

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -19,6 +19,7 @@ import triton
 import triton.language as tl
 
 from atom.distributed.dcp_utils import get_dcp_group, get_dcp_world_size
+from atom.utils.forward_context import get_published_dcp_local_context_lens
 
 _AG_CUSTOM_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
 
@@ -953,12 +954,12 @@ def dcp_local_context_lens(
 
     Depends only on context_lens / S / W / dcp_rank, so it is the same for every
     layer and prepare_decode already computes it on the host. Prefer that
-    published buffer -- deriving it here costs 8 elementwise kernels on every
+    published buffer -- deriving it here costs 7 elementwise kernels on every
     full-index layer (21 of them on GLM-5.2). The fallback keeps metadata
     builders that do not publish it working.
     """
-    local_ctx = getattr(attn_metadata, "dcp_local_context_lens", None)
-    if local_ctx is not None and local_ctx.shape[0] == num_rows:
+    local_ctx = get_published_dcp_local_context_lens(attn_metadata, num_rows)
+    if local_ctx is not None:
         return local_ctx
     g_ctx = attn_metadata.context_lens
     S = cp_kv_cache_interleave_size

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -587,6 +587,9 @@ class AttentionMetaData:
     # prefill/MTP-verify and per seq in decode. Separate from kv_last_page_lens
     # (the dense per-seq buffer) so the two never clobber each other.
     sparse_kv_last_page_lens: torch.Tensor | None = None
+    # Precomputed per-rank context lengths for qlen=1 sparse DSA + DCP decode.
+    # The padded running-width buffer is shared by eager, graph and TBO paths.
+    dcp_local_context_lens: torch.Tensor | None = None
 
     work_meta_data: torch.Tensor | None = None
     work_indptr: torch.Tensor | None = None
@@ -621,6 +624,8 @@ class AttentionMetaData:
         cu_seqlen_ks: torch.Tensor | None = None,
         cu_seqlen_ke: torch.Tensor | None = None,
         sparse_kv_indptr: torch.Tensor | None = None,
+        sparse_kv_last_page_lens: torch.Tensor | None = None,
+        dcp_local_context_lens: torch.Tensor | None = None,
         work_meta_data: torch.Tensor | None = None,
         work_indptr: torch.Tensor | None = None,
         work_info_set: torch.Tensor | None = None,
@@ -656,6 +661,8 @@ class AttentionMetaData:
         self.cu_seqlen_ks = cu_seqlen_ks
         self.cu_seqlen_ke = cu_seqlen_ke
         self.sparse_kv_indptr = sparse_kv_indptr
+        self.sparse_kv_last_page_lens = sparse_kv_last_page_lens
+        self.dcp_local_context_lens = dcp_local_context_lens
         self.work_meta_data = work_meta_data
         self.work_indptr = work_indptr
         self.work_info_set = work_info_set
@@ -676,6 +683,23 @@ class AttentionMetaData:
             for field in fields(self)
             if field.name not in skip_fields
         }
+
+
+def get_published_dcp_local_context_lens(
+    attn_metadata: AttentionMetaData, num_rows: int
+) -> torch.Tensor | None:
+    """Return the valid prefix of a published sparse-DCP local-length buffer.
+
+    Metadata is allocated at the engine's padded running width while PIECEWISE
+    eager execution may score only the scheduled rows. The real requests are
+    always the prefix and the producer zero-fills the padded tail.
+    """
+    local_ctx = attn_metadata.dcp_local_context_lens
+    if local_ctx is None or local_ctx.shape[0] < num_rows:
+        return None
+    if local_ctx.shape[0] == num_rows:
+        return local_ctx
+    return local_ctx[:num_rows]
 
 
 @dataclass

--- a/tests/test_dcp_topk.py
+++ b/tests/test_dcp_topk.py
@@ -507,8 +507,7 @@ def test_prefill_filter_is_layout_independent(
 class _FakeMeta:
     def __init__(self, ctx, published=None):
         self.context_lens = ctx
-        if published is not None:
-            self.dcp_local_context_lens = published
+        self.dcp_local_context_lens = published
 
 
 @pytest.mark.parametrize("world", [2, 4, 8])
@@ -517,7 +516,7 @@ def test_local_context_lens_prefers_published_buffer(world, interleave):
     """The published host buffer must be returned as-is, not recomputed.
 
     Identity, not equality: returning an equal-but-recomputed tensor is exactly
-    the regression this guards (8 elementwise kernels per full-index layer).
+    the regression this guards (7 elementwise kernels per full-index layer).
     """
     rows = 37
     ctx = torch.randint(1, 100000, (rows,), dtype=torch.int32, device=DEV)
@@ -543,9 +542,8 @@ def test_local_context_lens_fallback_matches_reference(world, interleave):
         ]
     )
     for meta in (
-        _FakeMeta(ctx),  # attribute absent
-        _FakeMeta(ctx, None),  # published but None (non-DCP metadata builder)
-        _FakeMeta(ctx, torch.zeros(rows + 1, dtype=torch.int32, device=DEV)),  # stale
+        _FakeMeta(ctx),  # non-DCP or non-sparse metadata builder
+        _FakeMeta(ctx, torch.zeros(rows - 1, dtype=torch.int32, device=DEV)),  # stale
     ):
         got = dcp_local_context_lens(meta, 0, world, interleave, rows)
         assert got.dtype == torch.int32

--- a/tests/test_mla_index_cache.py
+++ b/tests/test_mla_index_cache.py
@@ -4,6 +4,7 @@
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
 from atom.models.utils import get_pp_indices
@@ -13,6 +14,7 @@ try:
 
     from atom.model_ops.attentions import aiter_mla
     from atom.model_ops.attentions.aiter_mla import AiterMLAMetadataBuilder
+    from atom.model_ops.dcp_ops import dcp_local_context_lens
 except (ImportError, RuntimeError) as exc:
     pytest.skip(f"aiter MLA backend unavailable: {exc}", allow_module_level=True)
 
@@ -349,3 +351,86 @@ def test_transfer_regions_use_explicit_compact_consumer_map(monkeypatch):
         9,
         10,
     ]
+
+
+class _FakeMetadataBuffer:
+    def __init__(self, size):
+        self.np = np.zeros(size, dtype=np.int32)
+        self.gpu = np.zeros(size, dtype=np.int32)
+        self.copy_sizes = []
+
+    def copy_to_gpu(self, size):
+        self.copy_sizes.append(size)
+        self.gpu[:size] = self.np[:size]
+        return self.gpu[:size]
+
+
+def _capture_metadata_builder(dcp_world_size, *, is_sparse):
+    bs = 4
+    var = {
+        "slot_mapping": _FakeMetadataBuffer(bs),
+        "context_lens": _FakeMetadataBuffer(bs),
+        "block_tables": _FakeMetadataBuffer(bs),
+        "cu_seqlens_q": _FakeMetadataBuffer(bs + 1),
+        "kv_indptr": _FakeMetadataBuffer(bs + 1),
+        "kv_indices": _FakeMetadataBuffer(bs),
+        "kv_last_page_lens": _FakeMetadataBuffer(bs),
+        "positions": _FakeMetadataBuffer(bs),
+        "g_kv_indptr": _FakeMetadataBuffer(bs + 1),
+    }
+    if is_sparse:
+        var["sparse_kv_indptr"] = _FakeMetadataBuffer(bs + 1)
+        var["sparse_kv_last_page_lens"] = _FakeMetadataBuffer(bs)
+    if is_sparse and dcp_world_size > 1:
+        var["dcp_local_context_lens"] = _FakeMetadataBuffer(bs)
+
+    builder = object.__new__(AiterMLAMetadataBuilder)
+    builder.model_runner = SimpleNamespace(forward_vars=var)
+    builder.block_size = 1
+    builder.is_sparse = is_sparse
+    builder.dcp_world_size = dcp_world_size
+    builder.dtype_q = None
+    builder.set_mla_persistent_worker_buffers = lambda *args, **kwargs: {}
+    return builder, var
+
+
+def test_cudagraph_capture_publishes_dcp_local_context_lens():
+    builder, var = _capture_metadata_builder(dcp_world_size=4, is_sparse=True)
+
+    metadata, _ = builder.build_for_cudagraph_capture(bs=4)
+
+    np.testing.assert_array_equal(metadata.dcp_local_context_lens, np.ones(4))
+    assert var["dcp_local_context_lens"].copy_sizes == [4]
+    assert (
+        dcp_local_context_lens(metadata, 0, 4, 1, 4)
+        is metadata.dcp_local_context_lens
+    )
+
+
+def test_cudagraph_capture_keeps_tp_path_independent_of_dcp_buffer():
+    builder, var = _capture_metadata_builder(dcp_world_size=1, is_sparse=True)
+    assert "dcp_local_context_lens" not in var
+
+    metadata, _ = builder.build_for_cudagraph_capture(bs=4)
+
+    assert metadata.dcp_local_context_lens is None
+
+
+def test_cudagraph_capture_keeps_dense_dcp_independent_of_sparse_buffer():
+    builder, var = _capture_metadata_builder(dcp_world_size=4, is_sparse=False)
+    assert "dcp_local_context_lens" not in var
+
+    metadata, _ = builder.build_for_cudagraph_capture(bs=4)
+
+    assert metadata.dcp_local_context_lens is None
+
+
+def test_dcp_local_context_attachment_supports_ubatch_prefix():
+    builder, var = _capture_metadata_builder(dcp_world_size=4, is_sparse=True)
+    var["ub0_dcp_local_context_lens"] = _FakeMetadataBuffer(4)
+    var["ub0_dcp_local_context_lens"].gpu[:] = np.arange(4, dtype=np.int32)
+    metadata = SimpleNamespace()
+
+    builder._attach_dcp_local_context_lens(metadata, 3, prefix="ub0_")
+
+    np.testing.assert_array_equal(metadata.dcp_local_context_lens, [0, 1, 2])

--- a/tests/test_mla_index_cache.py
+++ b/tests/test_mla_index_cache.py
@@ -402,8 +402,7 @@ def test_cudagraph_capture_publishes_dcp_local_context_lens():
     np.testing.assert_array_equal(metadata.dcp_local_context_lens, np.ones(4))
     assert var["dcp_local_context_lens"].copy_sizes == [4]
     assert (
-        dcp_local_context_lens(metadata, 0, 4, 1, 4)
-        is metadata.dcp_local_context_lens
+        dcp_local_context_lens(metadata, 0, 4, 1, 4) is metadata.dcp_local_context_lens
     )
 
 

--- a/tests/test_mla_index_cache.py
+++ b/tests/test_mla_index_cache.py
@@ -6,15 +6,16 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import torch
 
 from atom.models.utils import get_pp_indices
+from atom.utils.forward_context import get_published_dcp_local_context_lens
 
 try:
     import aiter  # noqa: F401
 
     from atom.model_ops.attentions import aiter_mla
     from atom.model_ops.attentions.aiter_mla import AiterMLAMetadataBuilder
-    from atom.model_ops.dcp_ops import dcp_local_context_lens
 except (ImportError, RuntimeError) as exc:
     pytest.skip(f"aiter MLA backend unavailable: {exc}", allow_module_level=True)
 
@@ -356,12 +357,12 @@ def test_transfer_regions_use_explicit_compact_consumer_map(monkeypatch):
 class _FakeMetadataBuffer:
     def __init__(self, size):
         self.np = np.zeros(size, dtype=np.int32)
-        self.gpu = np.zeros(size, dtype=np.int32)
+        self.gpu = torch.zeros(size, dtype=torch.int32)
         self.copy_sizes = []
 
     def copy_to_gpu(self, size):
         self.copy_sizes.append(size)
-        self.gpu[:size] = self.np[:size]
+        self.gpu[:size].copy_(torch.from_numpy(self.np[:size]))
         return self.gpu[:size]
 
 
@@ -389,6 +390,8 @@ def _capture_metadata_builder(dcp_world_size, *, is_sparse):
     builder.block_size = 1
     builder.is_sparse = is_sparse
     builder.dcp_world_size = dcp_world_size
+    builder._publishes_dcp_local_lens = is_sparse and dcp_world_size > 1
+    builder._tbo_full_running_bs = 0
     builder.dtype_q = None
     builder.set_mla_persistent_worker_buffers = lambda *args, **kwargs: {}
     return builder, var
@@ -399,15 +402,26 @@ def test_cudagraph_capture_publishes_dcp_local_context_lens():
 
     metadata, _ = builder.build_for_cudagraph_capture(bs=4)
 
-    np.testing.assert_array_equal(metadata.dcp_local_context_lens, np.ones(4))
+    torch.testing.assert_close(
+        metadata.dcp_local_context_lens, torch.ones(4, dtype=torch.int32)
+    )
     assert var["dcp_local_context_lens"].copy_sizes == [4]
     assert (
-        dcp_local_context_lens(metadata, 0, 4, 1, 4) is metadata.dcp_local_context_lens
+        get_published_dcp_local_context_lens(metadata, 4)
+        is metadata.dcp_local_context_lens
     )
 
 
-def test_cudagraph_capture_keeps_tp_path_independent_of_dcp_buffer():
-    builder, var = _capture_metadata_builder(dcp_world_size=1, is_sparse=True)
+@pytest.mark.parametrize(
+    ("dcp_world_size", "is_sparse"),
+    [(1, True), (4, False)],
+)
+def test_cudagraph_capture_keeps_non_sparse_dcp_paths_independent(
+    dcp_world_size, is_sparse
+):
+    builder, var = _capture_metadata_builder(
+        dcp_world_size=dcp_world_size, is_sparse=is_sparse
+    )
     assert "dcp_local_context_lens" not in var
 
     metadata, _ = builder.build_for_cudagraph_capture(bs=4)
@@ -415,21 +429,40 @@ def test_cudagraph_capture_keeps_tp_path_independent_of_dcp_buffer():
     assert metadata.dcp_local_context_lens is None
 
 
-def test_cudagraph_capture_keeps_dense_dcp_independent_of_sparse_buffer():
-    builder, var = _capture_metadata_builder(dcp_world_size=4, is_sparse=False)
-    assert "dcp_local_context_lens" not in var
-
-    metadata, _ = builder.build_for_cudagraph_capture(bs=4)
-
-    assert metadata.dcp_local_context_lens is None
-
-
-def test_dcp_local_context_attachment_supports_ubatch_prefix():
+def test_ubatch_metadata_views_full_dcp_local_context_buffer():
     builder, var = _capture_metadata_builder(dcp_world_size=4, is_sparse=True)
-    var["ub0_dcp_local_context_lens"] = _FakeMetadataBuffer(4)
-    var["ub0_dcp_local_context_lens"].gpu[:] = np.arange(4, dtype=np.int32)
-    metadata = SimpleNamespace()
+    builder._tbo_full_running_bs = 4
+    builder._set_ubatch_mla_buffers = lambda *args, **kwargs: None
+    var["dcp_local_context_lens"].gpu.copy_(
+        torch.tensor([11, 12, 13, 14], dtype=torch.int32)
+    )
+    p = "ub1_"
+    for name, size in (
+        ("slot_mapping", 2),
+        ("context_lens", 2),
+        ("block_tables", 2),
+        ("cu_seqlens_q", 3),
+        ("kv_indptr", 3),
+        ("kv_indices", 2),
+        ("kv_last_page_lens", 2),
+        ("sparse_kv_indptr", 3),
+        ("g_kv_indptr", 3),
+    ):
+        var[f"{p}{name}"] = _FakeMetadataBuffer(size)
+    for name in (
+        "work_meta_data",
+        "work_info_set",
+        "work_indptr",
+        "reduce_indptr",
+        "reduce_final_map",
+        "reduce_partial_map",
+    ):
+        var[f"{p}{name}"] = torch.empty(1)
 
-    builder._attach_dcp_local_context_lens(metadata, 3, prefix="ub0_")
+    metadata = builder.build_ubatch_metadata(ubatch_idx=1, running_bs=2)
 
-    np.testing.assert_array_equal(metadata.dcp_local_context_lens, [0, 1, 2])
+    torch.testing.assert_close(
+        metadata.dcp_local_context_lens,
+        torch.tensor([13, 14], dtype=torch.int32),
+    )
+    assert "ub1_dcp_local_context_lens" not in var


### PR DESCRIPTION
## Motivation
 - Attach precomputed DCP local context lengths to CUDA Graph capture metadata.
 - Share the same metadata wiring across eager, CUDA Graph, and TBO paths.
 - Avoid capturing redundant elementwise kernels in every full-index layer.
 - Restrict the change to sparse DSA with DCP enabled.

## Root Cause
CUDA Graph capture metadata omitted dcp_local_context_lens, causing the sparse indexer to capture the eager elementwise fallback. Runtime metadata updates could not change the already-captured graph.

## Compatibility
Pure TP, dense MLA, and non-sparse models remain unchanged. LMCache compatibility is preserved because local context lengths are derived per decode step and are not persisted as KV-cache state.

## performance
before
<img width="2900" height="119" alt="image" src="https://github.com/user-attachments/assets/420410e0-45d5-47ff-b525-2dd3228e2b4c" />

after
<img width="1514" height="159" alt="image" src="https://github.com/user-attachments/assets/f9af2d2c-7bce-4dda-8555-b635d8c6d7cf" />
7 elementwise kernel are removed.

## Test Plan
gsm8k 5shot & 20shot for DCP4+TP4
server
```bash
export AITER_QUICK_REDUCE_QUANTIZATION=INT4
export AITER_USE_FLYDSL_MOE_SORTING=1
TP=${TP:-4}
CONC=${CONC:-64}
export ATOM_ENABLE_DETAILED_ANNOTATION=1
export PYTHONPATH=/home/qichu_qle/yuhua/work/pr/ATOM
export CUDA_VISIBLE_DEVICES=4,5,6,7
 
python -m atom.entrypoints.openai_server \
  --model "$model_path" \
  --server-port 8013 \
  --kv_cache_dtype fp8 \
  --online_quant_config '{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","*.mlp.gate","*expert*"]}' \
  -tp $TP \
  -dcp 4 \
  --max-num-seqs $((CONC * 2)) \
  --max-num-batched-tokens 16384 \
  2>&1 | tee "./server-glm5.2-fp4.log"
```
acc test 20 shot
```bash
python3 -m lm_eval --model local-chat-completions --apply_chat_template --tasks gsm8k --output_path ./eval_out-tta1J8 --log_samples --num_fewshot 20 --model_args 'model=/shared/data/amd_int/models/GLM-5.2-MXFP4,base_url=http://0.0.0.0:8013/v1/chat/completions,api_key=EMPTY,eos_string=</s>,max_retries=5,num_concurrent=64,timeout=1800,tokenized_requests=False,max_length=1048576' --gen_kwargs max_tokens=16384,temperature=0,top_p=1
```
acc test 5 shot
```bash
python3 -m lm_eval --model local-chat-completions --apply_chat_template --tasks gsm8k --output_path ./eval_out-tta1J8 --log_samples --num_fewshot 5 --model_args 'model=/shared/data/amd_int/models/GLM-5.2-MXFP4,base_url=http://0.0.0.0:8013/v1/chat/completions,api_key=EMPTY,eos_string=</s>,max_retries=5,num_concurrent=64,timeout=1800,tokenized_requests=False,max_length=1048576' --gen_kwargs max_tokens=16384,temperature=0,top_p=1
```
## Test Result
20 shot
```bash
local-chat-completions ({'model': '/shared/data/amd_int/models/GLM-5.2-MXFP4', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 64, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 1048576}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: 20, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|    20|exact_match|↑  |0.9636|±  |0.0052|
|     |       |strict-match    |    20|exact_match|↑  |0.9644|±  |0.0051|
```
5 shot
```bash
local-chat-completions ({'model': '/shared/data/amd_int/models/GLM-5.2-MXFP4', 'base_url': 'http://0.0.0.0:8013/v1/chat/completions', 'api_key': 'EMPTY', 'eos_string': '</s>', 'max_retries': 5, 'num_concurrent': 64, 'timeout': 1800, 'tokenized_requests': False, 'max_length': 1048576}), gen_kwargs: ({'max_tokens': 16384, 'temperature': 0, 'top_p': 1}), limit: None, num_fewshot: 5, batch_size: 1
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9675|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9683|±  |0.0055|
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
