### PR TITLE
[MoE] Add native RCCL DEP transport and decode-aware EPLB

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1378,6 +1378,9 @@ class EPLBConfig:
 
     load_window_size: int = 1000
     rebalance_interval: int = 3000
+    # 0 keeps periodic rebalancing unlimited. A positive value freezes the
+    # learned placement after that many completed automatic rebalances.
+    max_rebalances: int = 0
     rebalance_layers_per_chunk: int = 64
     num_redundant_experts: int = 0
     rebalance_min_balancedness: float = 2.0
@@ -1388,15 +1391,27 @@ class EPLBConfig:
     #   "biased" -> fully replicate top-K hottest experts to all GPUs
     #               (K = num_redundant // num_gpus, per-node in multi-node)
     placement_policy: str = "naive"
+    # Which real forward passes contribute load and advance the rebalance clock.
+    # Keep the historical prefill-only policy by default; decode-heavy serving can
+    # opt in without paying the decode accounting / migration cost everywhere.
+    load_mode: str = "prefill"
 
     def __post_init__(self):
         self.load_window_size = int(self.load_window_size)
         assert self.load_window_size > 0, "eplb.load_window_size must be > 0"
+        self.load_mode = str(self.load_mode).lower().strip()
+        assert self.load_mode in {
+            "prefill",
+            "decode",
+            "all",
+        }, "eplb.load_mode must be one of {'prefill','decode','all'}"
         self.rebalance_interval = int(self.rebalance_interval)
         assert self.rebalance_interval > 0, "eplb.rebalance_interval must be > 0"
         assert (
             self.rebalance_interval >= self.load_window_size
         ), "eplb.rebalance_interval must be >= eplb.load_window_size"
+        self.max_rebalances = int(self.max_rebalances)
+        assert self.max_rebalances >= 0, "eplb.max_rebalances must be >= 0"
         self.rebalance_layers_per_chunk = int(self.rebalance_layers_per_chunk)
         assert (
             self.rebalance_layers_per_chunk > 0
@@ -1595,6 +1610,12 @@ class Config:
     enable_tbo: bool = False
     enable_tbo_decode: bool = False
     enable_low_latency: bool = False
+    # Routed MoE transport selection. ``auto`` preserves the historical
+    # behavior (MoRI when importable, otherwise gather/scatter). ``rccl`` uses
+    # a graph-safe pre-routed collective for uniform decode, variable-size
+    # gather/scatter for matching DP/EP groups, and dynamic routed all-to-all
+    # for other prefill/mixed topologies.
+    moe_all2all_backend: str = "auto"
     # Post-routing routed-MoE implementation. This is deliberately separate
     # from all2all backend/mode: Mega owns dispatch, both GEMMs, and combine.
     moe_backend: str = "standard"
@@ -1674,6 +1695,23 @@ class Config:
         return list(sizes)
 
     def __post_init__(self):
+        self.moe_all2all_backend = (
+            str(self.moe_all2all_backend or "auto").strip().lower()
+        )
+        if self.moe_all2all_backend not in ("auto", "mori", "rccl", "none"):
+            raise ValueError(
+                "moe_all2all_backend must be one of "
+                "{'auto', 'mori', 'rccl', 'none'}, "
+                f"got {self.moe_all2all_backend!r}"
+            )
+        if self.moe_all2all_backend == "rccl" and self.enable_tbo:
+            logger.warning(
+                "Disabling TBO for the experimental RCCL routed MoE backend; "
+                "the first implementation is synchronous."
+            )
+            self.enable_tbo = False
+            self.enable_tbo_decode = False
+
         self.moe_backend = self.moe_backend.strip().lower()
         if self.moe_backend not in ("standard", "mega"):
             raise ValueError(
@@ -1684,6 +1722,11 @@ class Config:
             raise ValueError(
                 "moe_backend='mega' requires expert parallelism; "
                 "pass --enable-expert-parallel."
+            )
+        if self.moe_backend == "mega" and self.moe_all2all_backend == "rccl":
+            raise ValueError(
+                "moe_backend='mega' owns its MoRI transport and cannot use the "
+                "experimental RCCL prepare/finalize backend"
             )
 
         if isinstance(self.compilation_config, dict):

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -323,10 +323,11 @@ class EngineArgs:
             nargs="?",
             const="high-throughput",
             default=None,
-            choices=["high-throughput", "low-latency"],
-            help="All2all backend mode for MORI. "
-            "Default is 'high-throughput'. "
-            "Use '--all2all-backend low-latency' for AsyncLL MORI kernel overlap.",
+            choices=["high-throughput", "low-latency", "rccl", "none"],
+            help="Routed MoE transport. 'high-throughput' and 'low-latency' "
+            "select MORI modes, 'rccl' selects ATOM's native RCCL MoE "
+            "transport, and 'none' forces the DP "
+            "AllGather/ReduceScatter fallback. Default is auto-detect MORI.",
         )
         parser.add_argument(
             "--moe-backend",
@@ -629,6 +630,8 @@ class EngineArgs:
                 "--eplb-config only tunes it. Supported keys:\n"
                 '  - "load_window_size": int, non-dummy forwards accumulated '
                 "for EPLB load stats.\n"
+                '  - "load_mode": "prefill"|"decode"|"all", which real '
+                "forward modes feed load stats and advance rebalance.\n"
                 '  - "rebalance_interval": int, forward-pass interval for '
                 "EPLB rebalance gating.\n"
                 '  - "rebalance_layers_per_chunk": int, MoE layers migrated '
@@ -717,6 +720,13 @@ class EngineArgs:
 
         all2all_backend = kwargs.pop("all2all_backend", None)
         kwargs["enable_low_latency"] = all2all_backend == "low-latency"
+        kwargs["moe_all2all_backend"] = {
+            None: "auto",
+            "high-throughput": "mori",
+            "low-latency": "mori",
+            "rccl": "rccl",
+            "none": "none",
+        }[all2all_backend]
 
         # --dspark-config (JSON dict) → DSparkConfig object, passed through as
         # Config.dspark (no env vars).

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import itertools
+import importlib.util
 import logging
 import time
 from collections import Counter
@@ -62,6 +63,30 @@ class LLMEngine:
                     data_parallel_master_port
                 )
         self.data_parallel_size = config.parallel_config.data_parallel_size
+        # TBO's two concurrent ubatches are supported by the mori EP
+        # dispatch/combine path. The EP collective fallback instead issues
+        # full DP all-gather/reduce-scatter operations from both ubatch streams;
+        # those streams can enter the collectives in opposite order and hang.
+        # Keep the fallback usable by serializing it until it has dedicated
+        # per-ubatch communicators, analogous to the PCP/TP guard below.
+        mori_ep_enabled = (
+            getattr(config, "moe_all2all_backend", "auto") in {"auto", "mori"}
+            and not envs.ATOM_DISABLE_MORI_EP
+            and importlib.util.find_spec("mori") is not None
+        )
+        if (
+            config.enable_dp_attention
+            and config.enable_expert_parallel
+            and config.enable_tbo
+            and not mori_ep_enabled
+        ):
+            logger.warning(
+                "Disabling TBO for the DP-attention + EP collective fallback: "
+                "concurrent all-gather/reduce-scatter ubatches can deadlock. "
+                "Use mori EP or run the fallback without --enable-tbo."
+            )
+            config.enable_tbo = False
+            config.enable_tbo_decode = False
         # PCP and DP-attention are not yet compatible: PCP stripe-splits
         # input_ids to 1/pcp_size in ForCausalLM.forward, but DP-attention's
         # `_gather_ids_for_dp` all-gathers using dp_metadata sizes computed on

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2589,13 +2589,17 @@ class ModelRunner:
             local_tbo=self._local_tbo_eligibility(batch),
             max_seqlen_q=(batch.num_spec_step + 1 if shrunk_q is None else shrunk_q),
         )
-        # Stash the DP-wide prefill OR for the EPLB prefill gate; reused free by
-        # on_forward_pass_end when the DP group == the migration (EP) group.
-        self._eplb_any_rank_has_prefill = (
-            None
-            if forward_mode.sync is None
-            else forward_mode.sync.any_rank_has_prefill
-        )
+        # Stash DP-wide real-work signals for EPLB's configurable load-mode gate.
+        # They exclude synthetic dummy ranks and reuse the step's existing packed
+        # DP metadata collective when the DP and expert-migration groups align.
+        if forward_mode.sync is None:
+            self._eplb_any_rank_has_prefill = None
+            self._eplb_any_rank_has_decode = None
+        else:
+            self._eplb_any_rank_has_prefill = (
+                forward_mode.sync.any_rank_has_real_prefill
+            )
+            self._eplb_any_rank_has_decode = forward_mode.sync.any_rank_has_decode
         total_tokens_num = batch.total_tokens_num
         assert total_tokens_num > 0
 

--- a/atom/model_ops/eplb.py
+++ b/atom/model_ops/eplb.py
@@ -21,6 +21,7 @@ except ImportError:
 import logging
 
 logger = logging.getLogger("atom")
+_WARNED_DECODE_MASK_UNAVAILABLE = False
 
 BufferCopyPlan = list[tuple[int, int]]
 
@@ -1370,6 +1371,12 @@ def count_physical_load(topk_physical: torch.Tensor, num_physical: int) -> torch
 class ExpertLoadMonitor:
     def __init__(self, *, enabled: bool, window_size: int):
         self.enabled = enabled
+        # Keep ``enabled`` stable for the process-local singleton identity.
+        # ``collecting`` can be disabled after a one-shot rebalance while EPLB
+        # remapping remains active. The fixed-address device flag is read by
+        # captured decode graphs so their histogram body becomes a cheap no-op.
+        self.collecting = enabled
+        self._recording_flag: torch.Tensor | None = None
         self.window_size = max(1, int(window_size))
         self._slot = 0
         self._filled = 0
@@ -1424,6 +1431,7 @@ class ExpertLoadMonitor:
             dtype=torch.int32,
             device=device,
         )
+        self._recording_flag = torch.ones((), dtype=torch.int32, device=device)
         self._num_layers = num_layers
         self._num_physical = num_physical
         self._device = device
@@ -1459,9 +1467,21 @@ class ExpertLoadMonitor:
         )
 
     def on_forward_start(self) -> None:
-        if not self.enabled or self._cur_pass_count is None:
+        if not self.enabled or not self.collecting or self._cur_pass_count is None:
             return
         self._cur_pass_count.zero_()
