### PR TITLE
[feat] fix output for the text of a run with synthetic accept

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -15,6 +15,7 @@ Usage:
 import asyncio
 import base64
 import binascii
+import contextlib
 import io
 import json
 import logging
@@ -940,10 +941,8 @@ async def generate_async(
         #      forever). Streaming pops via cleanup_stream instead.
         if seq is not None:
             if not _finished_ok:
-                try:
+                with contextlib.suppress(Exception):
                     engine.core_mgr.abort_request(seq.id)
-                except Exception:
-                    pass
             engine.io_processor.requests.pop(seq.id, None)
 
     text = delivered_text(all_token_ids)
@@ -1047,10 +1046,8 @@ async def generate_async_multimodal(
         # See generate_async: abort on early exit, always pop to avoid leak.
         if seq is not None:
             if not _finished_ok:
-                try:
+                with contextlib.suppress(Exception):
                     engine.core_mgr.abort_request(seq.id)
-                except Exception:
-                    pass
             engine.io_processor.requests.pop(seq.id, None)
 
     text = delivered_text(all_token_ids)

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -105,6 +105,7 @@ from .serving_completion import (
 )
 from .sse import event_frame
 from .streaming_dispatch import (
+    SYNTHETIC_TOKEN_TEXT,
     FrameWait,
     StreamBatchDispatcher,
     StreamOutputCollector,
@@ -156,6 +157,25 @@ _stream_loops: dict[str, AbstractEventLoop] = {}
 _request_start_times: dict[str, float] = {}
 _request_logger: logging.Logger | None = None
 _stream_batch_dispatcher: StreamBatchDispatcher | None = None
+# `SYNTHETIC_TOKEN_TEXT` while a run's own text is meaningless, None otherwise.
+# One switch for both delivery modes: they decode in different places, and a
+# response that read differently depending on `stream` is the asymmetry the
+# reasoning and tool-call readers were unified to remove.
+synthetic_token_text: str | None = None
+
+
+def delivered_text(token_ids) -> str:
+    """The text a non-streaming response carries for these tokens.
+
+    Decoded even when the answer is thrown away: the runs that stand their text
+    in are measuring throughput, and skipping the work the measured server does
+    would flatter it. The streaming half of this lives in
+    `IncrementalStreamDetokenizer.update`.
+    """
+    decoded = tokenizer.decode(token_ids, skip_special_tokens=True)
+    if synthetic_token_text is None:
+        return decoded
+    return synthetic_token_text * len(token_ids)
 
 
 def reasoning_channel(
@@ -926,7 +946,7 @@ async def generate_async(
                     pass
             engine.io_processor.requests.pop(seq.id, None)
 
-    text = tokenizer.decode(all_token_ids, skip_special_tokens=True)
+    text = delivered_text(all_token_ids)
     num_tokens_input = (
         seq.num_prompt_tokens if seq is not None else len(tokenizer.encode(prompt))
     )
@@ -1033,7 +1053,7 @@ async def generate_async_multimodal(
                     pass
             engine.io_processor.requests.pop(seq.id, None)
 
-    text = tokenizer.decode(all_token_ids, skip_special_tokens=True)
+    text = delivered_text(all_token_ids)
     num_tokens_output = len(all_token_ids)
     finished_at = time.time()
     ttft = (first_token_at - started_at) if first_token_at is not None else 0.0
@@ -1177,7 +1197,7 @@ async def generate_async_fanout(
         )
         outputs.append(
             {
-                "text": tokenizer.decode(per_tokens[i], skip_special_tokens=True),
+                "text": delivered_text(per_tokens[i]),
                 "token_ids": per_tokens[i],
                 "finish_reason": per_finish_reason[i],
                 "num_tokens_input": num_tokens_input,
@@ -2458,7 +2478,7 @@ def main():
     """Main entry point for the server."""
     global engine, tokenizer, model_name, default_chat_template_kwargs, _request_logger
     global tool_call_parser_cls, model_starts_in_reasoning, reasoning_toggle
-    global reasoning_dialect
+    global reasoning_dialect, synthetic_token_text
     global custom_message_encoder, _stream_batch_dispatcher
 
     parser = FlexibleArgumentParser(description="ATOM OpenAI API Server")
@@ -2591,7 +2611,31 @@ def main():
     )
 
     engine = engine_args.create_engine(tokenizer=tokenizer)
-    _stream_batch_dispatcher = StreamBatchDispatcher(tokenizer)
+    # Forced acceptance emits draft tokens that nothing verified, and once the
+    # context is long enough those degenerate into the dialect's own channel
+    # framing and nothing else -- read as structure, correctly, that leaves a
+    # response with no content at all. The mode already announces that its text is
+    # meaningless, so stand in for it rather than parse it.
+    synthetic_token_text = (
+        SYNTHETIC_TOKEN_TEXT
+        if (
+            args.spec_decode_acceptance_length is not None
+            or args.spec_decode_acceptance_rate is not None
+        )
+        else None
+    )
+    if synthetic_token_text is not None:
+        logger.warning(
+            "Forced speculative acceptance is on, so every generated token is "
+            "delivered as %r instead of its decoded text. Token counts, timings "
+            "and throughput are unaffected; the text was already meaningless. "
+            "Unset --spec-decode-acceptance-length / --spec-decode-acceptance-rate "
+            "to read the model's own output again.",
+            SYNTHETIC_TOKEN_TEXT,
+        )
+    _stream_batch_dispatcher = StreamBatchDispatcher(
+        tokenizer, synthetic_text=synthetic_token_text
+    )
 
     # Wire the batched stream-flush hook: per-seq stream callbacks only buffer
     # their chunks into a thread-local; the engine core manager's output thread

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -36,6 +36,13 @@ _WAITING_SINCE: dict[int, float] = {}
 # merging this way hands them what reading each chunk separately would have.
 _LATEST_WINS = ("finish_reason", "kv_transfer_params", "num_cached_tokens")
 
+# Stands in for the decoded text of one token when the run has declared its own
+# output meaningless -- forced speculative acceptance, today. It says what it is,
+# so a dump of such a run cannot be mistaken for something the model wrote, and
+# it carries no marker any dialect or tool-call format intercepts, so it reaches
+# the client whatever the model is.
+SYNTHETIC_TOKEN_TEXT = "synthetic "
+
 
 @dataclass
 class IncrementalStreamDetokenizer:
@@ -48,8 +55,19 @@ class IncrementalStreamDetokenizer:
     tokens: array.array = field(default_factory=new_token_ids)
     prefix_offset: int = 0
     read_offset: int = 0
+    # Emitted once per token in place of the decoded text, for runs whose text
+    # is a byproduct rather than an answer. See `SYNTHETIC_TOKEN_TEXT`.
+    synthetic_text: str | None = None
 
     def update(self, token_ids: list[int], finished: bool) -> str:
+        decoded = self._decode(token_ids, finished)
+        if self.synthetic_text is None:
+            return decoded
+        # Decoded and thrown away: the run is measuring throughput, and skipping
+        # the work would make the server look faster than the one being measured.
+        return self.synthetic_text * len(token_ids)
+
+    def _decode(self, token_ids: list[int], finished: bool) -> str:
         self.tokens.extend(token_ids)
         prefix_text = self.tokenizer.decode(
             self.tokens[self.prefix_offset : self.read_offset],
@@ -230,13 +248,16 @@ class StreamBatchDispatcher:
     remember to remove.
     """
 
-    def __init__(self, tokenizer: Any):
+    def __init__(self, tokenizer: Any, synthetic_text: str | None = None):
         self.tokenizer = tokenizer
+        self.synthetic_text = synthetic_text
         self._thread_local = threading.local()
 
     def new_state(self) -> IncrementalStreamDetokenizer:
         """Make the detokenizer for one stream, for its callback to hold."""
-        return IncrementalStreamDetokenizer(self.tokenizer)
+        return IncrementalStreamDetokenizer(
+            self.tokenizer, synthetic_text=self.synthetic_text
+        )
 
     def enqueue(
         self,

--- a/tests/entrypoints/test_streaming_dispatch.py
+++ b/tests/entrypoints/test_streaming_dispatch.py
@@ -430,7 +430,11 @@ def test_dispatcher_keeps_no_per_stream_state():
         )
     dispatcher.flush()
 
-    assert vars(dispatcher).keys() == {"tokenizer", "_thread_local"}
+    assert vars(dispatcher).keys() == {
+        "tokenizer",
+        "synthetic_text",
+        "_thread_local",
+    }
 
 
 def test_each_stream_gets_its_own_detokenizer():


### PR DESCRIPTION
Alternative to [#2107](https://github.com/ROCm/ATOM/pull/2107), which fixes the same failure by dropping the resolved dialect while forced acceptance is on. This one leaves the readers alone. Only one should land.

## Fix

Nothing here is wrong except what is being parsed, so this does not touch the parsing. The mode already announces at startup that "output text and accuracy are meaningless" — the text is a byproduct of a throughput measurement, not something anyone reads.

While it is on, every token is delivered as the literal `"synthetic "` and every reader downstream is left exactly as it is. The stand-in says what it is, so a dump of such a run cannot be mistaken for something the model wrote, and it carries no marker any dialect or tool-call format intercepts, so it survives whatever the model is — unlike the model's own output, which survives only the readers that do not understand it.

