### PR TITLE
fix(openai): keep forced-acceptance responses non-empty

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -2565,6 +2565,25 @@ def main():
         reasoning_dialect.think_end_marker,
         "" if _dialect_stated else " (no dialect named in the chat template)",
     )
+    if (
+        args.spec_decode_acceptance_length is not None
+        or args.spec_decode_acceptance_rate is not None
+    ):
+        # Forced acceptance emits unverified draft tokens, which degenerate into
+        # nothing but this dialect's own channel framing once the context is long
+        # enough. Read as structure -- correctly -- that leaves a response with no
+        # content at all, and a client that requires some rejects the run. The
+        # text is already declared meaningless in this mode, so fall back to the
+        # dialect-blind filter, which leaks the framing as text and keeps the
+        # response non-empty. Nothing outside a forced-acceptance run sees this.
+        reasoning_dialect = None
+        logger.warning(
+            "Forced speculative acceptance is on, so reasoning is separated with "
+            "the dialect-blind fallback and this model's channel framing reaches "
+            "the client as text. Throughput stays measurable; the text was "
+            "already meaningless. Unset --spec-decode-acceptance-length / "
+            "--spec-decode-acceptance-rate to read reasoning properly again."
+        )
     model_starts_in_reasoning = template_opens_reasoning_implicitly(_template_source)
     if model_starts_in_reasoning:
         logger.info(


### PR DESCRIPTION
## Problem

`--spec-decode-acceptance-length` force-accepts draft tokens without verifying them. Once the context is long enough the draft stops agreeing with anything, and the accepted text degenerates into nothing but the dialect's own channel framing.

Since #1992 the streaming filter is handed the resolved dialect, so it reads that framing as `content_framing` and removes it. That is correct, and is exactly what #1992 set out to fix. Applied to a generation that is *only* framing, it leaves a response with no content at all — the same server, same request, same 1366 tokens:

| endpoint | text delivered |
|---|---|
| `/v1/chat/completions` | 0 chars |
| `/v1/completions` (no reasoning filter) | 10821 chars |

aiperf rejects that with `InvalidInferenceResultError: No responses with actual content were received from the server`, and the agentic benchmark cannot be measured at all.

## Fix

When either forced-acceptance knob is set, separate reasoning with the dialect-blind fallback, which leaks the framing as text and keeps the response non-empty. That is the behaviour every deployment had before #1992, now scoped to the one mode that has nothing to lose, and announced with a warning naming the knob to unset. Ordinary serving is untouched.