+
+    def stop_recording(self) -> None:
+        """Permanently stop load accounting while keeping EPLB remapping live."""
+        if not self.collecting:
+            return
+        self.collecting = False
+        if self._recording_flag is not None:
+            self._recording_flag.zero_()
+
+    @property
+    def recording_flag(self) -> torch.Tensor | None:
+        return self._recording_flag
 
     def pass_count_buffer(
         self, layer_id: int, num_physical: int
@@ -1470,7 +1490,7 @@ class ExpertLoadMonitor:
         if recording is disabled / uninitialized / out of capacity. Lets the
         fused EPLB map+record kernel atomic_add straight into the live buffer
         (same target as record())."""
-        if not self.enabled or self._cur_pass_count is None:
+        if not self.enabled or not self.collecting or self._cur_pass_count is None:
             return None
         if layer_id < 0 or layer_id >= self._num_layers:
             return None
@@ -1481,7 +1501,7 @@ class ExpertLoadMonitor:
     def record(
         self, *, layer_id: int, topk_physical: torch.Tensor, num_physical: int
     ) -> None:
-        if not self.enabled or layer_id < 0:
+        if not self.enabled or not self.collecting or layer_id < 0:
             return
         self._validate_record_shape(
             layer_id=layer_id,
@@ -1501,17 +1521,24 @@ class ExpertLoadMonitor:
                 tuple(topk_physical.shape),
             )
 
-    def on_forward_end(self, is_dummy_run: bool, is_pure_prefill: bool = True) -> None:
-        # Commit this pass's load to the sliding window ONLY on a real
-        # (non-dummy) pure-prefill forward -- EPLB balances on prefill load
-        # only, so decode / DP-mixed / dummy passes are dropped here. Committing
-        # is a purely local op, so gating it per-rank never desyncs the
-        # (step-driven, collective) rebalance -- lockstep is enforced separately
-        # by on_forward_pass_end, which advances on a group-uniform prefill flag.
+    def on_forward_end(
+        self,
+        is_dummy_run: bool,
+        is_pure_prefill: bool = True,
+        *,
+        should_commit: bool | None = None,
+    ) -> None:
+        # Commit only loads selected by EPLBConfig.load_mode. Selection is local:
+        # DPA ranks may run different batch modes in the same step, while the
+        # manager advances from a migration-group-uniform activity flag below.
+        # ``is_pure_prefill`` retains compatibility with the original API;
+        # new callers pass the mode-agnostic ``should_commit`` keyword.
+        commit = is_pure_prefill if should_commit is None else should_commit
         if (
             not self.enabled
+            or not self.collecting
             or is_dummy_run
-            or not is_pure_prefill
+            or not commit
             or self._cur_pass_count is None
             or self._expert_load_window is None
         ):
@@ -1610,8 +1637,8 @@ def get_live_expert_location_metadata() -> ExpertLocationMetadata | None:
 class EPLBManager:
     """Module-B scheduler/trigger manager.
 
-    Scope for now:
-    - periodic step progression on every forward (including dummy)
+    Scope:
+    - configurable prefill/decode/all load sampling and periodic progression
     - balancedness gate on module-A physical load
     - state-machine trigger for owner-provided C/D/E execution
     """
@@ -1625,6 +1652,8 @@ class EPLBManager:
         rebalance_min_balancedness: float,
         rebalance_balancedness_agg: str,
         placement_policy: str = "naive",
+        load_mode: str = "prefill",
+        max_rebalances: int = 0,
     ):
         self.enabled = enabled
         self.monitor = monitor
@@ -1632,6 +1661,8 @@ class EPLBManager:
         self.rebalance_min_balancedness = float(rebalance_min_balancedness)
         self.rebalance_balancedness_agg = str(rebalance_balancedness_agg).lower()
         self.placement_policy = str(placement_policy).lower().strip()
+        self.load_mode = str(load_mode).lower().strip()
+        self.max_rebalances = int(max_rebalances)
         assert self.rebalance_interval > 0, "eplb_rebalance_interval must be > 0"
         assert (
             self.rebalance_interval >= self.monitor.window_size
@@ -1640,9 +1671,16 @@ class EPLBManager:
             "min",
             "mean",
         ), "eplb_rebalance_balancedness_agg must be one of {'min','mean'}"
+        assert self.load_mode in (
+            "prefill",
+            "decode",
+            "all",
+        ), "eplb_load_mode must be one of {'prefill','decode','all'}"
+        assert self.max_rebalances >= 0, "eplb_max_rebalances must be >= 0"
         self._gen = self._entrypoint()
         self._rebalance_count = 0
         self._last_balancedness: float | None = None
+        self._automatic_rebalancing_frozen = False
         self.live_metadata: ExpertLocationMetadata | None = None
         self._moe_layers: dict[int, Any] = {}
         self._expert_weights_of_layer: dict[int, list[torch.Tensor]] = {}
@@ -1661,12 +1699,10 @@ class EPLBManager:
         self._nnodes: int = 1
         self._rebalance_layers_per_chunk: int = 64
         self._p2p_batch_chunk_size: int = 32
-        # True iff the DP group == the migration (EP) group. When True the DP
-        # sync's `any_rank_has_prefill` already spans exactly the migration
-        # collective, so the prefill gate reuses it for free (no extra collective).
-        # When False we OR the local prefill flag over the migration group
-        # ourselves. Resolved once in bind_runtime_owner (fail-safe default False
-        # => self-compute, which is always correct).
+        # True iff the DP group == the migration (EP) group. When True, packed DP
+        # metadata already provides group-wide real prefill/decode activity, so
+        # the load-mode gate reuses it for free. Otherwise we OR local selected
+        # activity over the migration group. Resolved once in bind_runtime_owner.
         self._dp_is_migration_group: bool = False
 
     def bind_runtime_owner(self, owner: Any) -> None:
@@ -1813,12 +1849,13 @@ class EPLBManager:
 
         logger.info(
             "EPLB runtime initialized: layers=%d num_logical=%d "
-            "num_physical=%d ep_size=%d ep_rank=%d",
+            "num_physical=%d ep_size=%d ep_rank=%d load_mode=%s",
             len(layers),
             num_logical,
             num_physical,
             ep_size,
             ep_rank,
+            self.load_mode,
         )
         self.monitor.initialize_for_metadata(self.live_metadata)
         # Initialize redundant physical slots the checkpoint loader left empty.
@@ -2049,34 +2086,58 @@ class EPLBManager:
     def last_balancedness(self) -> float | None:
         return self._last_balancedness
 
+    @property
+    def automatic_rebalancing_frozen(self) -> bool:
+        return self._automatic_rebalancing_frozen
+
     def on_forward_pass_end(
         self,
         local_has_prefill: bool,
         dp_any_has_prefill: bool | None = None,
+        local_has_decode: bool = False,
+        dp_any_has_decode: bool | None = None,
     ) -> None:
-        if not self.enabled:
+        if not self.enabled or self._automatic_rebalancing_frozen:
             return
 
-        # Resolve a migration-group-uniform has-prefill flag.
-        if self._dp_is_migration_group and dp_any_has_prefill is not None:
-            # DP group == migration group: reuse the DP sync's has-prefill OR for
-            # free (no extra collective).
-            has_prefill = dp_any_has_prefill
+        local_selected = self.should_record(local_has_prefill, local_has_decode)
+        can_reuse_dp_sync = self._dp_is_migration_group and (
+            (self.load_mode == "prefill" and dp_any_has_prefill is not None)
+            or (self.load_mode == "decode" and dp_any_has_decode is not None)
+            or (
+                self.load_mode == "all"
+                and dp_any_has_prefill is not None
+                and dp_any_has_decode is not None
+            )
+        )
+        if can_reuse_dp_sync:
+            # DP group == migration group: reuse the packed DP sync rather than
+            # inserting another per-token-step collective into decode.
+            has_selected_work = self.should_record(
+                dp_any_has_prefill, dp_any_has_decode
+            )
         else:
-            # OR the local has-prefill flag over exactly the migration collective
-            # (the group the rebalance actually runs on).
+            # OR selected real activity over exactly the group that performs the
+            # migration. Every member must advance the generator in lockstep.
             flag = torch.tensor(
-                [1 if local_has_prefill else 0], device="cuda", dtype=torch.int32
+                [1 if local_selected else 0], device="cuda", dtype=torch.int32
             )
             torch.distributed.all_reduce(
                 flag, op=torch.distributed.ReduceOp.MAX, group=self._migration_group
             )
-            has_prefill = bool(flag.item())
+            has_selected_work = bool(flag.item())
 
-        if not has_prefill:
-            # Pure-decode step across the migration group: do not advance.
+        if not has_selected_work:
             return
         next(self._gen)
+
+    def should_record(self, has_prefill: bool, has_decode: bool) -> bool:
+        """Whether a real local/group batch is selected by ``load_mode``."""
+        if self.load_mode == "prefill":
+            return has_prefill
+        if self.load_mode == "decode":
+            return has_decode
+        return has_prefill or has_decode
 
     def trigger_offline_rebalance(self, reason: str = "manual") -> None:
         if not self.enabled:
@@ -2090,16 +2151,25 @@ class EPLBManager:
             pass  # drain generator synchronously
 
     def _entrypoint(self):
-        # vllm-style warm start: the first LIVE rebalance fires after a quarter
-        # of the interval (equivalent to vllm initializing its rearrangement
-        # step counter to 3/4 of the interval), so balancing on real traffic
-        # kicks in early. Initial placement stays trivial (round-robin) until
-        # this first real-load rebalance
-        first_window = max(1, self.rebalance_interval // 4)
+        # vLLM-style warm start aims for interval/4, but never rebalance before
+        # the configured load window is full. A partial window made Agentic c96
+        # placement depend heavily on which trajectories happened to finish
+        # first and produced run-to-run regressions after migration.
+        first_window = max(1, self.monitor.window_size, self.rebalance_interval // 4)
         for _ in range(first_window):
             yield
         yield from self._rebalance()
         while True:
+            if self.max_rebalances and self._rebalance_count >= self.max_rebalances:
+                self._automatic_rebalancing_frozen = True
+                self.monitor.stop_recording()
+                logger.info(
+                    "EPLB automatic rebalancing and load recording frozen after "
+                    "%d completed rebalance(s)",
+                    self._rebalance_count,
+                )
+                while True:
+                    yield
             for _ in range(self.rebalance_interval):
                 yield
             yield from self._rebalance()
@@ -2324,6 +2394,8 @@ def get_eplb_manager(
     rebalance_min_balancedness: float,
     rebalance_balancedness_agg: str,
     placement_policy: str = "naive",
+    load_mode: str = "prefill",
+    max_rebalances: int = 0,
 ) -> EPLBManager:
     global _MANAGER
     if (
@@ -2336,6 +2408,8 @@ def get_eplb_manager(
         or _MANAGER.rebalance_balancedness_agg
         != str(rebalance_balancedness_agg).lower()
         or _MANAGER.placement_policy != str(placement_policy).lower().strip()
+        or _MANAGER.load_mode != str(load_mode).lower().strip()
+        or _MANAGER.max_rebalances != int(max_rebalances)
     ):
         _MANAGER = EPLBManager(
             enabled=enabled,
@@ -2344,6 +2418,8 @@ def get_eplb_manager(
             rebalance_min_balancedness=rebalance_min_balancedness,
             rebalance_balancedness_agg=rebalance_balancedness_agg,
             placement_policy=placement_policy,
+            load_mode=load_mode,
+            max_rebalances=max_rebalances,
         )
     return _MANAGER
 
@@ -2364,6 +2440,8 @@ def _get_configured_eplb_manager() -> EPLBManager | None:
         rebalance_min_balancedness=cfg.eplb_config.rebalance_min_balancedness,
         rebalance_balancedness_agg=cfg.eplb_config.rebalance_balancedness_agg,
         placement_policy=cfg.eplb_config.placement_policy,
+        load_mode=cfg.eplb_config.load_mode,
+        max_rebalances=cfg.eplb_config.max_rebalances,
     )
 
 
@@ -2412,28 +2490,37 @@ def with_eplb_forward_monitor(fn):
         # metadata (should not happen — init is fail-loud).
         if manager is None or manager.live_metadata is None:
             return fn(self, batch, *args, **kwargs)
+        # The learned expert map remains live, but a one-shot benchmark run no
+        # longer needs Python-side window maintenance or scheduler progression.
+        if manager.automatic_rebalancing_frozen:
+            return fn(self, batch, *args, **kwargs)
         monitor = manager.monitor
         monitor.on_forward_start()
         try:
             return fn(self, batch, *args, **kwargs)
         finally:
             is_dummy_run = getattr(batch, "is_dummy_run", False)
-            # Pure-prefill = has prefill tokens and no decode tokens (batches are
-            # not mixed today; the decode==0 check also future-proofs the TODO
-            # mixed batch). Local per-rank signal -- no DP sync needed, since only
-            # the (non-collective) window commit is gated; the step still advances.
-            is_pure_prefill = (
-                getattr(batch, "total_tokens_num_prefill", 0) > 0
-                and getattr(batch, "total_tokens_num_decode", 0) == 0
+            is_real = not is_dummy_run
+            local_has_prefill = (
+                is_real and getattr(batch, "total_tokens_num_prefill", 0) > 0
             )
-            # Recording gate commits clean load on pure-prefill only (local op).
-            monitor.on_forward_end(is_dummy_run, is_pure_prefill)
-            # Step gate advances on prefill ACTIVITY (has-prefill), reduced to a
-            # group-uniform flag. Coincides with the pure-prefill commit above
-            # under the no-mixed-batch invariant (see on_forward_pass_end).
-            local_has_prefill = getattr(batch, "total_tokens_num_prefill", 0) > 0
+            local_has_decode = (
+                is_real and getattr(batch, "total_tokens_num_decode", 0) > 0
+            )
+            monitor.on_forward_end(
+                is_dummy_run,
+                should_commit=manager.should_record(
+                    local_has_prefill, local_has_decode
+                ),
+            )
             dp_any_has_prefill = getattr(self, "_eplb_any_rank_has_prefill", None)
-            manager.on_forward_pass_end(local_has_prefill, dp_any_has_prefill)
+            dp_any_has_decode = getattr(self, "_eplb_any_rank_has_decode", None)
+            manager.on_forward_pass_end(
+                local_has_prefill=local_has_prefill,
+                dp_any_has_prefill=dp_any_has_prefill,
+                local_has_decode=local_has_decode,
+                dp_any_has_decode=dp_any_has_decode,
+            )
 
     return wrapper
 
@@ -2448,7 +2535,15 @@ def eplb_map_logical_to_physical(layer: Any, topk_ids: torch.Tensor) -> torch.Te
     """
     meta = get_live_expert_location_metadata()
     layer_id = getattr(layer, "layer_id", None)
-    if meta is None or not isinstance(layer_id, int):
+    # The target and speculative draft models share a process-local forward
+    # context, but the EPLB manager owns target-model layers only. Draft MoE
+    # layers use ids after the target range and must retain their static EP map.
+    if (
+        meta is None
+        or not isinstance(layer_id, int)
+        or layer_id < 0
+        or layer_id >= meta.num_layers
+    ):
         return topk_ids
     dispatch = meta.logical_to_rank_dispatch_physical_map[layer_id].to(
         device=topk_ids.device
@@ -2494,12 +2589,67 @@ def record_eplb_expert_load(layer: Any, topk_physical: torch.Tensor) -> None:
     )
     if num_physical <= 0:
         return
-    monitor = get_expert_load_monitor(
-        enabled=True, window_size=atom_cfg.eplb_config.load_window_size
-    )
+    monitor = _MANAGER.monitor if _MANAGER is not None else None
+    if monitor is None:
+        return
     monitor.record(
         layer_id=layer_id, topk_physical=topk_physical, num_physical=num_physical
     )
+
+
+def _eplb_record_mask(
+    topk_ids: torch.Tensor,
+) -> tuple[torch.Tensor | None, bool]:
+    """Return ``(valid_token_mask, safe_to_record)`` for the current forward.
+
+    The DPA gather path publishes a cross-rank selection mask for mixed-mode
+    steps. Decode CUDAGraphs may additionally append rows that are required for
+    a stable graph shape but do not belong to requests; their router output is
+    valid-looking and must not enter EPLB statistics. Attention's slot map is a
+    replay-safe fallback source of truth: real rows are >= 0, padding rows -1.
+    """
+    from atom.utils.forward_context import get_forward_context
+
+    ctx = get_forward_context()
+    fwd = getattr(ctx, "context", None)
+    num_rows = int(topk_ids.shape[0])
+    token_mask = getattr(ctx, "eplb_token_mask", None)
+    if isinstance(token_mask, torch.Tensor) and token_mask.numel() == num_rows:
+        return token_mask.reshape(-1).contiguous(), True
+
+    if fwd is None or getattr(fwd, "is_prefill", False):
+        return None, True
+    if not getattr(fwd, "dp_uniform_decode", True):
+        # Variable-length DPA has no padding. If it needed phase selection, the
+        # gather path would already have published a matching mask above.
+        return None, True
+
+    if token_mask is None:
+        attn_metadata = getattr(ctx, "attn_metadata", None)
+        slot_mapping = getattr(attn_metadata, "slot_mapping", None)
+        if isinstance(slot_mapping, torch.Tensor) and slot_mapping.numel() >= num_rows:
+            token_mask = slot_mapping.reshape(-1)[:num_rows] >= 0
+            ctx.eplb_token_mask = token_mask
+
+    if isinstance(token_mask, torch.Tensor) and token_mask.numel() == num_rows:
+        return token_mask.reshape(-1).contiguous(), True
+
+    # An eager/local decode with no graph padding is safe even if its attention
+    # backend does not expose slot_mapping.
+    if num_rows == int(getattr(fwd, "scheduled_tokens", -1)):
+        return None, True
+
+    global _WARNED_DECODE_MASK_UNAVAILABLE
+    if not _WARNED_DECODE_MASK_UNAVAILABLE:
+        logger.warning(
+            "EPLB decode load skipped: cannot identify real rows among %d MoE "
+            "rows (scheduled=%s, running=%s); expert routing is unaffected",
+            num_rows,
+            getattr(fwd, "scheduled_tokens", None),
+            getattr(fwd, "running_tokens", None),
+        )
+        _WARNED_DECODE_MASK_UNAVAILABLE = True
+    return None, False
 
 
 if _EPLB_HAS_TRITON:
@@ -2556,6 +2706,8 @@ if _EPLB_HAS_TRITON:
         cnt_ptr,  # [num_logical]    replica count per logical
         out_ids_ptr,  # [numel]          output physical ids (in dtype)
         load_ptr,  # [num_physical]   _cur_pass_count[layer_id]
+        recording_flag_ptr,  # scalar int32; fixed-address CUDAGraph runtime gate
+        valid_token_ptr,  # [num_tokens] bool; ignored when HAS_VALID_MASK=False
         num_logical,
         id_delta,
         num_physical,
@@ -2564,6 +2716,7 @@ if _EPLB_HAS_TRITON:
         BLOCK: tl.constexpr,
         NUM_BINS: tl.constexpr,  # next_pow2(num_physical + 1); last bins hold oob
         TOP_K: tl.constexpr,
+        HAS_VALID_MASK: tl.constexpr,
     ):
         pid = tl.program_id(0)
         offs = pid * BLOCK + tl.arange(0, BLOCK)
@@ -2586,13 +2739,22 @@ if _EPLB_HAS_TRITON:
         mapped = tl.where(need_spread, remote, mapped)
         phys = tl.where(valid, mapped, tl.where(is_tail, lid + id_delta, lid))
         tl.store(out_ids_ptr + offs, phys, mask=mask)
-        # out-of-range / masked-off lanes -> sentinel bin (== num_physical),
-        # excluded from the store below so they never touch load_ptr.
-        in_range = mask & (phys >= 0) & (phys < num_physical)
-        bin_idx = tl.where(in_range, phys, num_physical).to(tl.int32)
-        hist = tl.histogram(bin_idx, NUM_BINS)
-        bins = tl.arange(0, NUM_BINS)
-        tl.atomic_add(load_ptr + bins, hist, mask=bins < num_physical)
+        # Uniform runtime branch: after a one-shot rebalance the host clears
+        # this fixed-address flag. Already-captured decode graphs then retain
+        # remapping but skip histogram construction and atomics entirely.
+        if tl.load(recording_flag_ptr).to(tl.int1):
+            # out-of-range / masked-off lanes -> sentinel bin
+            # (== num_physical), excluded from the store below.
+            valid_token = True
+            if HAS_VALID_MASK:
+                valid_token = tl.load(
+                    valid_token_ptr + token_idx, mask=mask, other=0
+                ).to(tl.int1)
+            in_range = mask & valid_token & (phys >= 0) & (phys < num_physical)
+            bin_idx = tl.where(in_range, phys, num_physical).to(tl.int32)
+            hist = tl.histogram(bin_idx, NUM_BINS)
+            bins = tl.arange(0, NUM_BINS)
+            tl.atomic_add(load_ptr + bins, hist, mask=bins < num_physical)
 
 
 def eplb_map_and_record_fused(layer: Any, topk_ids: torch.Tensor) -> torch.Tensor:
