### PR TITLE
[DCP][Opt] Fuse the prefill context reorg, dequant and kv_b_proj into one kernel, and take the custom AllGather

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -1303,18 +1303,40 @@ class MLAAttention(nn.Module):
                 shuffled_kv_cache=True,
             )
         else:
-            gather_kv_b_proj(
-                kv_cache,
-                self._k_scale,
-                kv_indptr,
-                kv_indices,
-                cu_seqlens_k,
-                _maybe_view_mxfp4_weight_for_gather(self.kv_b_proj, weight),
-                getattr(self.kv_b_proj, "weight_scale", None),
-                k_out,
-                v_out,
-                weight_preshuffle=getattr(weight, "is_shuffled", False),
+            self._kv_b_proj_gather(
+                kv_cache, kv_indptr, kv_indices, cu_seqlens_k, k_out, v_out
             )
+
+    def _kv_b_proj_gather(
+        self,
+        kv_buffer: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        k_out: torch.Tensor,
+        v_out: torch.Tensor,
+    ) -> None:
+        """Gather compressed KV rows and decompress them into k/v, in one pass.
+
+        One kernel for the whole chain: row gather, KV-cache dequant,
+        ``kv_b_proj``, the k_nope/v split and the k_pe concat. ``kv_buffer`` is
+        any ``[rows, block, kv_lora_rank + qk_rope_head_dim]`` compressed-KV
+        tensor -- the paged cache for the non-DCP path, the AllGather block for
+        DCP -- and ``kv_indices`` selects rows out of it.
+        """
+        weight = self.kv_b_proj.weight
+        gather_kv_b_proj(
+            kv_buffer,
+            self._k_scale,
+            kv_indptr,
+            kv_indices,
+            cu_seqlens_k,
+            _maybe_view_mxfp4_weight_for_gather(self.kv_b_proj, weight),
+            getattr(self.kv_b_proj, "weight_scale", None),
+            k_out,
+            v_out,
+            weight_preshuffle=getattr(weight, "is_shuffled", False),
+        )
 
     def _forward_prefill_cached_chunked(
         self,
@@ -1489,39 +1511,38 @@ class MLAAttention(nn.Module):
         """DCP chunked cached-prefix context attention.
 
         Per chunk: index_select this rank's local compressed KV, AllGather it
-        across the DCP group, ``reorg_kvcache`` back to per-sequence contiguous
-        layout, ``kv_b_proj``-decompress, run flash_attn(causal=False), and
-        LSE-merge across chunks. The context attention is unmasked, so the
-        rank-major token order produced by reorg does not affect the result.
+        across the DCP group, then one fused pass turns the rank-major
+        AllGather block into the k/v the attention kernel wants, run
+        flash_attn(causal=False), and LSE-merge across chunks. The context
+        attention is unmasked, so the rank-major token order within a sequence
+        does not affect the result.
+
+        Everything between the collective and the attention is a single kernel:
+        the reorg back to per-sequence order is the fused gather's index map, so
+        the fp8 dequant, the reorg copies, the ``kv_b_proj`` decompress and the
+        k_pe concat all ride along with it instead of costing a kernel (and, for
+        the reorg, a per-layer Python walk over every (seq, rank) segment) each.
         """
         from atom.model_ops.attentions.triton_merge_attn_states import merge_attn_states
-        from atom.model_ops.dcp_ops import dcp_gather_compressed_kv, reorg_kvcache
-
-        is_fp8_kv = self.kv_cache_dtype.startswith("fp8")
+        from atom.model_ops.dcp_ops import dcp_all_gather, dcp_gather_compressed_kv
 
         chunked_out: torch.Tensor | None = None
         chunked_lse: torch.Tensor | None = None
         for c in range(chunk_meta.num_chunks):
-            toks = chunk_meta.seq_tot[c]
-            if toks == 0:
+            if chunk_meta.seq_tot[c] == 0:
+                # No local tokens on any rank here. Rank-invariant (the padded
+                # local length is), so every rank skips the collective together.
                 continue
             # 1. gather this rank's local compressed KV for the chunk (keeps the
             #    cache dtype, so fp8 stays fp8 here).
             local_kv = dcp_gather_compressed_kv(kv_cache, chunk_meta.local_slot_ids[c])
-            # 2. AllGather across DCP ranks -> [toks * dcp_world_size, d]. This is
+            # 2. AllGather across DCP ranks -> [seq_tot * dcp_world_size, d]. It is
             #    a copy-only collective, so an fp8 payload is safe (no fp8
-            #    arithmetic, unlike an all-reduce).
-            ag_kv = self.dcp_group.all_gather(local_kv, dim=0)
-            if is_fp8_kv:
-                # Dequant the fp8 compressed KV -> model dtype before reorg /
-                # kv_b_proj (which expect a bf16 latent). dequant = stored *
-                # scale mirrors the write-side quant (value / scale); _k_scale
-                # is 1.0 for MLA today. AllGather-then-dequant keeps the wire
-                # payload at fp8 (half the bf16 traffic). Tensor arithmetic (not
-                # float()/.item()): _k_scale may be a GPU tensor and a host sync
-                # is illegal under cudagraph capture; a 0-dim scale broadcasts on
-                # device with no sync.
-                ag_kv = ag_kv.to(self.dtype) * self._k_scale
+            #    arithmetic, unlike an all-reduce) and keeps the wire at half the
+            #    bf16 traffic. fp8 has no entry in the custom collective's dtype
+            #    enum, so dcp_all_gather pairs the bytes into fp16 rather than
+            #    give the gather up to pynccl.
+            ag_kv = dcp_all_gather(self.dcp_group, local_kv, 0)
 
             sum_seq_len = chunk_meta.total_tokens[c]
             if sum_seq_len == 0:
@@ -1529,37 +1550,23 @@ class MLAAttention(nn.Module):
                 # chunk); collective already ran, just skip the compute.
                 continue
 
-            # 3. reorg interleaved AllGather blocks -> per-seq contiguous.
-            ag_kv_c, ag_k_pe = ag_kv.unsqueeze(1).split(
-                [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
-            )
-            kv_c_normed, k_pe = reorg_kvcache(
-                ag_kv_c,
-                ag_k_pe,
-                padded_local_chunk_seq_lens_lst=chunk_meta.padded_local_chunk_seq_lens[
-                    c
-                ],
-                local_context_lens_allranks=chunk_meta.local_context_lens_allranks,
-                sum_seq_len=sum_seq_len,
-                max_seq_len=chunk_meta.max_seqlen_k[c],
-                chunk_size=chunk_meta.chunk_size,
-                chunk_idx=c,
-                toks=toks,
+            # 3. reorg + dequant + kv_b_proj + k_pe concat, fused. block_size 1
+            #    on the AllGather buffer makes the row map a plain token index.
+            k_chunk, v_chunk = self._dcp_context_kv_buffers(chunk_meta, sum_seq_len)
+            self._kv_b_proj_gather(
+                ag_kv.unsqueeze(1),
+                chunk_meta.cu_seqlens_k[c],
+                chunk_meta.ag_row_indices[c],
+                chunk_meta.cu_seqlens_k[c],
+                k_chunk,
+                v_chunk,
             )
 
-            # 4. kv_b_proj decompress -> k_nope, v; concat k_pe -> k.
-            kv_c_normed = kv_c_normed.squeeze(1)
-            kv_nope = self.kv_b_proj(kv_c_normed).view(
-                -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
-            )
-            k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
-            k = torch.cat((k_nope, k_pe.expand((*k_nope.shape[:-1], -1))), dim=-1)
-
-            # 5. flash attention over the (unmasked) context chunk.
+            # 4. flash attention over the (unmasked) context chunk.
             ctx_out, ctx_lse = flash_attn_varlen_func(
                 q=prefill_q,
-                k=k,
-                v=v,
+                k=k_chunk,
+                v=v_chunk,
                 cu_seqlens_q=attn_metadata.cu_seqlens_q[
                     : chunk_meta.cu_seqlens_k[c].shape[0]
                 ],
@@ -1573,7 +1580,7 @@ class MLAAttention(nn.Module):
                 return_lse=True,
             )
 
-            # 6. LSE-merge across chunks.
+            # 5. LSE-merge across chunks.
             if chunked_out is None:
                 chunked_out = ctx_out
                 chunked_lse = ctx_lse
@@ -1592,6 +1599,27 @@ class MLAAttention(nn.Module):
                 chunked_lse = tmp_lse
 
         return chunked_out, chunked_lse
+
+    def _dcp_context_kv_buffers(
+        self, chunk_meta, sum_seq_len: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Destination k/v for one DCP context chunk's fused gather.
+
+        Prefers the shared chunk workspace, which is sized to
+        ``attn_prefill_chunk_size`` tokens. DCP chunks the cached prefix per
+        sequence and its window must stay block-aligned, so a step carrying more
+        cached-prefix sequences than the token budget can divide into
+        block-sized windows produces a chunk wider than that; allocate for those
+        rather than write past the workspace.
+        """
+        k_workspace = chunk_meta.k_workspace
+        if k_workspace is not None and sum_seq_len <= k_workspace.shape[0]:
+            return k_workspace[:sum_seq_len], chunk_meta.v_workspace[:sum_seq_len]
+        kwargs = {"dtype": self.dtype, "device": self.kv_b_proj.weight.device}
+        return (
+            torch.empty((sum_seq_len, self.num_heads, self.qk_head_dim), **kwargs),
+            torch.empty((sum_seq_len, self.num_heads, self.v_head_dim), **kwargs),
+        )
 
     def _forward_prefill_mha(
         self,

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -144,24 +144,22 @@ class MLAChunkContextMetadata:
     # --- DCP (Decode Context Parallel) prefill fields ---
     # Present only when dcp_world_size > 1. The cached context KV is sharded
     # (interleaved) across DCP ranks, so per chunk each rank gathers its local
-    # compressed KV via `local_slot_ids`, AllGathers, and `reorg_kvcache`
+    # compressed KV via `local_slot_ids`, AllGathers, and `ag_row_indices`
     # rebuilds the per-sequence contiguous layout. `cu_seqlens_k` above then
     # holds the GLOBAL per-seq chunk lengths (post-reorg) for flash attention.
     is_dcp: bool = False
     # Per chunk: absolute slot ids of this rank's local cached tokens, laid out
-    # per-seq contiguous and padded to `padded_local_chunk_seq_lens` (so every
-    # rank's AllGather block has identical `seq_tot` tokens).
+    # per-seq contiguous and padded so every rank's AllGather block has
+    # identical `seq_tot` tokens.
     local_slot_ids: list[torch.Tensor] | None = None
-    # Per chunk: per-seq padded local chunk length (list[list[int]]).
-    padded_local_chunk_seq_lens: list[list[int]] | None = None
-    # Per seq: real local context length on each rank (list[list[int]]), shared
-    # across chunks; used by reorg to drop padding.
-    local_context_lens_allranks: list[list[int]] | None = None
-    # Per chunk: number of local tokens per rank in the AllGather block (== sum
-    # of that chunk's padded_local_chunk_seq_lens).
+    # Per chunk: the reorg as a row map into the `[seq_tot * dcp, d]` AllGather
+    # buffer, per-seq contiguous and rank-major within a seq (length ==
+    # `total_tokens[c]`). Doubles as the fused gather's `kv_indices`, which is
+    # what lets the reorg, dequant, kv_b_proj and k_pe concat collapse into one
+    # kernel -- see `dcp_reorg_row_indices`.
+    ag_row_indices: list[torch.Tensor] | None = None
+    # Per chunk: number of local tokens per rank in the AllGather block.
     seq_tot: list[int] | None = None
-    # Local padded max context chunk size (local tokens per seq per chunk).
-    chunk_size: int | None = None
 
 
 def cdiv(a, b):
@@ -1523,23 +1521,26 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         `(g // (S*W)) * S + g % S` (S = cp_kv_cache_interleave_size; S=1 = the
         original round-robin `g % W` / `g // W`). This builder produces, per
         chunk, the metadata to (1) index_select this rank's local cached tokens,
-        (2) AllGather them, and (3) `reorg_kvcache` them into per-sequence
-        contiguous layout. `reorg_kvcache` needs only the per-rank *counts*
-        (from `get_dcp_local_seq_lens(..., S)`), not S-aware ordering: the cached
+        (2) AllGather them, and (3) reorg them into per-sequence contiguous
+        layout. The reorg needs only the per-rank *counts* (from
+        `get_dcp_local_seq_lens(..., S)`), not S-aware ordering: the cached
         context is fully visible (no causal mask) so attention is permutation-
-        invariant over it, and RoPE travels with each key — the existing S=1
-        reorg already emits a non-global order and is correct, so any S is too.
+        invariant over it, and RoPE travels with each key — the S=1 reorg
+        already emits a non-global order and is correct, so any S is too.
 
         Chunking is per-seq (plugin-style, not the global-axis chunking of the
         non-DCP builder): each chunk covers a `chunk_size`-token local window
-        [c*chunk_size, (c+1)*chunk_size) of every sequence, so `reorg_kvcache`
-        (which assumes a uniform per-rank block) can rebuild the layout.
+        [c*chunk_size, (c+1)*chunk_size) of every sequence, which is what makes
+        every rank's AllGather block the same size.
 
         Local token `p` of a sequence maps to physical slot
         `block_table[p // block_size] * block_size + (p % block_size)` — the
         same contiguous local packing used by the Phase-1 slot_mapping writes.
         """
-        from atom.model_ops.dcp_ops import get_dcp_local_seq_lens
+        from atom.model_ops.dcp_ops import (
+            dcp_reorg_row_indices,
+            get_dcp_local_seq_lens,
+        )
 
         dcp = self.dcp_world_size
         bsz = self.model_runner.block_size
@@ -1551,8 +1552,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             return None
         num_with_context = int((cached_lens > 0).sum())
 
-        # Real local context length per (seq, rank). Shared across chunks;
-        # reorg uses it to drop the per-seq padding.
+        # Real local context length per (seq, rank). Shared across chunks; the
+        # reorg row map uses it to drop the per-seq padding.
         s_itl = self.cp_kv_cache_interleave_size
         local_lens_allranks = np.stack(
             [get_dcp_local_seq_lens(cached_lens, dcp, r, s_itl) for r in range(dcp)],
@@ -1581,9 +1582,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         block_tables = batch.block_tables
 
         local_slot_ids_list: list[torch.Tensor] = []
+        ag_row_indices_list: list[torch.Tensor] = []
         cu_seqlens_k_list: list[torch.Tensor] = []
         total_tokens_list: list[int] = []
-        padded_local_chunk_seq_lens_list: list[list[int]] = []
         seq_tot_list: list[int] = []
         max_seqlen_k_list: list[int] = []
 
@@ -1607,8 +1608,10 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             cu_seqlens_k_list.append(upload_numpy(cu, self.device))
             total_tokens_list.append(int(cu[-1]))
             max_seqlen_k_list.append(int(global_chunk_len.max(initial=0)))
-            padded_local_chunk_seq_lens_list.append(plc.astype(np.int32).tolist())
             seq_tot_list.append(int(plc.sum()))
+            ag_row_indices_list.append(
+                upload_numpy(dcp_reorg_row_indices(plc, real_local_chunk), self.device)
+            )
 
             # This rank's local slot ids for the chunk, per-seq padded to plc[i].
             slot_segments: list[np.ndarray] = []
@@ -1638,10 +1641,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             v_workspace=self.v_chunk_workspace,
             is_dcp=True,
             local_slot_ids=local_slot_ids_list,
-            padded_local_chunk_seq_lens=padded_local_chunk_seq_lens_list,
-            local_context_lens_allranks=local_lens_allranks.tolist(),
+            ag_row_indices=ag_row_indices_list,
             seq_tot=seq_tot_list,
-            chunk_size=int(chunk_size),
         )
 
     def _apply_pcp_reindex(

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -600,6 +600,56 @@ def dcp_gather_compressed_kv(
     return gathered.reshape(slot_ids.shape[0], -1)
 
 
+def dcp_reorg_row_indices(
+    padded_local_chunk_seq_lens: np.ndarray,
+    real_local_chunk_lens: np.ndarray,
+) -> np.ndarray:
+    """The reorg of an AllGathered compressed-KV chunk, as a row map.
+
+    Same reordering ``reorg_kvcache`` performs by slicing and concatenating,
+    expressed as ``dst_row -> src_row`` so a kernel can apply it in one gather.
+    ``reorg_kvcache`` walks the (seq, rank) segments in Python on every layer;
+    this walks them once per step in the metadata builder, and the gather then
+    rides along with the ``kv_b_proj`` decompress instead of costing two
+    ``cat``s of its own.
+
+    Args:
+        padded_local_chunk_seq_lens: [bs] per-seq padded local chunk length.
+            Uniform across ranks, so it also gives each rank's AllGather block
+            size (``toks = sum``) and each seq's offset inside a block.
+        real_local_chunk_lens: [bs, dcp] per-(seq, rank) REAL local chunk
+            length. Where it falls short of the padded length is exactly the
+            padding this map drops.
+
+    Returns:
+        int32 [``real_local_chunk_lens.sum()``] rows into the
+        ``[toks * dcp, d]`` AllGather buffer, per-seq contiguous and rank-major
+        within a seq -- the layout ``cu_seqlens_k`` describes.
+    """
+    padded = np.asarray(padded_local_chunk_seq_lens, dtype=np.int64).reshape(-1)
+    lens = np.asarray(real_local_chunk_lens, dtype=np.int64)
+    bs, dcp = lens.shape
+    assert padded.shape[0] == bs, (padded.shape, lens.shape)
+
+    toks = int(padded.sum())
+    seq_base = np.zeros(bs, dtype=np.int64)
+    np.cumsum(padded[:-1], out=seq_base[1:])
+    # Rank r's block starts at r * toks, and seq i sits at the same offset
+    # inside every block because the padded length is rank-invariant.
+    starts = (
+        seq_base[:, None] + np.arange(dcp, dtype=np.int64)[None, :] * toks
+    ).reshape(-1)
+
+    lens = lens.reshape(-1)  # (seq, rank) row-major == reorg's walk order
+    seg_base = np.zeros(lens.shape[0], dtype=np.int64)
+    np.cumsum(lens[:-1], out=seg_base[1:])
+    # Row `seg_base[s] + j` of the output is row `starts[s] + j` of the input,
+    # so a single arange carries the per-segment offset j.
+    total = int(lens.sum())
+    rows = np.repeat(starts - seg_base, lens) + np.arange(total, dtype=np.int64)
+    return rows.astype(np.int32)
+
+
 def reorg_kvcache(
     allgatered_kv_c_normed: torch.Tensor,
     allgatered_k_pe: torch.Tensor,


### PR DESCRIPTION
## Summary

The DCP cached-prefix prefill spends a lot of its budget between the AllGather and `flash_attn_varlen_func`: `reorg_kvcache` walks every (seq, rank) segment in Python **on every layer**, then the fp8 dequant, the `kv_b_proj` decompress and the k_pe concat each cost their own kernel. This collapses that whole span into a single kernel pass and moves the gather off pynccl.

Two changes:

1. **The reorg becomes an index map, and rides along with `kv_b_proj`.** The reorg is a pure permutation, so it can be precomputed as `dst_row -> src_row` instead of executed as slicing and concatenation. `dcp_reorg_row_indices` builds it with cumsum/repeat, and the metadata builder publishes one per chunk as `ag_row_indices`. That map then doubles as `kv_indices` for the existing `gather_kv_b_proj`, so the row gather, KV-cache dequant, `kv_b_proj`, the k_nope/v split and the k_pe concat all happen in one kernel. Viewing the AllGather buffer as a `block_size=1` cache is what lets the existing kernel take it unchanged — no aiter change needed.

2. **The gather goes through `dcp_all_gather`** rather than `GroupCoordinator.all_gather`, which prefers aiter's custom collective. fp8 has no entry in the custom kernel's dtype enum, so the helper pairs the bytes into fp16 instead of falling back to pynccl.

Three now-dead fields (`padded_local_chunk_seq_lens`, `local_context_lens_allranks`, `chunk_size`) drop off `MLAChunkContextMetadata`. The vLLM plugin path is untouched: it has its own `AiterMlaChunkedContextMetadataForVllm` and keeps calling `reorg_kvcache`, which stays.

## Results

Before:
<img width="548" height="462" alt="image" src="https://github.com/user-attachments/assets/59998df5-5ae2-4f82-b98f-3bbfe05fe5f4" />

After:
<img width="1272" height="412" alt="image" src="https://github.com/user-attachments/assets/3820cb0d-d0f4-4920-a980-7fb4e3c46312" />


Kimi-K3, 8xMI355, tp8 + dcp8, fp8 KV cache, `comm_backend=ag_rs`.

| | before | after |
|---|---|---|
| gsm8k, full 1319 @ 64 concurrency | — | **0.9621** strict / 0.9621 flexible |
| TTFT, 44k cached prefix, conc=1 | 271.9 ms | **254.2 ms** (-6.5%) |
| TTFT, 44k cached prefix, conc=4 | 565.1 ms | **525.8 ms** (-7.0%) |
| segment GPU compute (profiled window) | ~58 ms | **18.3 ms** |
| segment host-side ops | 36.8 ms | **5.3 ms** |
| kernel launches (profiled window) | 165715 | **164286** |

The per-layer Python walk and its 864 `cat` calls in the window are gone entirely.