@@ -2607,12 +2769,50 @@ def eplb_map_and_record_fused(layer: Any, topk_ids: torch.Tensor) -> torch.Tenso
     """
     meta = get_live_expert_location_metadata()
     layer_id = getattr(layer, "layer_id", None)
-    if meta is None or not isinstance(layer_id, int):
+    # MTP draft layers are not registered with the target-model EPLB manager.
+    # Leave their logical ids untouched so the caller's static expert_map is
+    # used, rather than indexing beyond the target placement table.
+    if (
+        meta is None
+        or not isinstance(layer_id, int)
+        or layer_id < 0
+        or layer_id >= meta.num_layers
+    ):
         return topk_ids
+
+    from atom.config import get_current_atom_config
+    from atom.utils.forward_context import get_forward_context
+
+    atom_cfg = get_current_atom_config()
+    eplb_enabled = bool(getattr(atom_cfg, "eplb_enable", False))
+    load_mode = getattr(atom_cfg.eplb_config, "load_mode", "prefill")
+    fwd = getattr(get_forward_context(), "context", None)
+    is_prefill = bool(getattr(fwd, "is_prefill", False))
+    monitor = _MANAGER.monitor if _MANAGER is not None else None
+    record_current_mode = (
+        eplb_enabled
+        and monitor is not None
+        and monitor.collecting
+        and (
+            load_mode == "all"
+            or (load_mode == "prefill" and is_prefill)
+            or (load_mode == "decode" and not is_prefill)
+        )
+    )
+    valid_token_mask = None
+    safe_to_record = True
+    if record_current_mode:
+        valid_token_mask, safe_to_record = _eplb_record_mask(topk_ids)
 
     if not _EPLB_HAS_TRITON:
         topk_physical = eplb_map_logical_to_physical(layer, topk_ids)
-        record_eplb_expert_load(layer, topk_physical)
+        if record_current_mode and safe_to_record:
+            to_record = (
+                topk_physical
+                if valid_token_mask is None
+                else topk_physical[valid_token_mask]
+            )
+            record_eplb_expert_load(layer, to_record)
         return topk_physical
 
     numel = topk_ids.numel()
@@ -2643,14 +2843,8 @@ def eplb_map_and_record_fused(layer: Any, topk_ids: torch.Tensor) -> torch.Tenso
     # Resolve record buffer (== _cur_pass_count[layer_id]); None disables it.
     # eplb_enable is static (server lifetime), so RECORD is a compile-time
     # constexpr -> cudagraph capture fixes it, no per-step host branch.
-    from atom.config import get_current_atom_config
-
     load_buf = None
-    atom_cfg = get_current_atom_config()
-    if bool(getattr(atom_cfg, "eplb_enable", False)):
-        monitor = get_expert_load_monitor(
-            enabled=True, window_size=atom_cfg.eplb_config.load_window_size
-        )
+    if record_current_mode and safe_to_record:
         load_buf = monitor.pass_count_buffer(layer_id, num_physical)
     record = load_buf is not None
 
@@ -2671,6 +2865,8 @@ def eplb_map_and_record_fused(layer: Any, topk_ids: torch.Tensor) -> torch.Tenso
             cnt,
             out,
             load_buf,
+            monitor.recording_flag,
+            valid_token_mask if valid_token_mask is not None else topk_c,
             num_logical,
             id_delta,
             num_physical,
@@ -2679,6 +2875,7 @@ def eplb_map_and_record_fused(layer: Any, topk_ids: torch.Tensor) -> torch.Tenso
             BLOCK=256,
             NUM_BINS=num_bins,
             TOP_K=top_k,
+            HAS_VALID_MASK=valid_token_mask is not None,
         )
     else:
         _eplb_remap_kernel[grid](

--- a/atom/model_ops/fused_moe/config.py
+++ b/atom/model_ops/fused_moe/config.py
@@ -361,6 +361,10 @@ class FusedMoEConfig:
     def use_mori_kernels(self):
         return self.moe_parallel_config.use_mori_kernels
 
+    @property
+    def use_rccl_kernels(self):
+        return self.moe_parallel_config.use_rccl_kernels
+
 
 def moe_kernel_token_capacity(
     atom_config,

--- a/atom/model_ops/fused_moe/rccl_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/rccl_prepare_finalize.py
@@ -1,0 +1,483 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Native MoE transport implemented with RCCL.
+
+Uniform decode uses a graph-safe pre-routed all-gather/reduce-scatter path over
+ATOM's PyNccl communicator. Prefill and mixed prefill/decode batches use the
+same pre-routed payload with variable-size all-gather/reduce-scatter whenever
+the EP and DP groups have the same width. Other layouts retain the
+variable-split routed ``all_to_all_single`` correctness path.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+from aiter import QuantType
+
+import atom.model_ops.fused_moe.modular_kernel as mk
+from atom.model_ops.fused_moe.config import FusedMoEQuantConfig
+from atom.model_ops.fused_moe.routed_all2all import (
+    build_routed_dispatch_plan,
+    combine_routed_rows,
+    pack_routed_payload,
+    unpack_routed_payload,
+)
+from atom.utils.forward_context import get_forward_context
+
+
+@dataclass
+class _PendingCombine:
+    token_indices: torch.Tensor
+    send_splits: list[int]
+    recv_splits: list[int]
+    num_tokens: int
+    recv_rows: int
+
+
+@dataclass
+class _PendingGatherCombine:
+    num_tokens: int
+    sizes: list[int] | None = None
+
+
+class RcclPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
+    """Synchronous RCCL dispatch/combine for expert-parallel MoE.
+
+    On ROCm, PyTorch's NCCL process group is backed by RCCL.  The class name
+    describes that production target while keeping the implementation usable
+    with any backend that implements ``all_to_all_single`` for tests.
+
+    Uniform decode avoids dynamic split sizes and remains graph-capturable.
+    Matching DP/EP groups reuse scheduler-owned split sizes for variable gather
+    and scatter. Other layouts use routed all-to-all and require a device-to-host
+    synchronization. TBO is unsupported. The backend is opt-in and never
+    replaces MoRI or the existing gather/scatter path implicitly.
+    """
+
+    def __init__(
+        self,
+        ep_group: Any,
+        *,
+        num_local_experts: int,
+        max_tokens_per_rank: int,
+        num_replicated_shared_experts: int = 0,
+        num_routed_experts_per_rank: int | None = None,
+    ) -> None:
+        super().__init__()
+        self._group = ep_group.device_group
+        self._device_communicator = ep_group.device_communicator
+        self._rank = int(ep_group.rank_in_group)
+        self._world_size = int(ep_group.world_size)
+        self._num_local_experts = int(num_local_experts)
+        self._max_tokens_per_rank = int(max_tokens_per_rank)
+        self._num_replicated_shared_experts = int(num_replicated_shared_experts)
+        self._num_routed_experts_per_rank = int(
+            num_routed_experts_per_rank
+            if num_routed_experts_per_rank is not None
+            else num_local_experts - num_replicated_shared_experts
+        )
+        self._pending: _PendingCombine | _PendingGatherCombine | None = None
+        device_communicator = getattr(ep_group, "device_communicator", None)
+        pynccl = getattr(device_communicator, "pynccl_comm", None)
+        self._pynccl = (
+            pynccl
+            if pynccl is not None and not getattr(pynccl, "disabled", True)
+            else None
+        )
+
+        if self._world_size <= 1:
+            raise ValueError("RCCL routed MoE requires an EP group larger than one")
+        if self._num_local_experts <= 0:
+            raise ValueError("num_local_experts must be positive")
+        if not (0 <= self._num_replicated_shared_experts <= self._num_local_experts):
+            raise ValueError(
+                "num_replicated_shared_experts must be between zero and "
+                "num_local_experts"
+            )
+        if (
+            self._num_routed_experts_per_rank + self._num_replicated_shared_experts
+            != self._num_local_experts
+        ):
+            raise ValueError(
+                "local routed and replicated shared expert counts must add up "
+                "to num_local_experts"
+            )
+
+    @property
+    def activation_format(self) -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    def output_is_reduced(self) -> bool:
+        return True
+
+    def num_dispatchers(self) -> int:
+        return self._world_size
+
+    def max_num_tokens_per_rank(self) -> int | None:
+        return self._max_tokens_per_rank
+
+    def topk_indices_dtype(self) -> torch.dtype | None:
+        return torch.int32
+
+    @staticmethod
+    def _reject_graph_capture(tensor: torch.Tensor) -> None:
+        is_capturing = getattr(torch.cuda, "is_current_stream_capturing", None)
+        if tensor.is_cuda and is_capturing is not None and is_capturing():
+            raise RuntimeError(
+                "the ATOM RCCL routed MoE backend uses dynamic all-to-all split "
+                "sizes and cannot run inside a CUDA/HIP graph; pass --enforce-eager"
+            )
+
+    def _exchange_counts(self, send_counts: torch.Tensor) -> torch.Tensor:
+        recv_counts = torch.empty_like(send_counts)
+        torch.distributed.all_to_all_single(
+            recv_counts,
+            send_counts.contiguous(),
+            group=self._group,
+        )
+        return recv_counts
+
+    def _exchange_rows(
+        self,
+        tensor: torch.Tensor,
+        *,
+        send_splits: list[int],
+        recv_splits: list[int],
+    ) -> torch.Tensor:
+        output = tensor.new_empty((sum(recv_splits), *tensor.shape[1:]))
+        torch.distributed.all_to_all_single(
+            output,
+            tensor.contiguous(),
+            output_split_sizes=recv_splits,
+            input_split_sizes=send_splits,
+            group=self._group,
+        )
+        return output
+
+    def _use_static_decode_path(self) -> bool:
+        if self._pynccl is None:
+            return False
+        context = get_forward_context().context
+        return bool(
+            context is not None and not context.is_prefill and context.dp_uniform_decode
+        )
+
+    def _variable_gather_sizes(self, a1: torch.Tensor) -> list[int] | None:
+        """Return DP token counts when EP can reuse the DP gather/scatter plan.
+
+        DPA8+EP8 uses the same ordered ranks for DP token sharding and EP expert
+        sharding. The scheduler has already exchanged every rank's token count,
+        so reusing that metadata avoids both the routed-plan GPU work and the
+        device-to-host count synchronization required by dynamic all-to-all.
+
+        A flattened DP*TP EP group can be wider than the DP metadata. Keep the
+        routed all-to-all fallback for that topology rather than guessing how
+        token shards should be replicated across TP peers.
+        """
+        forward_context = get_forward_context()
+        context = forward_context.context
+        dp_metadata = getattr(forward_context, "dp_metadata", None)
+        if context is None or context.dp_uniform_decode or dp_metadata is None:
+            return None
+
+        sizes = [int(size) for size in dp_metadata.get_sizes_across_dp()]
+        if len(sizes) != self._world_size:
+            return None
+        if sizes[self._rank] != a1.shape[0]:
+            raise ValueError(
+                "RCCL variable gather token count disagrees with the local "
+                f"input: sizes[{self._rank}]={sizes[self._rank]}, "
+                f"rows={a1.shape[0]}"
+            )
+        return sizes
+
+    def _balance_replicated_shared_experts(self, dispatch_ids: torch.Tensor) -> None:
+        """Round-robin gathered rows over the replicated shared experts.
+
+        ``LOCAL_REPLICA`` routing initially pins a token's shared expert to its
+        source rank, which is ideal for routed transports but creates a severe
+        hotspot when one DPA rank owns a much longer Agentic request. After an
+        all-gather every rank has the same row order, so the row index provides
+        a deterministic, communication-free owner that balances shared-expert
+        GEMMs while still computing each shared contribution exactly once.
+        """
+        num_shared = self._num_replicated_shared_experts
+        if num_shared == 0 or dispatch_ids.shape[0] == 0:
+            return
+        if dispatch_ids.shape[1] < num_shared:
+            raise ValueError(
+                "top-k width is smaller than the replicated shared expert count"
+            )
+
+        rows = torch.arange(
+            dispatch_ids.shape[0],
+            dtype=dispatch_ids.dtype,
+            device=dispatch_ids.device,
+        )
+        owner_bases = (rows % self._world_size) * self._num_local_experts
+        owner_bases += self._num_routed_experts_per_rank
+        shared_offsets = torch.arange(
+            num_shared,
+            dtype=dispatch_ids.dtype,
+            device=dispatch_ids.device,
+        )
+        dispatch_ids[:, -num_shared:].copy_(
+            owner_bases[:, None] + shared_offsets[None, :]
+        )
+
+    def _prepare_static_decode(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+    ) -> mk.PrepareResultType:
+        """Gather pre-routed rows without host-visible split metadata.
+
+        Uniform decode pads every DP/EP rank to the same row count. Gathering
+        the compact top-k result instead of router logits avoids both the
+        dynamic count exchange and redundant top-k calculation on peer ranks.
+        """
+        local_payload, payload_layout = pack_routed_payload(
+            a1,
+            topk_ids,
+            topk_weights,
+        )
+        dispatch_payload = local_payload.new_empty(
+            (self._world_size * a1.shape[0], payload_layout.row_bytes)
+        )
+        # ncclGroupStart/End only batches launch submission; it does not turn
+        # collectives over three native dtypes into one collective. In the full
+        # 61-layer decode graph, three grouped AllGathers caused severe channel
+        # scheduling/launch amplification despite looking faster in an isolated
+        # microbenchmark. One packed byte collective is consistently faster at
+        # AgentX c96 and also keeps collective ordering simpler during replay.
+        self._pynccl.all_gather(dispatch_payload, local_payload)
+        dispatch_a1, dispatch_ids, dispatch_weights = unpack_routed_payload(
+            dispatch_payload,
+            payload_layout,
+        )
+        self._balance_replicated_shared_experts(dispatch_ids)
+        self._pending = _PendingGatherCombine(num_tokens=a1.shape[0])
+        return (
+            dispatch_a1,
+            None,
+            mk.ExpertTokensMetadata(
+                expert_num_tokens=None,
+                expert_num_tokens_cpu=None,
+            ),
+            dispatch_ids,
+            dispatch_weights,
+        )
+
+    def _prepare_variable_gather(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        sizes: list[int],
+    ) -> mk.PrepareResultType:
+        """Gather variable token shards after routing, without a route plan.
+
+        Routing before the gather is important for two reasons: it avoids
+        gathering the full router-logit matrix and preserves source-rank IDs
+        for locally replicated shared experts. Each rank then evaluates only
+        the experts selected by its ``expert_mask`` and reduce-scatter sums the
+        partial results back to the source token shard.
+        """
+        local_payload, payload_layout = pack_routed_payload(
+            a1,
+            topk_ids,
+            topk_weights,
+        )
+        dispatch_payload = self._device_communicator.all_gatherv(
+            local_payload,
+            dim=0,
+            sizes=sizes,
+        )
+        dispatch_a1, dispatch_ids, dispatch_weights = unpack_routed_payload(
+            dispatch_payload,
+            payload_layout,
+        )
+        self._balance_replicated_shared_experts(dispatch_ids)
+        self._pending = _PendingGatherCombine(
+            num_tokens=a1.shape[0],
+            sizes=sizes,
+        )
+        return (
+            dispatch_a1,
+            None,
+            mk.ExpertTokensMetadata(
+                expert_num_tokens=None,
+                expert_num_tokens_cpu=None,
+            ),
+            dispatch_ids,
+            dispatch_weights,
+        )
+
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+        expert_map: torch.Tensor | None,
+        apply_router_weight_on_input: bool,
+        quant_config: FusedMoEQuantConfig,
+        quant_type: QuantType = QuantType.No,
+    ) -> mk.PrepareResultType:
+        del expert_map, quant_config, quant_type
+        if apply_router_weight_on_input:
+            raise NotImplementedError(
+                "RCCL routed MoE does not support apply_router_weight_on_input"
+            )
+        if self._pending is not None:
+            raise RuntimeError("prepare called twice without a matching finalize")
+        if num_experts != self._world_size * self._num_local_experts:
+            raise ValueError(
+                "RCCL routed MoE requires an evenly sharded dispatch space: "
+                f"num_experts={num_experts}, world_size={self._world_size}, "
+                f"num_local_experts={self._num_local_experts}"
+            )
+
+        if self._use_static_decode_path():
+            return self._prepare_static_decode(a1, topk_weights, topk_ids)
+
+        variable_sizes = self._variable_gather_sizes(a1)
+        if variable_sizes is not None:
+            return self._prepare_variable_gather(
+                a1,
+                topk_weights,
+                topk_ids.to(torch.int32),
+                variable_sizes,
+            )
+
+        self._reject_graph_capture(a1)
+        topk_ids = topk_ids.to(torch.int32)
+        plan = build_routed_dispatch_plan(
+            a1,
+            topk_ids,
+            topk_weights,
+            num_local_experts=self._num_local_experts,
+            world_size=self._world_size,
+        )
+
+        recv_counts = self._exchange_counts(plan.send_counts)
+        # PyTorch's variable-split API accepts host lists.  This synchronization
+        # is the main known performance gap of the correctness backend.
+        send_splits = [int(v) for v in plan.send_counts.cpu().tolist()]
+        recv_splits = [int(v) for v in recv_counts.cpu().tolist()]
+        recv_rows = sum(recv_splits)
+
+        send_payload, payload_layout = pack_routed_payload(
+            plan.hidden_states,
+            plan.topk_ids,
+            plan.topk_weights,
+        )
+        recv_payload = self._exchange_rows(
+            send_payload,
+            send_splits=send_splits,
+            recv_splits=recv_splits,
+        )
+        dispatch_a1, dispatch_ids, dispatch_weights = unpack_routed_payload(
+            recv_payload,
+            payload_layout,
+        )
+
+        self._pending = _PendingCombine(
+            token_indices=plan.token_indices,
+            send_splits=send_splits,
+            recv_splits=recv_splits,
+            num_tokens=a1.shape[0],
+            recv_rows=recv_rows,
+        )
+
+        if recv_rows == 0:
+            # Keep the downstream fused-MoE launch shape valid. AITER's EP
+            # sorter indexes expert_mask before filtering, so use an in-range
+            # local expert ID instead of a -1 sentinel. Zero weights make the
+            # dummy row's contribution zero, and finalize drops it.
+            dispatch_a1 = a1.new_zeros((1, a1.shape[1]))
+            dispatch_ids = topk_ids.new_full(
+                (1, topk_ids.shape[1]),
+                self._rank * self._num_local_experts,
+            )
+            dispatch_weights = topk_weights.new_zeros((1, topk_weights.shape[1]))
+
+        # Unlike MoRI v1, RCCL returns an exactly-sized receive tensor rather
+        # than a fixed-capacity arena with a live prefix. Passing recv_rows as
+        # num_local_tokens makes some AITER A8W4/EP kernels take the arena path
+        # and can corrupt memory when M is already the exact row count. Let
+        # fused_moe derive M directly from dispatch_ids instead.
+        return (
+            dispatch_a1,
+            None,
+            mk.ExpertTokensMetadata(
+                expert_num_tokens=None,
+                expert_num_tokens_cpu=None,
+            ),
+            dispatch_ids,
+            dispatch_weights,
+        )
+
+    def finalize(
+        self,
+        output: torch.Tensor | None,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+    ) -> torch.Tensor:
+        del topk_weights, topk_ids
+        if apply_router_weight_on_input:
+            raise NotImplementedError(
+                "RCCL routed MoE does not support apply_router_weight_on_input"
+            )
+        pending = self._pending
+        if pending is None:
+            raise RuntimeError("finalize called without a matching prepare")
+        self._pending = None
+
+        if isinstance(pending, _PendingGatherCombine):
+            expected_rows = (
+                sum(pending.sizes)
+                if pending.sizes is not None
+                else pending.num_tokens * self._world_size
+            )
+            if fused_expert_output.shape[0] != expected_rows:
+                raise ValueError(
+                    "gathered RCCL output has an unexpected row count: "
+                    f"got {fused_expert_output.shape[0]}, expected {expected_rows}"
+                )
+            if pending.sizes is not None:
+                result = self._device_communicator.reduce_scatterv(
+                    fused_expert_output,
+                    dim=0,
+                    sizes=pending.sizes,
+                )
+                if output is not None:
+                    output.copy_(result)
+                    return output
+                return result
+            result = (
+                output
+                if output is not None
+                else fused_expert_output.new_empty(
+                    (pending.num_tokens, *fused_expert_output.shape[1:])
+                )
+            )
+            self._pynccl.reduce_scatter(result, fused_expert_output.contiguous())
+            return result
+
+        returned_rows = self._exchange_rows(
+            fused_expert_output[: pending.recv_rows],
+            send_splits=pending.recv_splits,
+            recv_splits=pending.send_splits,
+        )
+        return combine_routed_rows(
+            returned_rows,
+            pending.token_indices,
+            pending.num_tokens,
+            output,
+        )

--- a/atom/model_ops/fused_moe/routed_all2all.py
+++ b/atom/model_ops/fused_moe/routed_all2all.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Pure-torch routing helpers for the native MoE all-to-all backend.
+
+The helpers intentionally do not import AITER or distributed state.  Besides
+keeping the routing policy independently testable on CPU, this makes the
+contract between routing and transport explicit:
+
+* ``topk_ids`` are physical IDs in dispatch space.
+* physical experts are laid out in contiguous, equally sized rank shards.
+* a token is sent once per destination rank, even if several of its selected
+  experts live on that rank.
+* each destination copy retains valid global expert IDs; AITER's binary
+  ``expert_mask`` filters the non-local routes during MoE sorting.
+
+The transport layer exchanges the returned rows in reverse and uses
+``token_indices`` to sum contributions from different expert-owner ranks back
+into the source token order.
+"""
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class RoutedDispatchPlan:
+    """Destination-major payload and the inverse combine map for one rank."""
+
+    token_indices: torch.Tensor
+    send_counts: torch.Tensor
+    hidden_states: torch.Tensor
+    topk_ids: torch.Tensor
+    topk_weights: torch.Tensor
+
+
+@dataclass(frozen=True)
+class RoutedPayloadLayout:
+    """Byte widths and dtypes needed to decode one packed dispatch row."""
+
+    hidden_dim: int
+    topk: int
+    hidden_dtype: torch.dtype
+    ids_dtype: torch.dtype
+    weights_dtype: torch.dtype
+    hidden_bytes: int
+    ids_offset: int
+    ids_bytes: int
+    weights_offset: int
+    weights_bytes: int
+    row_bytes: int
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def build_routed_dispatch_plan(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    *,
+    num_local_experts: int,
+    world_size: int,
+) -> RoutedDispatchPlan:
+    """Pack local tokens into destination-rank-major routed rows.
+
+    Each output row represents one ``(token, destination rank)`` pair.  If two
+    top-k experts for a token live on the same rank, the hidden state appears
+    only once and both expert columns remain enabled in that row.
+    """
+    if hidden_states.ndim != 2:
+        raise ValueError(
+            f"hidden_states must be rank 2, got shape={tuple(hidden_states.shape)}"
+        )
+    if topk_ids.ndim != 2 or topk_weights.ndim != 2:
+        raise ValueError("topk_ids and topk_weights must both be rank 2")
+    if topk_ids.shape != topk_weights.shape:
+        raise ValueError(
+            "topk_ids and topk_weights must have the same shape, got "
+            f"{tuple(topk_ids.shape)} and {tuple(topk_weights.shape)}"
+        )
+    if hidden_states.shape[0] != topk_ids.shape[0]:
+        raise ValueError(
+            "hidden_states and top-k tensors must have the same token count, got "
+            f"{hidden_states.shape[0]} and {topk_ids.shape[0]}"
+        )
+    if not (hidden_states.device == topk_ids.device == topk_weights.device):
+        raise ValueError("hidden_states and top-k tensors must be on the same device")
+    if topk_ids.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"topk_ids must be int32 or int64, got {topk_ids.dtype}")
+    if num_local_experts <= 0:
+        raise ValueError("num_local_experts must be positive")
+    if world_size <= 0:
+        raise ValueError("world_size must be positive")
+
+    num_tokens, topk = topk_ids.shape
+    num_experts = num_local_experts * world_size
+    valid = topk_ids >= 0
+    invalid = valid & (topk_ids >= num_experts)
+    if bool(invalid.any().item()):
+        bad_id = int(topk_ids[invalid][0].item())
+        raise ValueError(
+            f"physical expert id {bad_id} is outside dispatch space [0, {num_experts})"
+        )
+
+    safe_ids = torch.where(valid, topk_ids, torch.zeros_like(topk_ids))
+    owners = torch.div(safe_ids, num_local_experts, rounding_mode="floor").to(
+        torch.int64
+    )
+
+    # scatter_add handles duplicate owners deterministically: two experts on
+    # one rank still create one token row for that destination.
+    destination_hits = torch.zeros(
+        (num_tokens, world_size),
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    if topk:
+        destination_hits.scatter_add_(1, owners, valid.to(torch.int32))
+    destination_mask = destination_hits > 0
+
+    # nonzero on [destination, token] returns destination-major rows, exactly
+    # the layout expected by all_to_all_single input_split_sizes.
+    pairs = destination_mask.transpose(0, 1).contiguous().nonzero(as_tuple=False)
+    token_indices = pairs[:, 1]
+    send_counts = destination_mask.sum(dim=0, dtype=torch.int64)
+
+    # AITER's EP sorting kernels index expert_mask with every top-k ID before
+    # filtering non-local routes, so -1 sentinels are not safe here. Preserve
+    # the complete global routing row for parity with the gather/scatter path,
+    # and sanitize only genuinely empty input slots to an in-range zero-weight
+    # route. The destination's binary expert_mask performs the ownership
+    # filtering inside fused_moe.
+    selected_ids = safe_ids.index_select(0, token_indices)
+    selected_weights = topk_weights.index_select(0, token_indices)
+    selected_valid = valid.index_select(0, token_indices)
+    dispatch_weights = torch.where(
+        selected_valid, selected_weights, torch.zeros_like(selected_weights)
+    )
+    dispatch_hidden = hidden_states.index_select(0, token_indices)
+
+    return RoutedDispatchPlan(
+        token_indices=token_indices,
+        send_counts=send_counts,
+        hidden_states=dispatch_hidden.contiguous(),
+        topk_ids=selected_ids.contiguous(),
+        topk_weights=dispatch_weights.contiguous(),
+    )
+
+
+def combine_routed_rows(
+    returned_rows: torch.Tensor,
+    token_indices: torch.Tensor,
+    num_tokens: int,
+    output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Sum destination-rank contributions back into source token order."""
+    if returned_rows.shape[0] != token_indices.numel():
+        raise ValueError(
+            "returned row count must match token_indices, got "
+            f"{returned_rows.shape[0]} and {token_indices.numel()}"
+        )
+    expected_shape = (num_tokens, *returned_rows.shape[1:])
+    if output is None:
+        output = returned_rows.new_zeros(expected_shape)
+    else:
+        if tuple(output.shape) != expected_shape:
+            raise ValueError(
+                f"output shape must be {expected_shape}, got {tuple(output.shape)}"
+            )
+        output.zero_()
+    if token_indices.numel():
+        output.index_add_(0, token_indices, returned_rows)
+    return output
+
+
+def pack_routed_payload(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> tuple[torch.Tensor, RoutedPayloadLayout]:
+    """Pack mixed-dtype routed fields into one uint8 all-to-all payload."""
+    rows, hidden_dim = hidden_states.shape
+    if topk_ids.shape[0] != rows or topk_weights.shape != topk_ids.shape:
+        raise ValueError("routed payload fields must have matching row counts")
+    topk = topk_ids.shape[1]
+    hidden_bytes = hidden_dim * hidden_states.element_size()
+    ids_bytes = topk * topk_ids.element_size()
+    weights_bytes = topk * topk_weights.element_size()
+    ids_offset = _align_up(hidden_bytes, topk_ids.element_size())
+    weights_offset = _align_up(ids_offset + ids_bytes, topk_weights.element_size())
+    row_alignment = max(
+        hidden_states.element_size(),
+        topk_ids.element_size(),
+        topk_weights.element_size(),
+    )
+    row_bytes = _align_up(weights_offset + weights_bytes, row_alignment)
+    payload = torch.zeros(
+        (rows, row_bytes), dtype=torch.uint8, device=hidden_states.device
+    )
+    payload[:, :hidden_bytes].copy_(
+        hidden_states.contiguous().view(torch.uint8).reshape(rows, hidden_bytes)
+    )
+    payload[:, ids_offset : ids_offset + ids_bytes].copy_(
+        topk_ids.contiguous().view(torch.uint8).reshape(rows, ids_bytes)
+    )
+    payload[:, weights_offset : weights_offset + weights_bytes].copy_(
+        topk_weights.contiguous().view(torch.uint8).reshape(rows, weights_bytes)
+    )
+    return payload, RoutedPayloadLayout(
+        hidden_dim=hidden_dim,
+        topk=topk,
+        hidden_dtype=hidden_states.dtype,
+        ids_dtype=topk_ids.dtype,
+        weights_dtype=topk_weights.dtype,
+        hidden_bytes=hidden_bytes,
+        ids_offset=ids_offset,
+        ids_bytes=ids_bytes,
+        weights_offset=weights_offset,
+        weights_bytes=weights_bytes,
+        row_bytes=row_bytes,
+    )
+
+
+def unpack_routed_payload(
+    payload: torch.Tensor,
+    layout: RoutedPayloadLayout,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Reverse :func:`pack_routed_payload` into contiguous typed tensors."""
+    expected_width = layout.row_bytes
+    if payload.dtype != torch.uint8 or payload.ndim != 2:
+        raise ValueError("routed payload must be a rank-2 uint8 tensor")
+    if payload.shape[1] != expected_width:
+        raise ValueError(
+            f"routed payload width must be {expected_width}, got {payload.shape[1]}"
+        )
+
+    hidden_states = (
+        payload[:, : layout.hidden_bytes]
+        .contiguous()
+        .view(layout.hidden_dtype)
+        .reshape(payload.shape[0], layout.hidden_dim)
+    )
+    topk_ids = (
+        payload[:, layout.ids_offset : layout.ids_offset + layout.ids_bytes]
+        .contiguous()
+        .view(layout.ids_dtype)
+        .reshape(payload.shape[0], layout.topk)
+    )
+    topk_weights = (
+        payload[
+            :,
+            layout.weights_offset : layout.weights_offset + layout.weights_bytes,
+        ]
+        .contiguous()
+        .view(layout.weights_dtype)
+        .reshape(payload.shape[0], layout.topk)
+    )
+    return hidden_states, topk_ids, topk_weights

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -196,23 +196,33 @@ class FusedMoEParallelConfig:
     # deployment wider than the box, in which case experts shard that many
     # times finer and each rank repeats the gathered tokens that many times.
     dp_logical_ratio: int = 1
+    requested_all2all_backend: str = "auto"
+
+    @property
+    def selected_all2all_backend(self) -> str | None:
+        if self.dp_size <= 1 or not self.use_ep or self.dp_logical_ratio != 1:
+            return None
+        if self.requested_all2all_backend == "none":
+            return None
+        if self.requested_all2all_backend == "rccl":
+            return "rccl"
+        if not envs.ATOM_DISABLE_MORI_EP and _has_module("mori"):
+            return "mori"
+        return None
 
     @property
     def use_all2all_kernels(self):
-        # Only use mori all2all kernels when expert parallel is enabled.
-        # Never while simulating: mori is real peer-to-peer, so absent ranks
-        # cannot be stood in for, and it derives a token's destination from
-        # num_experts // real peer count -- which disagrees with a finer map.
-        return (
-            self.dp_size > 1
-            and self.use_ep
-            and self.dp_logical_ratio == 1
-            and _has_module("mori")
-        )
+        # Routed all-to-all requires real peers. Simulated DP has a finer
+        # expert map than the launched process group and stays on the fallback.
+        return self.selected_all2all_backend is not None
 
     @property
     def use_mori_kernels(self):
-        return True
+        return self.selected_all2all_backend == "mori"
+
+    @property
+    def use_rccl_kernels(self):
+        return self.selected_all2all_backend == "rccl"
 
     @staticmethod
     def make(
@@ -234,6 +244,9 @@ class FusedMoEParallelConfig:
         # Only flatten DP into TP/EP when enable_dp_attention is True.
         # Otherwise, use pure DP for MoE.
         enable_dp_attention = parallel_config.enable_dp_attention
+        requested_all2all_backend = getattr(
+            parallel_config, "moe_all2all_backend", "auto"
+        )
 
         # When EP shards across the flattened DP * TP space (vLLM plugin under
         # EP), the ep rank must be computed in that flattened group space.
@@ -291,6 +304,7 @@ class FusedMoEParallelConfig:
                 ep_rank=0,
                 use_ep=False,
                 local_ep_size=1,
+                requested_all2all_backend=requested_all2all_backend,
             )
         # DP + EP / TP + EP / DP + TP + EP
         assert use_ep
@@ -312,6 +326,7 @@ class FusedMoEParallelConfig:
             ),
             local_ep_size=atom_config.parallel_config.data_parallel_size_local
             * tp_size_,
+            requested_all2all_backend=requested_all2all_backend,
         )
 
 
@@ -456,6 +471,16 @@ def dp_gather_hidden_and_router(
     ``reduce_scatter_with_unpadding`` must trim back to. ``sizes`` is non-None
     only in eager mode (needed later for ``reduce_scatterv``).
     """
+    atom_cfg = get_current_atom_config()
+    eplb_cfg = getattr(atom_cfg, "eplb_config", None)
+    eplb_enabled = bool(getattr(atom_cfg, "eplb_enable", False))
+    eplb_load_mode = getattr(eplb_cfg, "load_mode", "prefill")
+    local_selected_for_eplb = not ctx.context.is_dummy_run and (
+        eplb_load_mode == "all"
+        or (eplb_load_mode == "prefill" and ctx.context.is_prefill)
+        or (eplb_load_mode == "decode" and not ctx.context.is_prefill)
+    )
+
     if dp_eager_mode:
         sizes = ctx.dp_metadata.get_sizes_across_dp()
         # Eager means nothing was padded, so the context's two heights agree
@@ -476,9 +501,30 @@ def dp_gather_hidden_and_router(
             if r_dtype == hidden_states.dtype
             else router_logits.to(hidden_states.dtype)
         )
-        combined = torch.cat([hidden_states, r_for_gather], dim=-1)
+        parts = [hidden_states, r_for_gather]
+        gather_eplb_mask = (
+            eplb_enabled and getattr(ctx, "eplb_token_mask", None) is None
+        )
+        if gather_eplb_mask:
+            # A DPA step may mix prefill and decode ranks. Carry one selection
+            # bit per row in the existing variable-length collective so only
+            # source ranks chosen by EPLB load_mode contribute statistics.
+            selected = torch.full(
+                (hidden_states.shape[0], 1),
+                local_selected_for_eplb,
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            parts.append(selected)
+        combined = torch.cat(parts, dim=-1)
         combined = all_gatherv(combined, sizes, dp_group)
-        hidden_states, router_logits = combined.split([h_dim, r_dim], dim=-1)
+        if gather_eplb_mask:
+            hidden_states, router_logits, selected = combined.split(
+                [h_dim, r_dim, 1], dim=-1
+            )
+            ctx.eplb_token_mask = selected[:, 0] > 0
+        else:
+            hidden_states, router_logits = combined.split([h_dim, r_dim], dim=-1)
         hidden_states = hidden_states.contiguous()
         if router_logits.dtype != r_dtype:
             router_logits = router_logits.to(r_dtype)
@@ -487,7 +533,34 @@ def dp_gather_hidden_and_router(
         return hidden_states, router_logits, local_tokens, sizes
 
     hidden_states, local_tokens = all_gather_with_padding(hidden_states)
-    router_logits, _ = all_gather_with_padding(router_logits)
+
+    record_decode = eplb_enabled and eplb_load_mode in {"decode", "all"}
+    cached_mask = getattr(ctx, "eplb_token_mask", None)
+    if record_decode and not ctx.context.is_prefill and cached_mask is None:
+        # Decode graphs pad to a captured batch size. The attention slot map is
+        # already refreshed on every replay and marks those tail rows with -1.
+        # Gather the validity bit alongside router logits (one extra scalar per
+        # token, no extra collective) so EPLB ignores padding from every rank.
+        attn_metadata = ctx.attn_metadata
+        slot_mapping = getattr(attn_metadata, "slot_mapping", None)
+        if isinstance(slot_mapping, torch.Tensor):
+            padded_router, _ = pad_for_all_gather(router_logits)
+            local_mask = slot_mapping[: padded_router.shape[0]] >= 0
+            router_and_mask = torch.cat(
+                (padded_router, local_mask[:, None].to(padded_router.dtype)), dim=-1
+            )
+            gathered = get_dp_group().all_gather(
+                router_and_mask, use_custom=True, dim=0
+            )
+            router_logits = gathered[:, :-1].contiguous()
+            ctx.eplb_token_mask = gathered[:, -1] > 0
+        else:
+            # Backends without a slot map cannot expose dynamic graph padding.
+            # The EPLB mapper will conservatively skip decode accounting rather
+            # than train placement on arbitrary padded rows.
+            router_logits, _ = all_gather_with_padding(router_logits)
+    else:
+        router_logits, _ = all_gather_with_padding(router_logits)
     return hidden_states, router_logits, local_tokens, None
 
 
@@ -598,10 +671,30 @@ class FusedMoEMethodBase(QuantizeMethodBase):
     ) -> FusedMoEPrepareAndFinalize | None:
         from aiter.dist.parallel_state import get_ep_group
 
-        all2all_manager = get_ep_group().device_communicator.all2all_manager
-        assert all2all_manager is not None
-
         prepare_finalize: FusedMoEPrepareAndFinalize | None = None
+        ep_group = get_ep_group()
+
+        if moe.use_rccl_kernels:
+            from atom.model_ops.fused_moe.rccl_prepare_finalize import (
+                RcclPrepareAndFinalize,
+            )
+
+            return RcclPrepareAndFinalize(
+                ep_group,
+                num_local_experts=moe.num_local_experts,
+                max_tokens_per_rank=moe.max_num_tokens,
+                num_replicated_shared_experts=(
+                    moe.expert_layout.num_fused_shared_experts
+                    if moe.expert_layout.uses_dispatch_remap
+                    else 0
+                ),
+                num_routed_experts_per_rank=(
+                    moe.expert_layout.routed_physical_per_rank
+                ),
+            )
+
+        all2all_manager = ep_group.device_communicator.all2all_manager
+        assert all2all_manager is not None
 
         # TODO: could allow this now
         # assert not moe.use_flashinfer_cutlass_kernels, "Must be created in modelopt.py"
@@ -4324,6 +4417,12 @@ class FusedMoE(torch.nn.Module):
             if dp_repeat > 1:
                 hidden_states = repeat_rows(hidden_states, dp_repeat)
                 router_logits = repeat_rows(router_logits, dp_repeat)
+                eplb_mask = getattr(ctx, "eplb_token_mask", None)
+                if eplb_mask is not None:
+                    # A subsequent MoE layer sees the cached repeated mask; trim
+                    # it to the real gathered extent before repeating again.
+                    eplb_mask = eplb_mask[:gathered_rows]
+                    ctx.eplb_token_mask = repeat_rows(eplb_mask, dp_repeat)
 
             if _tbo:
                 tbo_switch_to_compute_sync()

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -27,11 +27,19 @@ def is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
     # layout (set by the vLLM plugin under DP+EP); disable it there.
     if dp_size > 1 and config.moe_ep_flatten_tp_across_dp:
         return False
-    # Only MoRI needs the switch; the TP fusion is a different mechanism.
+    # Only the selected MoRI transport needs this switch; the TP fusion is a
+    # different mechanism, and an explicitly selected RCCL/none backend must
+    # not be inferred from the mere presence of the ``mori`` Python package.
     # EPLB always fuses, otherwise the env decides.
+    requested_all2all = getattr(config, "moe_all2all_backend", "auto")
+    mori_selected = (
+        requested_all2all in {"auto", "mori"}
+        and not envs.ATOM_DISABLE_MORI_EP
+        and _has_module("mori")
+    )
     if (
         dp_size > 1
-        and _has_module("mori")
+        and mori_selected
         and config.enable_dp_attention
         and not (getattr(config, "eplb_enable", False) or envs.ATOM_FUSE_SHARED_EXPERT)
     ):

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -4642,9 +4642,17 @@ class DeepseekV4ForCausalLM(nn.Module):
         # default [max_num_batched_tokens, hidden_size]. forward returns
         # the un-reduced mHC residual stack [N, hc, dim].
         self.extra_output_dims: tuple[int, ...] = (self.args.hc_mult,)
+        # Hash routing must see one token id for every MoE row. DPA gathers MoE
+        # rows when EP is disabled *and* when EP uses the collective fallback;
+        # only the mori all-to-all path keeps routing on rank-local rows.
+        uses_mori_all2all = any(
+            isinstance(module, MoE)
+            and module.experts.moe_parallel_config.use_all2all_kernels
+            for module in self.model.modules()
+        )
         self._need_ids_gather = (
             config.enable_dp_attention
-            and not config.enable_expert_parallel
+            and not uses_mori_all2all
             and self.args.n_hash_layers > 0
         )
 
@@ -4729,8 +4737,9 @@ class DeepseekV4ForCausalLM(nn.Module):
                     full_padded_ids = pcp_allgather_rankmajor(input_ids, pcp_size)
 
         if self._need_ids_gather:
-            # DP-attention (no EP) hash routing: input_ids is local but the MoE
-            # gate sees DP-gathered gating_output, so gather ids to match. Run
+            # DP-attention collective fallback hash routing: input_ids is local
+            # but the MoE gate sees DP-gathered gating_output, so gather ids to
+            # match. This covers TP-style MoE and EP with mori disabled. Run
             # the gather INLINE on the compute stream. Running this all-gather on
             # a side stream coordinated it with a DIFFERENT stream/sync than the
             # MoE hidden/router DP gather under TBO → mismatched DP layouts →

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -73,6 +73,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_USE_TRITON_MOE": lambda: os.getenv("ATOM_USE_TRITON_MOE", "0") == "1",
     "ATOM_USE_TRITON_MOE_DECODE": lambda: os.getenv("ATOM_USE_TRITON_MOE_DECODE", "0")
     == "1",
+    # Force DP-attention + EP through the collective fallback even when mori is
+    # installed. This is useful for controlled A/B tests and for deployments
+    # where the mori shared-memory transport is unavailable or undesirable.
+    # The fallback gathers hidden/router rows across DP ranks, computes only
+    # the locally owned experts, then reduce-scatters the outputs.
+    "ATOM_DISABLE_MORI_EP": lambda: os.getenv("ATOM_DISABLE_MORI_EP", "0").lower()
+    in {"1", "true", "yes", "on"},
     # Use mori dispatch_combine_v2 (FlyDSL/cco, gfx1250 wave32) instead of the
     # production mori v1 (mori.ops.EpDispatchCombineOp) for the EP+DP MoE
     # all2all. v1 is authored for gfx942/950 and does not run on gfx1250; v2 is

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -265,8 +265,9 @@ class ForwardMode:
                 local_meets_min_tokens=meets_min,
                 local_can_split=can_split,
                 local_ub_tokens=(ub0, ub1),
+                local_is_dummy=bool(getattr(batch, "is_dummy_run", False)),
                 # Only a block drafter needs the group to agree on it; every
-                # other flavor keeps its own and the two extra wire rows are
+                # other flavor keeps its own and the extra wire row is
                 # not sent.
                 max_seqlen_q=max_seqlen_q if is_block_drafter else None,
             )
@@ -736,6 +737,12 @@ class ForwardContext:
     # per-ubatch all_reduce. Shape: tuple of length N == len(ubatch_slices).
     # None when DP is off or when TBO is not active this step.
     ub_max_tokens_across_dp: tuple | None = None
+
+    # One boolean per MoE input row. Populated lazily when decode-aware EPLB is
+    # enabled so padded CUDAGraph/DP rows do not pollute expert-load statistics.
+    # The tensor address remains stable under graph capture and is reused by all
+    # MoE layers in the forward.
+    eplb_token_mask: torch.Tensor | None = None
 
     # Cached current_stream() captured at set_forward_context() time, so
     # downstream code (V4 attention / MoE / metadata builder) doesn't have

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -194,6 +194,11 @@ class DPSyncResult:
     # the graph-shape sync no longer needs its own separate all_reduce (halves
     # the per-step DP round-trips).
     max_seqlen_q_across_dp: int | None = None
+    # EPLB activity signals exclude synthetic dummy forwards. They let a DPA
+    # group advance a prefill- or decode-specific rebalance clock without an
+    # additional collective on every model step.
+    any_rank_has_real_prefill: bool = False
+    any_rank_has_decode: bool = False
 
 
 def sync_dp_metadata(
@@ -208,6 +213,7 @@ def sync_dp_metadata(
     local_can_split: bool = False,
     local_ub_tokens: tuple[int, int] = (0, 0),
     max_seqlen_q: int | None = None,
+    local_is_dummy: bool = False,
 ) -> DPSyncResult:
     """Single packed DP all_gather over all per-rank scalars a decode/prefill
     step needs synchronized: DP token padding, the prefill fan-out, the
@@ -219,19 +225,19 @@ def sync_dp_metadata(
     Pre-Plan-B this required up to 3 separate all_reduces per step
     (``get_dp_padding`` / this sync / a third inside
     ``UBatchWrapper``). Now one all_gather of ``n_fields`` int32 values
-    per rank suffices. When TBO is off only the first 3 fields are
-    exchanged (saves 57 % payload + skips :func:`local_tbo_precompute`
-    at the call site).
+    per rank suffices. When TBO is off only the first 4 fields are exchanged
+    (and :func:`local_tbo_precompute` is skipped at the call site).
 
     Layout (``sync`` is ``[n_fields, dp_size]``):
 
       row 0 : scheduled_tokens         -> num_tokens_across_dp
       row 1 : scheduled_bs             -> max_bs_across_dp (MAX)
       row 2 : is_prefill (0/1)         -> any_rank_has_prefill (OR)
-      row 3 : meets_min_tokens (0/1)   -> OR  -> any rank reached the min-token bar [TBO only]
-      row 4 : can_split (0/1)          -> AND -> every rank can split              [TBO only]
-      row 5 : ub0_tokens               -> ub_max_tokens_across_dp[0]              [TBO only]
-      row 6 : ub1_tokens               -> ub_max_tokens_across_dp[1]              [TBO only]
+      row 3 : is_dummy (0/1)           -> real prefill/decode activity for EPLB
+      row 4 : meets_min_tokens (0/1)   -> OR  -> any rank reached the min-token bar [TBO only]
+      row 5 : can_split (0/1)          -> AND -> every rank can split              [TBO only]
+      row 6 : ub0_tokens               -> ub_max_tokens_across_dp[0]              [TBO only]
+      row 7 : ub1_tokens               -> ub_max_tokens_across_dp[1]              [TBO only]
       row k+0 : max_seqlen_q           -> max_seqlen_q_across_dp (MAX)  [DSpark only]
 
     Rows 0 and 1 are the same batch in ATOM's two units; both ride this one
@@ -247,18 +253,20 @@ def sync_dp_metadata(
     0 already carry them, and a step that reaches the reduction with every rank
     decoding has `scheduled_tokens` == its decode total on every rank.
     """
-    tbo_fields = 7 if tbo_on else 3
+    base_fields = 4
+    tbo_fields = 8 if tbo_on else base_fields
     dspark_on = max_seqlen_q is not None
     n_fields = tbo_fields + (1 if dspark_on else 0)
     local = torch.zeros(n_fields, dtype=torch.int32, device="cpu")
     local[0] = scheduled_tokens
     local[1] = scheduled_bs
     local[2] = 1 if is_prefill else 0
+    local[3] = 1 if local_is_dummy else 0
     if tbo_on:
-        local[3] = 1 if local_meets_min_tokens else 0
-        local[4] = 1 if local_can_split else 0
-        local[5] = local_ub_tokens[0]
-        local[6] = local_ub_tokens[1]
+        local[4] = 1 if local_meets_min_tokens else 0
+        local[5] = 1 if local_can_split else 0
+        local[6] = local_ub_tokens[0]
+        local[7] = local_ub_tokens[1]
     if dspark_on:
         local[tbo_fields + 0] = max_seqlen_q
 
@@ -271,6 +279,9 @@ def sync_dp_metadata(
     num_tokens_across_dp = sync[0]
     max_bs_across_dp = int(sync[1].max())
     any_rank_has_prefill = bool(sync[2].any())
+    real_rank = sync[3] == 0
+    any_rank_has_real_prefill = bool(((sync[2] != 0) & real_rank).any())
+    any_rank_has_decode = bool(((sync[2] == 0) & real_rank).any())
     tbo_collective_active = False
     ub_max_tokens_across_dp: tuple[int, int] | None = None
     if tbo_on:
@@ -279,7 +290,7 @@ def sync_dp_metadata(
         # that rank would run 1 ubatch while peers run 2 → per-ubatch collective
         # size mismatch → RCCL hang. Under-filled-but-splittable ranks are then
         # force-split (see maybe_create_ubatch_slices force=True) to stay aligned.
-        tbo_collective_active = bool(sync[3].any()) and bool(sync[4].all())
+        tbo_collective_active = bool(sync[4].any()) and bool(sync[5].all())
         # Mixed-mode guard: ALWAYS require a uniform batch mode (all prefill or
         # all decode) across DP. A prefill rank running 2 ubatches alongside a
         # decode rank running 2 ubatches still issues different collectives per
@@ -291,8 +302,8 @@ def sync_dp_metadata(
             tbo_collective_active = uniform_mode
         if tbo_collective_active:
             ub_max_tokens_across_dp = (
-                int(sync[5].max()),
                 int(sync[6].max()),
+                int(sync[7].max()),
             )
 
     max_seqlen_q_across_dp: int | None = None
@@ -303,6 +314,8 @@ def sync_dp_metadata(
         num_tokens_across_dp=num_tokens_across_dp,
         max_bs_across_dp=max_bs_across_dp,
         any_rank_has_prefill=any_rank_has_prefill,
+        any_rank_has_real_prefill=any_rank_has_real_prefill,
+        any_rank_has_decode=any_rank_has_decode,
         tbo_collective_active=tbo_collective_active,
         ub_max_tokens_across_dp=ub_max_tokens_across_dp,
         max_seqlen_q_across_dp=max_seqlen_q_across_dp,

--- a/recipes/DeepSeek-V4.md
+++ b/recipes/DeepSeek-V4.md
@@ -33,6 +33,41 @@ Tips on server configuration:
 - Clear compile cache before restarting after code changes: `rm -rf /root/.cache/atom/*`
 - V4-Pro reuses the DeepSeek-V3 config schema; V4-specific fields (compress ratios, hash layers, index head dims) are read from the HF config automatically.
 
+### Experimental native RCCL routed MoE
+
+ATOM can run expert dispatch/combine without MoRI through a native RCCL
+backend. Uniform decode uses a graph-safe pre-routed AllGather/ReduceScatter
+fast path. When DP and EP have the same width, prefill and mixed batches reuse
+the scheduler's token counts for variable-size AllGather/ReduceScatter; other
+topologies use variable-split routed `torch.distributed.all_to_all_single`:
+
+```bash
+AITER_BF16_FP8_MOE_BOUND=0 ATOM_MOE_GU_ITLV=1 AITER_LOG_LEVEL=WARNING \
+python -m atom.entrypoints.openai_server \
+  --model deepseek-ai/DeepSeek-V4-Pro \
+  --kv_cache_dtype fp8 -tp 8 \
+  --enable-expert-parallel --enable-dp-attention \
+  --all2all-backend rccl
+```
+
+The backend consumes the same physical expert IDs produced after EPLB remap.
+Uniform decode packs hidden states plus compact top-k IDs/weights into one
+AllGather payload instead of gathering full router logits, runs the existing
+local fused expert kernel, and reduce-scatters the result.
+The variable-size path routes once on each source rank, gathers the packed
+hidden/ID/weight rows, runs the same local expert kernel, then reduce-scatters
+partial outputs to source-token order. Routed-expert IDs are preserved. Locally
+replicated shared experts are computed exactly once rather than once on every
+rank, and their owner is reassigned round-robin by global token row so one DPA
+rank with an unusually long request cannot hotspot its local shared-expert GEMM.
+
+The prefill/mixed path remains correctness-first rather than a MoRI performance
+replacement: the packed hidden/ID/weight payload is not yet produced by a fused
+GPU kernel, and wider flattened DP*TP expert groups still use the dynamic
+all-to-all fallback. TBO is not supported and is disabled for this backend. Use
+`--all2all-backend none` to select the original AllGather/ReduceScatter path, or
+omit the option to preserve automatic MoRI detection.
+
 ### MegaMoE fused MoE backend (`--moe-backend mega`)
 
 The routed-MoE implementation is selectable with `--moe-backend {standard,mega}`
@@ -133,10 +168,12 @@ python -m atom.entrypoints.openai_server \
 
   | Key | Default | Meaning |
   |---|---|---|
+  | `load_mode` | `"prefill"` | Forward modes used for load sampling and the rebalance clock. `"decode"` enables decode-only EPLB; `"all"` combines both. Decode accounting excludes dummy/CUDAGraph padding rows. |
   | `num_redundant_experts` | `0` | Extra physical expert slots per MoE layer set aside for replicas. `0` = pure rearrangement only (no extra memory; still rebalances via re-placement). Must be a multiple of the GPU count. |
   | `placement_policy` | `"naive"` | How the redundant-expert budget is spent. `"naive"`: greedy-replicate + `balanced_packing` spreads replicas thinly (DeepSeek-reference algorithm) — works with `num_redundant_experts=0` (pure rearrangement) or `>0`. `"biased"`: fully replicates the top-K hottest experts to **every** GPU (K = `num_redundant_experts // num_gpus`), trading memory for eliminating cross-GPU traffic on the hottest experts — **requires `num_redundant_experts > 0` (K ≥ 1); with `num_redundant_experts=0` it silently computes K=0 and falls back to identical behavior as `"naive"` ** If you set `placement_policy="biased"` and don't see the expected throughput gain, check `num_redundant_experts` first. |
-  | `rebalance_interval` | `3000` | Forward-pass steps between rebalance attempts. **Tune to the workload**: prefill-heavy/short runs accumulate steps slowly — use a small interval (e.g. `200`) or a short eval simply never triggers a rebalance. Decode-heavy runs accumulate steps fast — too small an interval (e.g. `200` for a long decode run) fires rebalances every few seconds and the migration overhead itself becomes the bottleneck; use a larger interval (e.g. `3000`) so rebalances land roughly every 8–12× the load-window size. |
-  | `load_window_size` | `1000` | Non-dummy (real) forward passes accumulated into the load histogram before a rebalance decision uses it. Must be `<= rebalance_interval`. |
+  | `rebalance_interval` | `3000` | Selected forward-pass steps between rebalance attempts. **Tune to the workload**: a short eval may need a small interval (e.g. `200`) to trigger at all. With `load_mode="decode"`, too small an interval on long generations can make migration overhead the bottleneck; start around `1000`–`3000`. |
+  | `max_rebalances` | `0` | Maximum completed automatic rebalances; `0` means unlimited. Use `1` for benchmark serving: calibrate once on representative traffic, then freeze the learned placement so the measured phase cannot pay another expert-weight migration pause. A gate skip does not consume the limit. |
+  | `load_window_size` | `1000` | Non-dummy forwards selected by `load_mode` and accumulated into the load histogram before a rebalance decision uses it. Must be `<= rebalance_interval`. |
   | `rebalance_min_balancedness` | `2.0` | Gate: skip a rebalance if the measured per-GPU balancedness is already `>=` this value. Per-GPU balancedness is bounded by ~1.0 in practice, so the `2.0` default is **inert** (always rebalances every interval) — lower it toward `~0.85–0.9` to let already-balanced layers skip rebalancing (saves plan/migration cost when biased placement is already flat). |
   | `rebalance_balancedness_agg` | `"min"` | `"min"` or `"mean"` — how per-layer balancedness scores are aggregated for the gate. |
   | `rebalance_layers_per_chunk` | `64` | MoE layers migrated per rebalance chunk (chunking bounds per-rebalance P2P burst size). |
@@ -144,6 +181,43 @@ python -m atom.entrypoints.openai_server \
 
 - **Memory**: `num_redundant_experts=0` (pure rearrangement) costs nothing extra. Each redundant slot costs one extra physical expert's weights on the GPU(s) holding it — `biased` concentrates that cost onto every GPU for the top-K experts, `naive` spreads it thinly.
 - EPLB is safe to enable with `num_redundant_experts=0` any time EP is on — it just periodically re-places experts across the existing physical slots to flatten per-GPU load, with no placement/memory tradeoffs to reason about.
+- **Decode-heavy serving**: set `"load_mode":"decode"` so expert statistics and the rebalance clock follow actual decode traffic instead of prompt traffic. Use `"all"` only when one placement should represent both phases; token counts naturally weight larger prefill batches more heavily.
+
+For long-context Agentic benchmarks, the usual one-token-per-lane warmup does
+not contain enough decode steps to train `load_mode="decode"`. Run a short,
+representative decode calibration on the same server before measurement and set
+`"max_rebalances":1`; after the log reports
+`EPLB automatic rebalancing and load recording frozen`,
+start the scored run. Do not substitute `load_mode="all"` with the standard
+one-token Agentic warmup: prompt-trained placement can differ from generated-token
+routing and has regressed c96 decode measurements. The calibration requests must
+produce representative output tokens.
+
+The first automatic rebalance waits for at least a full `load_window_size`
+after startup. For Agentic traffic, do not reduce this merely to make a short
+smoke test trigger sooner: the resulting placement is sensitive to whichever
+trajectories finish first. Prefer a longer calibration window over a noisier
+early placement.
+
+Keep the default `"rebalance_layers_per_chunk":64` for throughput runs and move
+the resulting one-time pause into calibration. Splitting all 61 layers into
+single-layer online migrations increased total migration time and regressed c96
+throughput in testing. Once the one-shot placement freezes, EPLB also disables
+Python-side load-window maintenance and gates load histograms in already captured
+decode graphs.
+
+For a decode-throughput run, start with pure rearrangement and a conservative
+migration interval, then add replicas only after measuring the available memory:
+
+```bash
+python -m atom.entrypoints.openai_server \
+  --model deepseek-ai/DeepSeek-V4-Pro \
+  --kv_cache_dtype fp8 -tp 8 \
+  --enable-dp-attention --enable-expert-parallel \
+  --dp-load-balance least_tokens \
+  --eplb-enable \
+  --eplb-config '{"load_mode":"decode","load_window_size":1000,"rebalance_interval":3000,"max_rebalances":1,"rebalance_min_balancedness":0.9,"num_redundant_experts":0,"placement_policy":"naive"}'
+```
 
 **Measured effect** (8×MI355X, EP+DPA, 8k-in/1-out prefill, `mnbt=8192`, conc=128; relative to EP with EPLB disabled):
 

--- a/tests/model_ops/test_rccl_prepare_finalize.py
+++ b/tests/model_ops/test_rccl_prepare_finalize.py
@@ -1,0 +1,220 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("aiter")
+
+from atom.model_ops.fused_moe.rccl_prepare_finalize import RcclPrepareAndFinalize
+
+
+class _FakePyNccl:
+    disabled = False
+
+    def __init__(self, world_size: int):
+        self.world_size = world_size
+        self.all_gather_calls: list[tuple[torch.dtype, torch.dtype]] = []
+
+    def all_gather(self, output: torch.Tensor, input_: torch.Tensor) -> None:
+        self.all_gather_calls.append((output.dtype, input_.dtype))
+        output.view(self.world_size, *input_.shape).copy_(
+            input_.unsqueeze(0).expand(self.world_size, *input_.shape)
+        )
+
+    def group_start(self) -> None:
+        pass
+
+    def group_end(self) -> None:
+        pass
+
+    def reduce_scatter(self, output: torch.Tensor, input_: torch.Tensor) -> None:
+        output.copy_(input_.view(self.world_size, *output.shape).sum(dim=0))
+
+
+class _FakeDeviceCommunicator:
+    def __init__(self, world_size: int):
+        self.pynccl_comm = _FakePyNccl(world_size)
+        self.peer_payload: torch.Tensor | None = None
+        self.all_gatherv_calls: list[tuple[int, list[int]]] = []
+        self.reduce_scatterv_calls: list[tuple[int, list[int]]] = []
+
+    def all_gatherv(
+        self, input_: torch.Tensor, *, dim: int, sizes: list[int]
+    ) -> torch.Tensor:
+        self.all_gatherv_calls.append((dim, list(sizes)))
+        assert self.peer_payload is not None
+        return torch.cat((input_, self.peer_payload), dim=dim)
+
+    def reduce_scatterv(
+        self, input_: torch.Tensor, *, dim: int, sizes: list[int]
+    ) -> torch.Tensor:
+        self.reduce_scatterv_calls.append((dim, list(sizes)))
+        assert dim == 0
+        # Simulate the sum from two ranks and return rank zero's source slice.
+        return input_[: sizes[0]] * 2
+
+
+def _make_backend(
+    world_size: int = 2,
+    *,
+    num_local_experts: int = 2,
+    num_replicated_shared_experts: int = 0,
+) -> RcclPrepareAndFinalize:
+    device_communicator = _FakeDeviceCommunicator(world_size)
+    ep_group = SimpleNamespace(
+        device_group=None,
+        device_communicator=device_communicator,
+        rank_in_group=0,
+        world_size=world_size,
+    )
+    backend = RcclPrepareAndFinalize(
+        ep_group,
+        num_local_experts=num_local_experts,
+        max_tokens_per_rank=8,
+        num_replicated_shared_experts=num_replicated_shared_experts,
+    )
+    backend._use_static_decode_path = lambda: True
+    return backend
+
+
+def test_static_decode_gathers_prerouted_rows_and_reduce_scatters_output():
+    backend = _make_backend()
+    hidden = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    topk_ids = torch.tensor([[0, 2], [1, 3]], dtype=torch.int32)
+    topk_weights = torch.tensor([[0.6, 0.4], [0.25, 0.75]])
+
+    dispatched, scale, metadata, dispatch_ids, dispatch_weights = backend.prepare(
+        hidden,
+        topk_weights,
+        topk_ids,
+        num_experts=4,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        quant_config=None,
+    )
+
+    assert scale is None
+    assert metadata.expert_num_tokens is None
+    assert torch.equal(dispatched, hidden.repeat(2, 1))
+    assert torch.equal(dispatch_ids, topk_ids.repeat(2, 1))
+    assert torch.equal(dispatch_weights, topk_weights.repeat(2, 1))
+    assert backend._pynccl.all_gather_calls == [(torch.uint8, torch.uint8)]
+
+    output = backend.finalize(
+        None,
+        dispatched,
+        topk_weights,
+        topk_ids,
+        apply_router_weight_on_input=False,
+    )
+    assert torch.equal(output, hidden * 2)
+
+
+def test_variable_gather_uses_scheduler_sizes_and_preserves_source_routing():
+    from atom.model_ops.fused_moe.routed_all2all import pack_routed_payload
+
+    backend = _make_backend()
+    backend._use_static_decode_path = lambda: False
+    backend._variable_gather_sizes = lambda _: [2, 1]
+
+    hidden = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    topk_ids = torch.tensor([[0, 2], [1, 3]], dtype=torch.int32)
+    topk_weights = torch.tensor([[0.6, 0.4], [0.25, 0.75]])
+    peer_hidden = torch.tensor([[5.0, 6.0]])
+    # The peer's locally replicated shared-expert ID deliberately differs from
+    # rank zero's IDs. Gathering post-routing metadata must preserve it.
+    peer_ids = torch.tensor([[2, 3]], dtype=torch.int32)
+    peer_weights = torch.tensor([[0.1, 0.9]])
+    peer_payload, _ = pack_routed_payload(peer_hidden, peer_ids, peer_weights)
+    backend._device_communicator.peer_payload = peer_payload
+
+    dispatched, scale, metadata, dispatch_ids, dispatch_weights = backend.prepare(
+        hidden,
+        topk_weights,
+        topk_ids,
+        num_experts=4,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        quant_config=None,
+    )
+
+    assert scale is None
+    assert metadata.expert_num_tokens is None
+    assert torch.equal(dispatched, torch.cat((hidden, peer_hidden)))
+    assert torch.equal(dispatch_ids, torch.cat((topk_ids, peer_ids)))
+    assert torch.equal(dispatch_weights, torch.cat((topk_weights, peer_weights)))
+    assert backend._device_communicator.all_gatherv_calls == [(0, [2, 1])]
+    assert backend._pynccl.all_gather_calls == []
+
+    output = backend.finalize(
+        None,
+        dispatched,
+        topk_weights,
+        topk_ids,
+        apply_router_weight_on_input=False,
+    )
+    assert torch.equal(output, hidden * 2)
+    assert backend._device_communicator.reduce_scatterv_calls == [(0, [2, 1])]
+
+
+def test_variable_gather_rejects_inconsistent_local_token_count(monkeypatch):
+    backend = _make_backend()
+    backend._use_static_decode_path = lambda: False
+
+    import atom.model_ops.fused_moe.rccl_prepare_finalize as rccl_module
+
+    monkeypatch.setattr(
+        rccl_module,
+        "get_forward_context",
+        lambda: SimpleNamespace(
+            context=SimpleNamespace(dp_uniform_decode=False),
+            dp_metadata=SimpleNamespace(get_sizes_across_dp=lambda: [1, 1]),
+        ),
+    )
+    with pytest.raises(ValueError, match="token count disagrees"):
+        backend._variable_gather_sizes(torch.empty((2, 4)))
+
+
+def test_static_decode_preserves_topk_ids_for_aiter_expert_mask():
+    backend = _make_backend()
+    hidden = torch.tensor([[1.0, 2.0]])
+    topk_ids = torch.tensor([[0, 2]], dtype=torch.int32)
+    topk_weights = torch.tensor([[0.6, 0.4]])
+
+    _, _, _, dispatch_ids, dispatch_weights = backend.prepare(
+        hidden,
+        topk_weights,
+        topk_ids,
+        num_experts=4,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        quant_config=None,
+    )
+
+    assert torch.equal(dispatch_ids, topk_ids.repeat(2, 1))
+    assert torch.equal(dispatch_weights, topk_weights.repeat(2, 1))
+
+
+def test_gathered_rows_round_robin_replicated_shared_expert_owners():
+    backend = _make_backend(
+        num_local_experts=3,
+        num_replicated_shared_experts=1,
+    )
+    hidden = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    # Rank zero initially pins its shared column to dispatch slot 2. The fake
+    # gather repeats that source payload, after which rows 1 and 3 must move to
+    # rank one's replica at slot 5.
+    topk_ids = torch.tensor([[0, 3, 2], [1, 4, 2]], dtype=torch.int32)
+    topk_weights = torch.tensor([[0.6, 0.4, 1.0], [0.25, 0.75, 1.0]])
+
+    _, _, _, dispatch_ids, _ = backend.prepare(
+        hidden,
+        topk_weights,
+        topk_ids,
+        num_experts=6,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        quant_config=None,
+    )
+
+    assert dispatch_ids[:, -1].tolist() == [2, 5, 2, 5]

--- a/tests/model_ops/test_rccl_routed_alltoall.py
+++ b/tests/model_ops/test_rccl_routed_alltoall.py
@@ -1,0 +1,204 @@
+import pytest
+import torch
+
+from atom.model_ops.fused_moe.routed_all2all import (
+    build_routed_dispatch_plan,
+    combine_routed_rows,
+    pack_routed_payload,
+    unpack_routed_payload,
+)
+
+
+def test_dispatch_plan_is_destination_major_and_deduplicates_rank():
+    hidden = torch.tensor([[10.0, 11.0], [20.0, 21.0], [30.0, 31.0]])
+    topk_ids = torch.tensor(
+        [
+            [0, 1, 4],
+            [2, 3, -1],
+            [5, 0, -1],
+        ],
+        dtype=torch.int32,
+    )
+    topk_weights = torch.tensor(
+        [
+            [0.5, 0.3, 0.2],
+            [0.6, 0.4, 0.0],
+            [0.8, 0.2, 0.0],
+        ]
+    )
+
+    plan = build_routed_dispatch_plan(
+        hidden,
+        topk_ids,
+        topk_weights,
+        num_local_experts=2,
+        world_size=3,
+    )
+
+    assert plan.send_counts.tolist() == [2, 1, 2]
+    assert plan.token_indices.tolist() == [0, 2, 1, 0, 2]
+    assert plan.hidden_states.tolist() == [
+        [10.0, 11.0],
+        [30.0, 31.0],
+        [20.0, 21.0],
+        [10.0, 11.0],
+        [30.0, 31.0],
+    ]
+    assert plan.topk_ids.tolist() == [
+        [0, 1, 4],
+        [5, 0, 0],
+        [2, 3, 0],
+        [0, 1, 4],
+        [5, 0, 0],
+    ]
+    assert torch.allclose(
+        plan.topk_weights,
+        torch.tensor(
+            [
+                [0.5, 0.3, 0.2],
+                [0.8, 0.2, 0.0],
+                [0.6, 0.4, 0.0],
+                [0.5, 0.3, 0.2],
+                [0.8, 0.2, 0.0],
+            ]
+        ),
+    )
+
+
+def test_dispatch_plan_handles_no_valid_routes():
+    plan = build_routed_dispatch_plan(
+        torch.empty((2, 4)),
+        torch.full((2, 3), -1, dtype=torch.int32),
+        torch.zeros((2, 3)),
+        num_local_experts=2,
+        world_size=4,
+    )
+
+    assert plan.send_counts.tolist() == [0, 0, 0, 0]
+    assert plan.token_indices.numel() == 0
+    assert plan.hidden_states.shape == (0, 4)
+    assert plan.topk_ids.shape == (0, 3)
+
+
+def test_dispatch_plan_rejects_expert_outside_physical_space():
+    with pytest.raises(ValueError, match="outside dispatch space"):
+        build_routed_dispatch_plan(
+            torch.ones((1, 4)),
+            torch.tensor([[6]], dtype=torch.int32),
+            torch.ones((1, 1)),
+            num_local_experts=2,
+            world_size=3,
+        )
+
+
+def test_dispatch_plan_rejects_non_integer_expert_ids():
+    with pytest.raises(ValueError, match="topk_ids must be int32 or int64"):
+        build_routed_dispatch_plan(
+            torch.ones((1, 4)),
+            torch.tensor([[1.0]]),
+            torch.ones((1, 1)),
+            num_local_experts=2,
+            world_size=2,
+        )
+
+
+def test_combine_routed_rows_restores_source_order_and_sums_destinations():
+    returned = torch.tensor([[1.0], [2.0], [3.0], [4.0], [5.0]])
+    token_indices = torch.tensor([0, 2, 1, 0, 2])
+
+    combined = combine_routed_rows(returned, token_indices, num_tokens=3)
+
+    assert combined.tolist() == [[5.0], [3.0], [7.0]]
+
+
+def test_combine_routed_rows_reuses_output_buffer():
+    returned = torch.tensor([[2.0, 3.0], [5.0, 7.0]])
+    token_indices = torch.tensor([1, 1])
+    output = torch.full((2, 2), 99.0)
+
+    combined = combine_routed_rows(returned, token_indices, 2, output)
+
+    assert combined.data_ptr() == output.data_ptr()
+    assert combined.tolist() == [[0.0, 0.0], [7.0, 10.0]]
+
+
+def test_mixed_dtype_payload_round_trip():
+    # Odd BF16 width forces padding before the int32 metadata segment and
+    # catches row-stride alignment bugs in dtype views.
+    hidden = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.bfloat16)
+    topk_ids = torch.tensor([[1, -1], [2, 3]], dtype=torch.int32)
+    topk_weights = torch.tensor([[0.75, 0.0], [0.6, 0.4]], dtype=torch.float32)
+
+    payload, layout = pack_routed_payload(hidden, topk_ids, topk_weights)
+    restored_hidden, restored_ids, restored_weights = unpack_routed_payload(
+        payload, layout
+    )
+
+    assert payload.dtype == torch.uint8
+    assert torch.equal(restored_hidden, hidden)
+    assert torch.equal(restored_ids, topk_ids)
+    assert torch.equal(restored_weights, topk_weights)
+
+
+def test_two_rank_dispatch_compute_and_reverse_combine():
+    hidden_by_rank = [
+        torch.tensor([[1.0], [2.0]]),
+        torch.tensor([[3.0]]),
+    ]
+    ids_by_rank = [
+        torch.tensor([[0, 2], [1, 3]], dtype=torch.int32),
+        torch.tensor([[0, 3]], dtype=torch.int32),
+    ]
+    weights_by_rank = [
+        torch.tensor([[0.5, 0.5], [0.25, 0.75]]),
+        torch.tensor([[0.25, 0.75]]),
+    ]
+    plans = [
+        build_routed_dispatch_plan(
+            hidden,
+            ids,
+            weights,
+            num_local_experts=2,
+            world_size=2,
+        )
+        for hidden, ids, weights in zip(
+            hidden_by_rank, ids_by_rank, weights_by_rank, strict=True
+        )
+    ]
+
+    # Simulate all-to-all: every destination concatenates source-major chunks.
+    computed_by_destination: list[list[torch.Tensor]] = [[], []]
+    for destination in range(2):
+        lo, hi = destination * 2, (destination + 1) * 2
+        for plan in plans:
+            offsets = torch.cat(
+                (torch.zeros(1, dtype=torch.int64), plan.send_counts.cumsum(0))
+            )
+            start, end = int(offsets[destination]), int(offsets[destination + 1])
+            hidden = plan.hidden_states[start:end]
+            ids = plan.topk_ids[start:end]
+            weights = plan.topk_weights[start:end]
+            owned = (ids >= lo) & (ids < hi)
+            factors = torch.where(owned, ids + 1, torch.zeros_like(ids)).to(
+                weights.dtype
+            )
+            computed_by_destination[destination].append(
+                hidden * (weights * factors).sum(dim=1, keepdim=True)
+            )
+
+    # The reverse all-to-all restores destination-major order on each source.
+    outputs = []
+    for source, plan in enumerate(plans):
+        returned = torch.cat(
+            [computed_by_destination[dest][source] for dest in range(2)]
+        )
+        outputs.append(
+            combine_routed_rows(
+                returned,
+                plan.token_indices,
+                num_tokens=hidden_by_rank[source].shape[0],
+            )
+        )
+
+    assert torch.allclose(outputs[0], torch.tensor([[2.0], [7.0]]))
+    assert torch.allclose(outputs[1], torch.tensor([[9.75]]))

--- a/tests/model_ops/test_shared_expert_dispatch.py
+++ b/tests/model_ops/test_shared_expert_dispatch.py
@@ -88,8 +88,8 @@ def test_select_experts_keeps_shared_out_of_router_and_eplb(monkeypatch):
         moe_module, "is_rocm_aiter_fuse_routed_scaling_factor", lambda: True
     )
     # Pins the ordering router -> EPLB -> shared, not the kernel arithmetic.
-    layer.to_dispatch_space = lambda weights, ids: (
-        FusedMoE.to_dispatch_space(layer, weights, ids)
+    layer.to_dispatch_space = lambda weights, ids: FusedMoE.to_dispatch_space(
+        layer, weights, ids
     )
 
     weights, ids = FusedMoEMethodBase.select_experts_with_record(
@@ -145,7 +145,9 @@ def test_eplb_appends_unscaled_shared_weight(monkeypatch):
     assert captured["scale"] == 2.0
 
 
-def _parallel_config(*, dp_size: int, use_ep: bool) -> FusedMoEParallelConfig:
+def _parallel_config(
+    *, dp_size: int, use_ep: bool, backend: str = "auto"
+) -> FusedMoEParallelConfig:
     return FusedMoEParallelConfig(
         tp_size=8,
         dp_size=dp_size,
@@ -155,31 +157,45 @@ def _parallel_config(*, dp_size: int, use_ep: bool) -> FusedMoEParallelConfig:
         ep_rank=0,
         use_ep=use_ep,
         local_ep_size=8,
+        requested_all2all_backend=backend,
     )
 
 
 @pytest.mark.parametrize(
-    "dp_size, use_ep, has_mori, expected",
+    "dp_size, use_ep, has_mori, disable_mori, backend, expected_backend",
     [
         # EP without DP still runs the legacy AITER fusion: no all2all backend,
         # so there is no dispatch space to fold the shared expert into.
-        (1, True, True, False),
-        (8, True, True, True),
-        (8, False, True, False),
-        (8, True, False, False),
+        (1, True, True, False, "auto", None),
+        (8, True, True, False, "auto", "mori"),
+        (8, False, True, False, "auto", None),
+        (8, True, False, False, "auto", None),
+        (8, True, True, True, "auto", None),
+        # The native backend is explicit and does not depend on MoRI import or
+        # ATOM_DISABLE_MORI_EP, whose scope remains MoRI only.
+        (8, True, False, True, "rccl", "rccl"),
+        (8, True, True, False, "none", None),
     ],
 )
 def test_ep_alone_does_not_imply_all2all(
-    monkeypatch, dp_size, use_ep, has_mori, expected
+    monkeypatch,
+    dp_size,
+    use_ep,
+    has_mori,
+    disable_mori,
+    backend,
+    expected_backend,
 ):
     monkeypatch.setattr(moe_module, "_has_module", lambda name: has_mori)
+    monkeypatch.setattr(moe_module.envs, "ATOM_DISABLE_MORI_EP", disable_mori)
 
-    config = _parallel_config(dp_size=dp_size, use_ep=use_ep)
+    config = _parallel_config(dp_size=dp_size, use_ep=use_ep, backend=backend)
 
-    assert config.use_all2all_kernels is expected
+    assert config.selected_all2all_backend == expected_backend
+    assert config.use_all2all_kernels is (expected_backend is not None)
 
 
-def _atom_config(*, eplb: bool) -> SimpleNamespace:
+def _atom_config(*, eplb: bool, backend: str = "auto") -> SimpleNamespace:
     """The four fields this gate reads, over the real Config's defaults.
 
     Hand-built, this went red the day `is_rocm_aiter_fusion_shared_expert_
@@ -193,6 +209,7 @@ def _atom_config(*, eplb: bool) -> SimpleNamespace:
         parallel_config=SimpleNamespace(data_parallel_size=8),
         moe_ep_flatten_tp_across_dp=False,
         eplb_enable=eplb,
+        moe_all2all_backend=backend,
         # The branch under test is the MoRI + DP-attention one -- "only MoRI
         # needs the switch", says the code -- so the scenario has to say so.
         # Left at Config's default of False, the early return is unreachable
@@ -212,6 +229,7 @@ def _atom_config(*, eplb: bool) -> SimpleNamespace:
 )
 def test_eplb_overrides_the_local_replica_switch(monkeypatch, eplb, switch, expected):
     monkeypatch.setattr(topK_module.envs, "ATOM_FUSE_SHARED_EXPERT", switch)
+    monkeypatch.setattr(topK_module.envs, "ATOM_DISABLE_MORI_EP", False)
     # Stated, not inherited: the gate asks whether MoRI is importable, so
     # without this the truth table below holds only on a box that has it.
     monkeypatch.setattr(topK_module, "_has_module", lambda name: True)
@@ -224,3 +242,16 @@ def test_eplb_overrides_the_local_replica_switch(monkeypatch, eplb, switch, expe
     enabled = is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(None)
 
     assert enabled is expected
+
+
+def test_rccl_backend_does_not_take_mori_shared_expert_gate(monkeypatch):
+    monkeypatch.setattr(topK_module.envs, "ATOM_FUSE_SHARED_EXPERT", False)
+    monkeypatch.setattr(topK_module.envs, "ATOM_DISABLE_MORI_EP", False)
+    monkeypatch.setattr(topK_module, "_has_module", lambda name: True)
+    monkeypatch.setattr(
+        topK_module,
+        "get_current_atom_config",
+        lambda: _atom_config(eplb=False, backend="rccl"),
+    )
+
+    assert is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(None)

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -132,6 +132,36 @@ class TestMoEBackendCli:
         assert args._get_engine_kwargs()["moe_backend"] == "mega"
 
 
+class TestMoEAll2AllBackendCli:
+    def _parse(self, argv):
+        parser = argparse.ArgumentParser()
+        EngineArgs.add_cli_args(parser)
+        return EngineArgs.from_cli_args(parser.parse_args(argv))
+
+    def test_default_preserves_auto_mori_detection(self):
+        kwargs = self._parse([])._get_engine_kwargs()
+
+        assert kwargs["moe_all2all_backend"] == "auto"
+        assert kwargs["enable_low_latency"] is False
+
+    def test_rccl_selects_native_backend(self):
+        kwargs = self._parse(["--all2all-backend", "rccl"])._get_engine_kwargs()
+
+        assert kwargs["moe_all2all_backend"] == "rccl"
+        assert kwargs["enable_low_latency"] is False
+
+    def test_low_latency_still_selects_mori(self):
+        kwargs = self._parse(["--all2all-backend", "low-latency"])._get_engine_kwargs()
+
+        assert kwargs["moe_all2all_backend"] == "mori"
+        assert kwargs["enable_low_latency"] is True
+
+    def test_none_forces_collective_fallback(self):
+        kwargs = self._parse(["--all2all-backend", "none"])._get_engine_kwargs()
+
+        assert kwargs["moe_all2all_backend"] == "none"
+
+
 class TestEngineArgsSpeculativeValidation:
     """Regression tests for speculative-config construction in _get_engine_kwargs."""
 

--- a/tests/test_dp_sync_layout.py
+++ b/tests/test_dp_sync_layout.py
@@ -112,7 +112,7 @@ def test_the_prefill_flag_still_reads_as_a_flag_after_the_batch_row(monkeypatch)
 
 
 def test_the_tbo_rows_survive_the_batch_being_folded_in(monkeypatch):
-    """TBO's four fields shifted down with everything else.
+    """TBO's four fields follow the batch, mode, and dummy rows.
 
     `can_split` AND-reduces and `meets_min_tokens` OR-reduces, so reading each
     other's row inverts the gate. Pinned with the two disagreeing.
@@ -133,7 +133,7 @@ def test_the_tbo_rows_survive_the_batch_being_folded_in(monkeypatch):
     # One rank that cannot split vetoes the whole group.
     vetoed = _sync(
         monkeypatch,
-        peers=[_with(4, 0)],
+        peers=[_with(5, 0)],
         **_base(
             tbo_on=True,
             local_meets_min_tokens=True,
@@ -153,7 +153,7 @@ def test_the_dspark_block_starts_after_the_tbo_block_in_both_widths(monkeypatch)
     shifted offset reads one of the head's fields and reports it.
     """
     for tbo_on in (False, True):
-        head = 7 if tbo_on else 3
+        head = 8 if tbo_on else 4
         r = _sync(
             monkeypatch,
             peers=[_with(head, 9)],

--- a/tests/test_eplb_dp_activity_sync.py
+++ b/tests/test_eplb_dp_activity_sync.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+
+import pytest
+from import_guard import skip_if_dependency_missing
+
+torch = pytest.importorskip("torch")
+
+try:
+    from atom.utils.tbo.ubatching import sync_dp_metadata
+except ImportError as _e:
+    skip_if_dependency_missing(_e, "requires full atom import env")
+
+
+def _mock_all_gather(monkeypatch, rows):
+    def _all_gather(outputs, local, group=None):
+        _ = group
+        assert local.numel() == len(rows[0])
+        for output, row in zip(outputs, rows):
+            output.copy_(torch.tensor(row, dtype=torch.int32))
+
+    monkeypatch.setattr(torch.distributed, "all_gather", _all_gather)
+
+
+def test_dp_sync_distinguishes_real_decode_from_dummy(monkeypatch):
+    # [scheduled_tokens, scheduled_bs, is_prefill, is_dummy]
+    _mock_all_gather(
+        monkeypatch,
+        [
+            [10, 2, 1, 0],  # real prefill
+            [8, 4, 0, 0],  # real decode
+            [1, 1, 0, 1],  # synchronization-only dummy decode
+        ],
+    )
+
+    result = sync_dp_metadata(
+        dp_group=object(),
+        dp_size=3,
+        scheduled_tokens=10,
+        scheduled_bs=2,
+        is_prefill=True,
+        tbo_on=False,
+    )
+
+    assert result.num_tokens_across_dp.tolist() == [10, 8, 1]
+    assert result.max_bs_across_dp == 4
+    assert result.any_rank_has_prefill
+    assert result.any_rank_has_real_prefill
+    assert result.any_rank_has_decode
+
+
+def test_dp_sync_preserves_tbo_and_dspark_field_offsets(monkeypatch):
+    # Four base fields, four TBO fields, then max_seqlen_q.
+    _mock_all_gather(
+        monkeypatch,
+        [
+            [10, 3, 1, 0, 1, 1, 4, 6, 2],
+            [8, 5, 0, 1, 0, 0, 0, 0, 4],
+        ],
+    )
+
+    result = sync_dp_metadata(
+        dp_group=object(),
+        dp_size=2,
+        scheduled_tokens=10,
+        scheduled_bs=3,
+        is_prefill=True,
+        tbo_on=True,
+        local_meets_min_tokens=True,
+        local_can_split=True,
+        local_ub_tokens=(4, 6),
+        max_seqlen_q=2,
+    )
+
+    assert not result.tbo_collective_active
+    assert result.ub_max_tokens_across_dp is None
+    assert result.max_bs_across_dp == 5
+    assert result.max_seqlen_q_across_dp == 4
+    assert result.any_rank_has_real_prefill
+    assert not result.any_rank_has_decode

--- a/tests/test_eplb_module_a.py
+++ b/tests/test_eplb_module_a.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Tests for atom/model_ops/eplb.py (Module-A: ExpertLoadMonitor)
 
+import types
+
 import pytest
 from import_guard import skip_if_dependency_missing
 
@@ -137,10 +139,44 @@ def test_monitor_initialize_rejects_runtime_resize():
         monitor.initialize(num_layers=2, num_physical=2, device=torch.device("cpu"))
 
 
+def test_monitor_stop_recording_keeps_existing_window_but_disables_hot_path(
+    monkeypatch,
+):
+    monkeypatch.setattr(eplb, "get_tp_group", lambda: _FakeTPGroup(world_size=1))
+    monitor = eplb.ExpertLoadMonitor(enabled=True, window_size=2)
+    _init_monitor(monitor, num_layers=1, num_physical=2)
+    monitor.on_forward_start()
+    monitor.record(
+        layer_id=0,
+        topk_physical=torch.tensor([[0, 1]], dtype=torch.int32),
+        num_physical=2,
+    )
+    monitor.on_forward_end(is_dummy_run=False)
+
+    monitor.stop_recording()
+
+    assert monitor.enabled
+    assert not monitor.collecting
+    assert monitor.recording_flag.item() == 0
+    assert monitor.pass_count_buffer(layer_id=0, num_physical=2) is None
+    assert monitor.dump_global_physical_load()[0].tolist() == [1, 1]
+
+
 def test_count_physical_load_rejects_float_dtype():
     bad = torch.tensor([[0.0, 1.0]], dtype=torch.float32)
     with pytest.raises(AssertionError):
         eplb.count_physical_load(bad, num_physical=4)
+
+
+def test_mapping_skips_draft_layer_outside_target_metadata(monkeypatch):
+    """MTP draft layers keep their static EP map instead of indexing target EPLB."""
+    meta = types.SimpleNamespace(num_layers=2)
+    monkeypatch.setattr(eplb, "get_live_expert_location_metadata", lambda: meta)
+    layer = types.SimpleNamespace(layer_id=2)
+    topk = torch.tensor([[0, 1]], dtype=torch.int32)
+
+    assert eplb.eplb_map_logical_to_physical(layer, topk) is topk
+    assert eplb.eplb_map_and_record_fused(layer, topk) is topk
 
 
 def test_monitor_record_rejects_new_layer_after_initialization(monkeypatch):
@@ -160,6 +196,57 @@ def test_monitor_record_rejects_new_layer_after_initialization(monkeypatch):
             topk_physical=torch.tensor([[0, 1]], dtype=torch.int32),
             num_physical=2,
         )
+
+
+def test_decode_record_mask_excludes_cudagraph_padding(monkeypatch):
+    slot_mapping = torch.tensor([7, 8, 9, -1, -1], dtype=torch.int64)
+    context = types.SimpleNamespace(
+        is_prefill=False,
+        dp_uniform_decode=True,
+        scheduled_tokens=3,
+        running_tokens=5,
+    )
+    forward_context = types.SimpleNamespace(
+        context=context,
+        attn_metadata=types.SimpleNamespace(slot_mapping=slot_mapping),
+        eplb_token_mask=None,
+    )
+    import atom.utils.forward_context as forward_context_mod
+
+    monkeypatch.setattr(
+        forward_context_mod, "get_forward_context", lambda: forward_context
+    )
+
+    mask, safe_to_record = eplb._eplb_record_mask(
+        torch.zeros((5, 2), dtype=torch.int32)
+    )
+    assert safe_to_record
+    assert mask.tolist() == [True, True, True, False, False]
+
+
+def test_decode_record_mask_uses_gathered_dpa_mask(monkeypatch):
+    gathered_mask = torch.tensor([True, False, True, True])
+    forward_context = types.SimpleNamespace(
+        context=types.SimpleNamespace(
+            is_prefill=False,
+            dp_uniform_decode=True,
+            scheduled_tokens=1,
+            running_tokens=2,
+        ),
+        attn_metadata=types.SimpleNamespace(slot_mapping=None),
+        eplb_token_mask=gathered_mask,
+    )
+    import atom.utils.forward_context as forward_context_mod
+
+    monkeypatch.setattr(
+        forward_context_mod, "get_forward_context", lambda: forward_context
+    )
+
+    mask, safe_to_record = eplb._eplb_record_mask(
+        torch.zeros((4, 2), dtype=torch.int32)
+    )
+    assert safe_to_record
+    assert torch.equal(mask, gathered_mask)
 
 
 # NOTE: Module-B (EPLBManager scheduler) tests live in test_eplb_module_b.py.

--- a/tests/test_eplb_module_b.py
+++ b/tests/test_eplb_module_b.py
@@ -53,6 +53,17 @@ def _step(mgr):
     mgr.on_forward_pass_end(local_has_prefill=True, dp_any_has_prefill=True)
 
 
+def _decode_step(mgr):
+    """Advance a decode-aware manager with an already synchronized DP flag."""
+    mgr._dp_is_migration_group = True
+    mgr.on_forward_pass_end(
+        local_has_prefill=False,
+        dp_any_has_prefill=False,
+        local_has_decode=True,
+        dp_any_has_decode=True,
+    )
+
+
 def _spy_rebalance(mgr, fired):
     """Replace the runtime rebalance with a 0-yield spy that records each fire.
 
@@ -104,6 +115,109 @@ def test_manager_steps_with_dummy_and_triggers_by_interval(monkeypatch):
     _step(manager)  # 8th steady call -> fire
     assert fired == [1, 1]
     assert manager.rebalance_count == 2
+
+
+def test_first_rebalance_waits_for_full_load_window(monkeypatch):
+    monkeypatch.setattr(eplb, "get_tp_group", lambda: _FakeTPGroup(world_size=1))
+    monitor = eplb.ExpertLoadMonitor(enabled=True, window_size=4)
+    _record_single_pass(monitor, counts=[4, 0])
+    fired = []
+    manager = eplb.EPLBManager(
+        enabled=True,
+        monitor=monitor,
+        rebalance_interval=8,
+        rebalance_min_balancedness=0.8,
+        rebalance_balancedness_agg="min",
+    )
+    _spy_rebalance(manager, fired)
+
+    # interval/4 is only 2, but the placement must not be derived from less
+    # than the configured four-pass load window.
+    for _ in range(4):
+        _step(manager)
+    assert fired == []
+    _step(manager)
+    assert fired == [1]
+
+
+def test_decode_only_skew_is_recorded_and_triggers_rebalance(monkeypatch):
+    """Regression scenario for a saturated decode-only DPA worker.
+
+    Two hot experts start on rank 0's contiguous slots, so the measured rank
+    load is badly skewed. Decode mode must retain those samples, advance the
+    periodic scheduler without any prefill, and feed a placement whose maximum
+    per-rank work is lower than the initial layout.
+    """
+    monkeypatch.setattr(eplb, "get_tp_group", lambda: _FakeTPGroup(world_size=1))
+
+    monitor = eplb.ExpertLoadMonitor(enabled=True, window_size=2)
+    _init_monitor(monitor, num_layers=1, num_physical=4)
+    fired = []
+    manager = eplb.EPLBManager(
+        enabled=True,
+        monitor=monitor,
+        rebalance_interval=4,
+        rebalance_min_balancedness=0.8,
+        rebalance_balancedness_agg="min",
+        load_mode="decode",
+    )
+    manager.live_metadata = types.SimpleNamespace(ep_size=2)
+    _spy_rebalance(manager, fired)
+
+    for _ in range(3):
+        monitor.on_forward_start()
+        monitor.record(
+            layer_id=0,
+            topk_physical=torch.tensor(
+                [[0]] * 10 + [[1]] * 9 + [[2]], dtype=torch.int32
+            ),
+            num_physical=4,
+        )
+        monitor.on_forward_end(is_dummy_run=False, should_commit=True)
+        _decode_step(manager)
+
+    assert fired == [1]
+    assert manager.rebalance_count == 1
+    assert manager.last_balancedness == pytest.approx(10 / 19)
+
+    logical_load = monitor.dump_global_physical_load()
+    old_p2l = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    new_p2l, _, _ = eplb.rebalance_experts(
+        logical_load,
+        num_physical=4,
+        num_groups=1,
+        num_nodes=1,
+        num_gpus=2,
+        enable_hierarchical=False,
+        old_p2l=old_p2l,
+    )
+
+    def max_rank_load(p2l):
+        weights = logical_load[0, p2l[0].to(torch.int64)].view(2, 2).sum(dim=1)
+        return int(weights.max().item())
+
+    assert max_rank_load(new_p2l) < max_rank_load(old_p2l)
+
+
+def test_decode_mode_ignores_prefill_activity(monkeypatch):
+    monitor = eplb.ExpertLoadMonitor(enabled=True, window_size=1)
+    manager = eplb.EPLBManager(
+        enabled=True,
+        monitor=monitor,
+        rebalance_interval=1,
+        rebalance_min_balancedness=0.8,
+        rebalance_balancedness_agg="min",
+        load_mode="decode",
+    )
+    manager._dp_is_migration_group = True
+    manager.on_forward_pass_end(
+        local_has_prefill=True,
+        dp_any_has_prefill=True,
+        local_has_decode=False,
+        dp_any_has_decode=False,
+    )
+    # The warm-start generator has not advanced.
+    assert manager.rebalance_count == 0
 
 
 def test_manager_balancedness_gate_skips_when_balanced(monkeypatch):
@@ -180,6 +294,60 @@ def test_manager_interval_must_cover_window():
             rebalance_min_balancedness=0.8,
             rebalance_balancedness_agg="min",
         )
+
+
+def test_manager_rejects_unknown_load_mode():
+    monitor = eplb.ExpertLoadMonitor(enabled=True, window_size=1)
+    with pytest.raises(AssertionError, match="load_mode"):
+        eplb.EPLBManager(
+            enabled=True,
+            monitor=monitor,
+            rebalance_interval=1,
+            rebalance_min_balancedness=0.8,
+            rebalance_balancedness_agg="min",
+            load_mode="tokens-from-mars",
+        )
+
+
+def test_manager_rejects_negative_max_rebalances():
+    monitor = eplb.ExpertLoadMonitor(enabled=True, window_size=1)
+    with pytest.raises(AssertionError, match="max_rebalances"):
+        eplb.EPLBManager(
+            enabled=True,
+            monitor=monitor,
+            rebalance_interval=1,
+            rebalance_min_balancedness=0.8,
+            rebalance_balancedness_agg="min",
+            max_rebalances=-1,
+        )
+
+
+def test_manager_freezes_after_configured_rebalance_limit(monkeypatch):
+    monkeypatch.setattr(eplb, "get_tp_group", lambda: _FakeTPGroup(world_size=1))
+    monitor = eplb.ExpertLoadMonitor(enabled=True, window_size=1)
+    _record_single_pass(monitor, counts=[4, 0])
+    fired = []
+    manager = eplb.EPLBManager(
+        enabled=True,
+        monitor=monitor,
+        rebalance_interval=4,
+        rebalance_min_balancedness=0.8,
+        rebalance_balancedness_agg="min",
+        max_rebalances=1,
+    )
+    manager.live_metadata = types.SimpleNamespace(ep_size=2)
+    _spy_rebalance(manager, fired)
+
+    # The warm-start window fires once; later automatic steps stay frozen.
+    _step(manager)
+    _step(manager)
+    assert fired == [1]
+    for _ in range(20):
+        _step(manager)
+    assert fired == [1]
+    assert manager.rebalance_count == 1
+    assert manager.automatic_rebalancing_frozen
+    assert not monitor.collecting
 
 
 def test_manager_trigger_offline_rebalance(monkeypatch):


### PR DESCRIPTION
## Summary

- Add opt-in `--all2all-backend rccl` support for native RCCL routed MoE while preserving the existing automatic MoRI selection by default.
- Use a graph-safe packed AllGather/ReduceScatter path for uniform decode.
- Use variable-size AllGather/ReduceScatter for matching DP/EP prefill or mixed batches, with a routed all-to-all correctness path for other topologies.
- Balance replicated shared-expert rows across local shared-expert replicas.
- Extend EPLB with `load_mode={prefill,decode,all}` and `max_rebalances`.
- Exclude dummy/CUDAGraph padding work from EPLB load accounting and stop collecting statistics after EPLB freezes.
- Fold real prefill/decode activity into the existing packed DP metadata collective, avoiding an extra per-step collective.

The default transport behavior is unchanged:

- unspecified / auto: use MoRI when available
- high-throughput / low-latency: use the corresponding MoRI mode
- rccl: use the experimental native RCCL path
- none: use the existing AllGather/ReduceScatter fallback

## Testing

Current rebased HEAD (`origin/main` at `761b1486`):

- `git diff --check origin/main...HEAD`
- Black check on all modified Python files
- Ruff check on all modified Python files (`E402` ignored because `tests/test_arg_utils_spec.py` has an existing guarded-import layout)
- `python3 -m compileall -q atom/model_engine atom/model_ops atom/models/deepseek_v4.py atom/utils`
- Focused + DP shape/TBO/DSpark/EPLB regression suite: **125 passed, 7 skipped**

Earlier GPU validation on the pre-rebase equivalent patch:

- ROCm/AITER container suite: **78 passed**
- Focused RCCL/shared-expert suite: **28 passed**
- 2-rank and 8-rank RCCL smoke tests passed
- DeepSeek-V4 graph capture passed
- 3600-second AgentX c48/c64/c96/c128 runs passed

A full host `tests/` collection is not available in the current shell: it uses Python 3.10 while diffusion tests import `typing.Self`, and optional test dependencies (`uvicorn`, `triton`, `aiter`, and `sglang`) are not installed. The affected targeted suites above pass.

## Performance

Compared with the official ATOM DPA CI result on the same hardware ([run](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33376779864/job/99523227795)):

| Concurrency | Output tok/s/chip | P90 interactivity |
|---:|---:|---:|
| c48 | +4.30% | +9.13% |
| c64 | +5.75% | +14.05% |
| c96 | +8.21% | +1.99% |
| c128 | +4.92% | +2.55% |

This is a system-level comparison, not an isolated attribution: the official run is DPA + EP1, while the local run is DPA8 + EP8 + RCCL + EPLB with the existing session-affinity option enabled. Session affinity is already upstream and is not changed by this PR.

## Limitations

- The RCCL backend is experimental and opt-in.
- TBO is automatically disabled for the RCCL backend in this first synchronous implementation.
- Prefill/mixed traffic uses a correctness-first path and remains an optimization opportunity.
- The RCCL wire format does not yet use FP8/FP4 communication quantization.
