### PR TITLE
feat(dsv4): add AITer communication-fused MoE

### DIFF
--- a/atom/model_ops/fused_moe/comm_fused_moe.py
+++ b/atom/model_ops/fused_moe/comm_fused_moe.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: MIT
+"""Optional communication-fused backend for :class:`FusedMoE`."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from collections.abc import Callable
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+import torch
+from aiter import ActivationType, QuantType, dtypes
+from aiter.dist.parallel_state import get_tp_group
+from aiter.jit.utils.chip_info import get_gfx_runtime
+from aiter.ops.flydsl.moe_common import GateMode
+
+from atom.config import get_current_atom_config
+from atom.utils import envs
+from atom.utils.custom_register import direct_register_custom_op
+
+if TYPE_CHECKING:
+    from atom.model_ops.moe import FusedMoE
+
+
+def _load_backend() -> tuple[ModuleType, ModuleType] | None:
+    try:
+        host = importlib.import_module("aiter.ops.flydsl.comm_fused_moe_host")
+        runtime = importlib.import_module("aiter.ops.comm_fused_moe_runtime")
+    except (ImportError, OSError):
+        return None
+
+    if not all(
+        hasattr(host, name)
+        for name in ("ShapeKey", "winners_for", "create_flydsl_comm_fused_runners")
+    ) or not hasattr(runtime, "CommFusedMoeRuntime"):
+        return None
+    return host, runtime
+
+
+def create_comm_fused_moe_backend(
+    *,
+    layer_quant_config: Any,
+    online_quant: bool,
+    parallel_config: Any,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    activation: ActivationType,
+    apply_router_weight_on_input: bool,
+) -> CommFusedMoeBackend | None:
+    """Return a configured backend when this FusedMoE layout is supported."""
+    config = get_current_atom_config()
+    if (
+        config.moe_backend != "standard"
+        or online_quant
+        or layer_quant_config is None
+        or layer_quant_config.quant_dtype != dtypes.fp4x2
+        or layer_quant_config.quant_type != QuantType.per_1x32
+        or config.torch_dtype != torch.bfloat16
+        or activation != ActivationType.Silu
+        or not envs.ATOM_MOE_GU_ITLV
+        or apply_router_weight_on_input
+        or os.getenv("AITER_DISABLE_COMM_FUSED_MOE") == "1"
+        or config.enable_tbo
+        or config.enable_rapidserve
+        or config.fake_eplb
+        or config.enable_expert_parallel
+        or parallel_config.dp_size != 1
+        or parallel_config.use_ep
+        or config.prefill_context_parallel_size != 1
+        or parallel_config.tp_size == 1
+    ):
+        return None
+
+    modules = _load_backend()
+    if modules is None:
+        return None
+    host, runtime = modules
+    try:
+        winners = host.winners_for(
+            host.ShapeKey(
+                get_gfx_runtime(),
+                model_dim,
+                inter_dim,
+                experts,
+                topk,
+                parallel_config.tp_size,
+            )
+        )
+    except KeyError:
+        return None
+    return CommFusedMoeBackend(host, runtime) if winners else None
+
+
+class CommFusedMoeBackend:
+    """Communication-fused execution plugged into an ordinary FusedMoE."""
+
+    def __init__(self, host: ModuleType, runtime: ModuleType) -> None:
+        self.host = host
+        self.runtime_module = runtime
+        self.runtime = None
+
+    def initialize(self, layer: FusedMoE) -> None:
+        # Importing here avoids a cycle while atom.model_ops.moe defines FusedMoE.
+        from atom.model_ops.moe import Mxfp4MoEMethod
+
+        method = layer.quant_method
+        if not isinstance(method, Mxfp4MoEMethod):
+            raise TypeError("Communication-fused MoE requires MXFP4 weights")
+        tp_size = int(get_tp_group().world_size)
+        if (
+            tp_size == 1
+            or layer.dp_size != 1
+            or layer.use_ep
+            or layer.tp_size != tp_size
+        ):
+            raise ValueError(
+                "Communication-fused MoE requires an unflattened TP-only layout: "
+                f"tp_group={tp_size}, moe_tp={layer.tp_size}, "
+                f"dp={layer.dp_size}, use_ep={layer.use_ep}"
+            )
+
+        method.use_triton = False
+        method.use_triton_decode = False
+        self.runtime = self.runtime_module.CommFusedMoeRuntime(
+            runners=self.host.create_flydsl_comm_fused_runners(
+                tp_group=get_tp_group(),
+                model_dim=layer.hidden_size,
+                inter_dim=layer.intermediate_size_per_partition,
+                experts=layer.global_num_experts,
+                topk=layer.top_k,
+            )
+        )
+
+    def supports(self, tokens: int) -> bool:
+        return self.runtime is not None and self.runtime.supports(tokens)
+
+    def forward(
+        self,
+        layer: FusedMoE,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        shared_partial: torch.Tensor | None,
+        before_stage2: Callable[[], torch.Tensor] | None = None,
+        stage2_stream: torch.cuda.Stream | None = None,
+    ) -> torch.Tensor:
+        if before_stage2 is not None:
+            return self.forward_impl(
+                layer,
+                hidden_states,
+                router_logits,
+                shared_partial,
+                before_stage2=before_stage2,
+                stage2_stream=stage2_stream,
+            )
+        if shared_partial is None:
+            raise ValueError("Communication-fused MoE requires a shared partial")
+        return torch.ops.aiter.comm_fused_moe_forward(
+            hidden_states,
+            router_logits,
+            shared_partial,
+            layer.layer_name,
+        )
+
+    def forward_impl(
+        self,
+        layer: FusedMoE,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        shared_partial: torch.Tensor | None,
+        before_stage2: Callable[[], torch.Tensor] | None = None,
+        stage2_stream: torch.cuda.Stream | None = None,
+    ) -> torch.Tensor:
+        method = layer.quant_method
+        topk_weights, topk_ids = method.select_experts_with_record(
+            layer=layer,
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+            use_grouped_topk=layer.use_grouped_topk,
+            top_k=layer.top_k,
+            renormalize=layer.renormalize,
+            topk_group=layer.topk_group,
+            num_expert_group=layer.num_expert_group,
+            global_num_experts=layer.global_num_experts,
+            custom_routing_function=layer.custom_routing_function,
+            scoring_func=layer.scoring_func,
+            e_score_correction_bias=layer.e_score_correction_bias,
+            fused_shared_experts_scoring_func=layer.shared_expert_scoring_func,
+        )
+        return self.runtime.run(
+            hidden_states=hidden_states,
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            topk_weight=topk_weights,
+            topk_ids=topk_ids,
+            expert_mask=layer.expert_mask,
+            activation=layer.activation,
+            quant_type=method.quant_type,
+            doweight_stage1=layer.apply_router_weight_on_input,
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            a1_scale=layer.w13_input_scale,
+            a2_scale=layer.w2_input_scale,
+            hidden_pad=method.hidden_pad,
+            intermediate_pad=method.intermediate_pad,
+            bias1=layer.w13_bias,
+            bias2=layer.w2_bias,
+            swiglu_limit=float(layer.swiglu_limit),
+            gate_mode=(
+                GateMode.INTERLEAVE.value
+                if method.is_guinterleave
+                else GateMode.SEPARATED.value
+            ),
+            shared_partial=shared_partial,
+            before_stage2=before_stage2,
+            stage2_stream=stage2_stream,
+        )
+
+
+def comm_fused_moe_forward(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    shared_partial: torch.Tensor,
+    layer_name: str,
+) -> torch.Tensor:
+    layer = get_current_atom_config().compilation_config.static_forward_context[
+        layer_name
+    ]
+    return layer._comm_fused_moe.forward_impl(
+        layer, hidden_states, router_logits, shared_partial
+    )
+
+
+def _comm_fused_moe_forward_fake(
+    hidden_states: torch.Tensor,
+    router_logits: torch.Tensor,
+    shared_partial: torch.Tensor,
+    layer_name: str,
+) -> torch.Tensor:
+    return torch.empty_like(hidden_states)
+
+
+direct_register_custom_op(
+    op_name="comm_fused_moe_forward",
+    op_func=comm_fused_moe_forward,
+    mutates_args=[],
+    fake_impl=_comm_fused_moe_forward_fake,
+    tags=(torch.Tag.needs_fixed_stride_order,),
+)
+
+
+__all__ = ["CommFusedMoeBackend", "create_comm_fused_moe_backend"]

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -2733,6 +2733,7 @@ class FusedMoE(torch.nn.Module):
         config: PretrainedConfig | None = None,
         shared_expert_prefix: str | None = None,
         pad_align: int | None = None,
+        enable_comm_fused: bool = False,
     ):
         super().__init__()
         self.layer_id = layer_id
@@ -2760,10 +2761,28 @@ class FusedMoE(torch.nn.Module):
         self.moe_parallel_config = FusedMoEParallelConfig.make(
             tp_size, dp_size, atom_config
         )
+        self._comm_fused_moe = None
+        if enable_comm_fused:
+            from atom.model_ops.fused_moe.comm_fused_moe import (
+                create_comm_fused_moe_backend,
+            )
+
+            self._comm_fused_moe = create_comm_fused_moe_backend(
+                layer_quant_config=layer_quant_config,
+                online_quant=quant_config is not None and quant_config.online_quant,
+                parallel_config=self.moe_parallel_config,
+                model_dim=hidden_size,
+                inter_dim=intermediate_size // self.tp_size,
+                experts=num_experts,
+                topk=top_k,
+                activation=activation,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+            )
         if shared_expert_prefix is None and prefix.endswith(".experts"):
             shared_expert_prefix = prefix[: -len(".experts")] + ".shared_experts"
         fuse_shared_experts = (
-            is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
+            self._comm_fused_moe is None
+            and is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
                 quant_config,
                 shared_expert_prefix=shared_expert_prefix,
                 routed_expert_prefix=prefix,
@@ -3085,6 +3104,8 @@ class FusedMoE(torch.nn.Module):
     def process_weights_after_loading(self):
         self._online_quant()
         self._validate_moe_backend()
+        if self._comm_fused_moe is not None:
+            self._comm_fused_moe.initialize(self)
 
     def _validate_moe_backend(self) -> None:
         if get_current_atom_config().moe_backend != "mega":
@@ -4319,6 +4340,33 @@ class FusedMoE(torch.nn.Module):
         return torch.ops.aiter.moe_forward(
             hidden_states, router_logits, self.layer_name
         )
+
+    def forward_maybe_comm_fused(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        shared_partial: torch.Tensor | None,
+        before_stage2: Callable[[], torch.Tensor] | None = None,
+        stage2_stream: torch.cuda.Stream | None = None,
+    ) -> tuple[torch.Tensor, bool]:
+        """Return ``(output, complete)`` after fused or ordinary dispatch.
+
+        A complete output already contains the shared expert and TP reduction.
+        """
+        backend = self._comm_fused_moe
+        if backend is not None and backend.supports(hidden_states.shape[0]):
+            return (
+                backend.forward(
+                    self,
+                    hidden_states,
+                    router_logits,
+                    shared_partial,
+                    before_stage2=before_stage2,
+                    stage2_stream=stage2_stream,
+                ),
+                True,
+            )
+        return self(hidden_states, router_logits), False
 
     def forward_impl_graph(
         self, hidden_states: torch.Tensor, router_logits: torch.Tensor

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -95,9 +95,6 @@ from atom.model_ops.quant_v4 import act_quant_inplace
 from atom.model_ops.sparse_attn_v4 import (
     hc_split_sinkhorn,
 )
-from atom.model_ops.topK import (
-    is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config,
-)
 from atom.model_ops.triton_hash_topk import hash_topk_triton
 from atom.model_ops.triton_rmsnorm_nw import rmsnorm_nw
 from atom.model_ops.utils import atom_parameter, shuffle_weights
@@ -3526,18 +3523,9 @@ class MoE(nn.Module):
             # attribute mutation across the compile boundary, so stashing on
             # `self.foo` from inside forward is a no-op at runtime.
         assert args.n_shared_experts == 1
-        self._fuse_shared_into_routed = (
-            is_rocm_aiter_fusion_shared_expert_enabled_for_quant_config(
-                qc,
-                shared_expert_prefix=f"{prefix}.shared_experts",
-                routed_expert_prefix=f"{prefix}.experts",
-            )
-        )
         moe_cfg = SimpleNamespace(
             routed_scaling_factor=self.routed_scaling_factor,
-            n_shared_experts=(
-                args.n_shared_experts if self._fuse_shared_into_routed else 0
-            ),
+            n_shared_experts=args.n_shared_experts,
         )
         self.experts = FusedMoE(
             num_experts=self.n_routed_experts,
@@ -3557,8 +3545,10 @@ class MoE(nn.Module):
             # inter=3072/TP8=384 is a 128-multiple; pad to 128 (not the 256
             # default) to avoid padding the MoE intermediate up to 512.
             pad_align=128,
+            enable_comm_fused=True,
         )
         self.experts.swiglu_limit = args.swiglu_limit
+        self._fuse_shared_into_routed = self.experts.num_fused_shared_experts > 0
 
         if not self._fuse_shared_into_routed:
             # self.experts.num_fused_shared_experts = 0
@@ -3588,13 +3578,15 @@ class MoE(nn.Module):
             and self.alt_stream is not None
             and envs.ATOM_DUAL_STREAM_MOE_TOKEN_THRESHOLD > 0
         )
+        # Keep comm-fused token-bucket dispatch dynamic under torch.compile.
+        self._use_comm_fused_dispatch = self.experts._comm_fused_moe is not None
         # Register self in static_forward_context so the custom op dispatcher
         # can look us up by `layer_name` (= self.prefix). Needed by
         # maybe_dual_stream_forward (dual-stream) AND moe_pcp_merge_forward
         # — the latter requires registration regardless of
         # dual-stream, so register whenever either consumer is active.
         _pcp_merge_on = get_pcp_world_size() > 1 and bool(envs.ATOM_PCP_MOE_MERGE)
-        if self._use_dual_stream or _pcp_merge_on:
+        if self._use_dual_stream or self._use_comm_fused_dispatch or _pcp_merge_on:
             get_current_atom_config().compilation_config.static_forward_context[
                 prefix
             ] = self
@@ -3668,8 +3660,12 @@ class MoE(nn.Module):
         return topk_weights, topk_ids
 
     def routed_expert_forward(
-        self, x: torch.Tensor  # [num_tokens, dim]
-    ) -> torch.Tensor:  # [num_tokens, dim]
+        self,
+        x: torch.Tensor,  # [num_tokens, dim]
+        shared_partial: torch.Tensor | None = None,
+        before_stage2=None,
+        stage2_stream: torch.cuda.Stream | None = None,
+    ) -> tuple[torch.Tensor, bool]:
         """Gate + FusedMoE routed-expert pass.
 
         For hash layers the gate's `tid2eid` lookup needs `input_ids`;
@@ -3678,7 +3674,13 @@ class MoE(nn.Module):
         `_hash_topk` (FusedMoE's custom_routing_function) reads it there.
         """
         router_logits = self.gate(x)  # [num_tokens, n_routed_experts]
-        return self.experts(hidden_states=x, router_logits=router_logits)
+        return self.experts.forward_maybe_comm_fused(
+            x,
+            router_logits,
+            shared_partial,
+            before_stage2=before_stage2,
+            stage2_stream=stage2_stream,
+        )
 
     @staticmethod
     def _gather_ids_for_dp(ids: torch.Tensor, ctx) -> torch.Tensor:
@@ -3736,9 +3738,13 @@ class MoE(nn.Module):
     ) -> torch.Tensor:  # [num_tokens, dim]
         """Sequential: shared_experts → routed_experts → combine."""
         shared = self.shared_experts(x) if self.shared_experts is not None else None
-        routed = self.routed_expert_forward(x)
+        routed, is_complete = self.routed_expert_forward(x, shared_partial=shared)
+        if is_complete:
+            return routed
         return self.combine_outputs(
-            routed, shared, prefix=f"{self.prefix}.combine_outputs"
+            routed,
+            shared,
+            prefix=f"{self.prefix}.combine_outputs",
         )
 
     def dual_stream_moe_forward(
@@ -3749,12 +3755,26 @@ class MoE(nn.Module):
         independent; main stream waits on alt_stream's completion before
         combining.
         """
-        current_stream = get_forward_context().main_stream
-        self.alt_stream.wait_stream(current_stream)
-        routed = self.routed_expert_forward(x)
+        routed_stream = torch.cuda.current_stream(x.device)
+        self.alt_stream.wait_stream(routed_stream)
+
+        def produce_shared():
+            with torch.cuda.stream(self.alt_stream):
+                shared = self.shared_experts.forward(x)
+            routed_stream.wait_stream(self.alt_stream)
+            shared.record_stream(routed_stream)
+            return shared
+
+        routed, is_complete = self.routed_expert_forward(
+            x,
+            before_stage2=produce_shared,
+            stage2_stream=routed_stream,
+        )
+        if is_complete:
+            return routed
         with torch.cuda.stream(self.alt_stream):
             shared = self.shared_experts.forward(x)
-        current_stream.wait_stream(self.alt_stream)
+        routed_stream.wait_stream(self.alt_stream)
         return self.combine_outputs(
             routed, shared, prefix=f"{self.prefix}.combine_outputs"
         )
@@ -3769,11 +3789,8 @@ class MoE(nn.Module):
         assert (
             x.dim() == 2 and x.shape[-1] == self.dim
         ), f"MoE expects 2D [num_tokens, {self.dim}], got {tuple(x.shape)}"
-        if self._use_dual_stream:
-            # Shared custom op (also used by V2). Dispatcher reads
-            # `_use_dual_stream` + per-call num_tokens vs threshold to pick
-            # dual vs single. Custom op = Dynamo barrier so stream context
-            # inside `dual_stream_moe_forward` is opaque to torch.compile.
+        if self._use_dual_stream or self._use_comm_fused_dispatch:
+            # Keep stream and comm-fused dispatch opaque to torch.compile.
             return torch.ops.aiter.maybe_dual_stream_forward(x, self.prefix)
         return self.single_stream_moe_forward(x)
 

--- a/tests/model_ops/test_comm_fused_moe.py
+++ b/tests/model_ops/test_comm_fused_moe.py
@@ -1,0 +1,658 @@
+# SPDX-License-Identifier: MIT
+"""CPU coverage for ATOM's communication-fused MoE integration.
+
+The TP8 numerical/kernel coverage lives in AITer's
+``op_tests/multigpu_tests/test_comm_fused_moe.py``. These tests exercise the
+real ATOM classes and only replace the unavailable AITER/Triton boundary, so
+the non-GPU CI catches API and DSV4 dispatch drift instead of passing against
+hand-written ATOM stand-ins.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import importlib.util
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import Enum
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from conftest import atom_config_double
+
+
+@dataclass(frozen=True)
+class _ShapeKey:
+    gfx: str
+    model_dim: int
+    inter_dim: int
+    experts: int
+    topk: int
+    tp_size: int
+
+
+class _ActivationType(Enum):
+    Silu = 0
+    Swiglu = 1
+    Situv2 = 2
+
+
+class _QuantType(Enum):
+    No = 0
+    per_Tensor = 1
+    per_Token = 2
+    per_1x128 = 3
+    per_1x32 = 4
+
+
+class _GateMode(Enum):
+    INTERLEAVE = "interleave"
+    SEPARATED = "separated"
+
+
+class _CommFusedMoeRuntime:
+    def __init__(self, *, runners) -> None:
+        self.runners = runners
+
+    def supports(self, tokens: int) -> bool:
+        return self.runners.supports(tokens)
+
+
+class _State:
+    def __init__(self) -> None:
+        self.config = atom_config_double(
+            enable_tbo=False,
+            enable_rapidserve=False,
+            fake_eplb=False,
+            enable_expert_parallel=False,
+            parallel_config=SimpleNamespace(data_parallel_size=1),
+            prefill_context_parallel_size=1,
+            torch_dtype=torch.bfloat16,
+        )
+        self.shape_keys = []
+        self.runner_calls = []
+        self.missing_shape = False
+
+
+def _identity_decorator(*_args, **_kwargs):
+    return lambda function: function
+
+
+def _external_module_attributes(name: str) -> dict[str, object]:
+    dtypes = SimpleNamespace(
+        bf16=torch.bfloat16,
+        fp32=torch.float32,
+        fp4x2=torch.uint8,
+        fp8=torch.float8_e4m3fnuz,
+        fp8_e8m0=torch.uint8,
+        i4x2=torch.uint8,
+        i8=torch.int8,
+        d_dtypes={},
+    )
+    return {
+        "aiter": {
+            "ActivationType": _ActivationType,
+            "QuantType": _QuantType,
+            "dtypes": dtypes,
+        },
+        "aiter.jit.utils.torch_guard": {
+            "torch_compile_guard": _identity_decorator,
+        },
+        "aiter.ops.flydsl.moe_common": {"GateMode": _GateMode},
+        "triton": {
+            "jit": lambda function: function,
+            "heuristics": _identity_decorator,
+        },
+        "triton.language": {"constexpr": object},
+    }.get(name, {})
+
+
+class _ExternalModuleLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module) -> None:
+        module.__file__ = f"<test stub for {module.__name__}>"
+        module.__path__ = []
+        module.__dict__.update(_external_module_attributes(module.__name__))
+
+        def resolve(attribute: str):
+            value = MagicMock(name=f"{module.__name__}.{attribute}")
+            setattr(module, attribute, value)
+            return value
+
+        module.__getattr__ = resolve
+
+
+class _ExternalModuleFinder(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname in {"aiter", "triton"} or fullname.startswith(
+            ("aiter.", "triton.")
+        ):
+            return importlib.util.spec_from_loader(
+                fullname, _ExternalModuleLoader(), is_package=True
+            )
+        return None
+
+
+@contextmanager
+def _stubbed_external_kernel_modules():
+    # Torch imports its own optional Triton integration lazily. Resolve that
+    # first so this test's deliberately small Triton stub cannot affect it.
+    importlib.import_module("torch._dynamo.config")
+
+    prefixes = ("aiter", "triton")
+    saved = {
+        name: module
+        for name, module in sys.modules.items()
+        if name in prefixes or name.startswith(("aiter.", "triton."))
+    }
+    for name in saved:
+        sys.modules.pop(name, None)
+
+    finder = _ExternalModuleFinder()
+    sys.meta_path.insert(0, finder)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
+        for name in list(sys.modules):
+            if name in prefixes or name.startswith(("aiter.", "triton.")):
+                sys.modules.pop(name, None)
+        sys.modules.update(saved)
+
+
+@pytest.fixture(scope="module")
+def atom_modules():
+    existing_atom_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "atom" or name.startswith("atom.")
+    }
+    with _stubbed_external_kernel_modules():
+        moe = importlib.import_module("atom.model_ops.moe")
+        comm = importlib.import_module("atom.model_ops.fused_moe.comm_fused_moe")
+        deepseek_v4 = importlib.import_module("atom.models.deepseek_v4")
+        host = importlib.import_module("aiter.ops.flydsl.comm_fused_moe_host")
+        runtime = importlib.import_module("aiter.ops.comm_fused_moe_runtime")
+        try:
+            yield SimpleNamespace(
+                moe=moe,
+                comm=comm,
+                deepseek_v4=deepseek_v4,
+                host=host,
+                runtime=runtime,
+            )
+        finally:
+            for name in list(sys.modules):
+                if (name == "atom" or name.startswith("atom.")) and (
+                    name not in existing_atom_modules
+                ):
+                    sys.modules.pop(name, None)
+            sys.modules.update(existing_atom_modules)
+
+
+@pytest.fixture
+def comm_fused_env(monkeypatch, atom_modules):
+    state = _State()
+    tp_group = SimpleNamespace(world_size=8)
+    monkeypatch.setenv("ATOM_MOE_GU_ITLV", "1")
+
+    def winners_for(shape):
+        state.shape_keys.append(shape)
+        if state.missing_shape:
+            raise KeyError(shape)
+        return ["winner"]
+
+    def create_flydsl_comm_fused_runners(**kwargs):
+        state.runner_calls.append(kwargs)
+        return SimpleNamespace(supports=lambda tokens: tokens == 32)
+
+    monkeypatch.setattr(
+        atom_modules.comm, "get_current_atom_config", lambda: state.config
+    )
+    monkeypatch.setattr(atom_modules.comm, "get_tp_group", lambda: tp_group)
+    monkeypatch.setattr(atom_modules.comm, "get_gfx_runtime", lambda: "gfx950")
+    monkeypatch.setattr(atom_modules.host, "ShapeKey", _ShapeKey, raising=False)
+    monkeypatch.setattr(atom_modules.host, "winners_for", winners_for, raising=False)
+    monkeypatch.setattr(
+        atom_modules.host,
+        "create_flydsl_comm_fused_runners",
+        create_flydsl_comm_fused_runners,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        atom_modules.runtime,
+        "CommFusedMoeRuntime",
+        _CommFusedMoeRuntime,
+        raising=False,
+    )
+    return atom_modules, state, tp_group
+
+
+def _create_backend(modules, state, **overrides):
+    arguments = {
+        "layer_quant_config": SimpleNamespace(
+            quant_dtype=modules.comm.dtypes.fp4x2,
+            quant_type=modules.comm.QuantType.per_1x32,
+        ),
+        "online_quant": False,
+        "parallel_config": SimpleNamespace(dp_size=1, use_ep=False, tp_size=8),
+        "model_dim": 7168,
+        "inter_dim": 384,
+        "experts": 384,
+        "topk": 6,
+        "activation": modules.comm.ActivationType.Silu,
+        "apply_router_weight_on_input": False,
+    }
+    arguments.update(overrides)
+    return modules.comm.create_comm_fused_moe_backend(**arguments)
+
+
+def _new_fused_moe(modules):
+    # FusedMoE is exposed through the repository's lazy plugin-mode decorator.
+    layer = object.__new__(modules.moe.FusedMoE.__mro__[1])
+    torch.nn.Module.__init__(layer)
+    return layer
+
+
+def test_registers_functional_custom_op(atom_modules):
+
+    schema = torch._C._dispatch_find_schema_or_throw(
+        "aiter::comm_fused_moe_forward", ""
+    ).schema()
+    assert all(argument.alias_info is None for argument in schema.arguments)
+
+
+@pytest.mark.parametrize(
+    "attribute, value",
+    [
+        ("moe_backend", "mega"),
+        ("online_quant", True),
+        ("quant_dtype", torch.bfloat16),
+        ("quant_type", _QuantType.per_Token),
+        ("torch_dtype", torch.float16),
+        ("activation", _ActivationType.Swiglu),
+        ("apply_router_weight_on_input", True),
+        ("enable_tbo", True),
+        ("enable_rapidserve", True),
+        ("fake_eplb", True),
+        ("enable_expert_parallel", True),
+        ("data_parallel_size", 2),
+        ("use_ep", True),
+        ("prefill_context_parallel_size", 2),
+        ("tp_size", 1),
+    ],
+)
+def test_support_predicate_rejects_unsupported_configuration(
+    comm_fused_env, attribute, value
+):
+    modules, state, _ = comm_fused_env
+    overrides = {}
+    if attribute == "data_parallel_size":
+        overrides["parallel_config"] = SimpleNamespace(
+            dp_size=value, use_ep=False, tp_size=8
+        )
+    elif attribute == "use_ep":
+        overrides["parallel_config"] = SimpleNamespace(
+            dp_size=1, use_ep=value, tp_size=8
+        )
+    elif attribute == "tp_size":
+        overrides["parallel_config"] = SimpleNamespace(
+            dp_size=1, use_ep=False, tp_size=value
+        )
+    elif attribute == "online_quant":
+        overrides[attribute] = value
+    elif attribute == "quant_dtype":
+        overrides["layer_quant_config"] = SimpleNamespace(
+            quant_dtype=value,
+            quant_type=modules.comm.QuantType.per_1x32,
+        )
+    elif attribute == "quant_type":
+        overrides["layer_quant_config"] = SimpleNamespace(
+            quant_dtype=modules.comm.dtypes.fp4x2,
+            quant_type=value,
+        )
+    elif attribute in {"activation", "apply_router_weight_on_input"}:
+        overrides[attribute] = value
+    else:
+        setattr(state.config, attribute, value)
+
+    assert _create_backend(modules, state, **overrides) is None
+    assert not state.shape_keys
+
+
+def test_support_predicate_honors_disable_flag(monkeypatch, comm_fused_env):
+    modules, state, _ = comm_fused_env
+    monkeypatch.setenv("AITER_DISABLE_COMM_FUSED_MOE", "1")
+
+    assert _create_backend(modules, state) is None
+    assert not state.shape_keys
+
+
+def test_support_predicate_requires_interleaved_gate_up(monkeypatch, comm_fused_env):
+    modules, state, _ = comm_fused_env
+    monkeypatch.setenv("ATOM_MOE_GU_ITLV", "0")
+
+    assert _create_backend(modules, state) is None
+    assert not state.shape_keys
+
+
+@pytest.mark.parametrize(
+    "missing_module",
+    [
+        "aiter.ops.flydsl.comm_fused_moe_host",
+        "aiter.ops.comm_fused_moe_runtime",
+    ],
+)
+def test_support_predicate_falls_back_when_aiter_backend_is_missing(
+    monkeypatch, comm_fused_env, missing_module
+):
+    modules, state, _ = comm_fused_env
+    import_module = modules.comm.importlib.import_module
+
+    def import_without_comm_fused_backend(name):
+        if name == missing_module:
+            raise ModuleNotFoundError(name)
+        return import_module(name)
+
+    monkeypatch.setattr(
+        modules.comm.importlib, "import_module", import_without_comm_fused_backend
+    )
+
+    assert _create_backend(modules, state) is None
+    assert not state.shape_keys
+
+
+def test_support_predicate_uses_runtime_shape_and_fails_closed(comm_fused_env):
+    modules, state, _ = comm_fused_env
+
+    assert _create_backend(modules, state) is not None
+    assert state.shape_keys == [_ShapeKey("gfx950", 7168, 384, 384, 6, 8)]
+
+    state.missing_shape = True
+    assert _create_backend(modules, state) is None
+
+
+def test_runner_wiring_uses_real_moe_types(comm_fused_env):
+    modules, state, tp_group = comm_fused_env
+    backend = _create_backend(modules, state)
+    layer = _new_fused_moe(modules)
+    layer.quant_method = object.__new__(modules.moe.Mxfp4MoEMethod)
+    layer.quant_method.use_triton = True
+    layer.quant_method.use_triton_decode = True
+    layer.moe_parallel_config = SimpleNamespace(
+        dp_size=1,
+        use_ep=False,
+        tp_size=8,
+    )
+    layer.hidden_size = 7168
+    layer.intermediate_size_per_partition = 384
+    layer.global_num_experts = 384
+    layer.top_k = 6
+
+    backend.initialize(layer)
+
+    assert not layer.quant_method.use_triton
+    assert not layer.quant_method.use_triton_decode
+    assert state.runner_calls == [
+        {
+            "tp_group": tp_group,
+            "model_dim": 7168,
+            "inter_dim": 384,
+            "experts": 384,
+            "topk": 6,
+        }
+    ]
+    assert backend.supports(32)
+    assert not backend.supports(31)
+
+
+def test_missing_runtime_falls_back(comm_fused_env):
+    modules, state, _ = comm_fused_env
+    backend = _create_backend(modules, state)
+
+    assert not backend.supports(32)
+
+
+def test_forward_impl_bridges_fused_moe_state_to_runtime(comm_fused_env):
+    modules, state, _ = comm_fused_env
+    backend = _create_backend(modules, state)
+    layer = _new_fused_moe(modules)
+
+    hidden_states, router_logits, topk_weights, topk_ids = (object() for _ in range(4))
+    shared_partial, stage2_stream, output = (object() for _ in range(3))
+    before_stage2 = MagicMock(name="before_stage2")
+
+    method = SimpleNamespace(
+        select_experts_with_record=MagicMock(return_value=(topk_weights, topk_ids)),
+        quant_type=object(),
+        hidden_pad=17,
+        intermediate_pad=19,
+        is_guinterleave=True,
+    )
+    runtime = SimpleNamespace(run=MagicMock(return_value=output))
+    layer_state = {
+        "quant_method": method,
+        "use_grouped_topk": False,
+        "top_k": 2,
+        "renormalize": True,
+        "topk_group": None,
+        "num_expert_group": None,
+        "global_num_experts": 16,
+        "scoring_func": "sqrtsoftplus",
+        "shared_expert_scoring_func": None,
+        "apply_router_weight_on_input": True,
+        "swiglu_limit": 7.0,
+    }
+    for name, value in layer_state.items():
+        setattr(layer, name, value)
+    opaque_attributes = (
+        "custom_routing_function e_score_correction_bias w13_weight w2_weight "
+        "expert_mask activation w13_weight_scale w2_weight_scale "
+        "w13_input_scale w2_input_scale w13_bias w2_bias"
+    )
+    for name in opaque_attributes.split():
+        setattr(layer, name, object())
+    backend.runtime = runtime
+
+    result = backend.forward_impl(
+        layer,
+        hidden_states,
+        router_logits,
+        shared_partial,
+        before_stage2=before_stage2,
+        stage2_stream=stage2_stream,
+    )
+
+    assert result is output
+    select_args = method.select_experts_with_record.call_args.kwargs
+    assert select_args["layer"] is layer
+    assert select_args["hidden_states"] is hidden_states
+    assert select_args["router_logits"] is router_logits
+    passthrough = {
+        "w1": "w13_weight",
+        "w2": "w2_weight",
+        "expert_mask": "expert_mask",
+        "activation": "activation",
+        "w1_scale": "w13_weight_scale",
+        "w2_scale": "w2_weight_scale",
+        "a1_scale": "w13_input_scale",
+        "a2_scale": "w2_input_scale",
+        "bias1": "w13_bias",
+        "bias2": "w2_bias",
+    }
+    expected_runtime_args = {
+        "hidden_states": hidden_states,
+        "topk_weight": topk_weights,
+        "topk_ids": topk_ids,
+        "quant_type": method.quant_type,
+        "doweight_stage1": True,
+        "hidden_pad": 17,
+        "intermediate_pad": 19,
+        "swiglu_limit": 7.0,
+        "gate_mode": _GateMode.INTERLEAVE.value,
+        "shared_partial": shared_partial,
+        "before_stage2": before_stage2,
+        "stage2_stream": stage2_stream,
+    }
+    expected_runtime_args.update(
+        {
+            argument: getattr(layer, attribute)
+            for argument, attribute in passthrough.items()
+        }
+    )
+    runtime.run.assert_called_once_with(**expected_runtime_args)
+
+
+@pytest.mark.parametrize("supported", [True, False])
+def test_fused_moe_dispatches_optional_backend(monkeypatch, atom_modules, supported):
+    layer = _new_fused_moe(atom_modules)
+    hidden_states = torch.randn(4, 8)
+    router_logits = torch.randn(4, 16)
+    shared_partial = torch.randn_like(hidden_states)
+    fused_output = torch.randn_like(hidden_states)
+    ordinary_output = torch.randn_like(hidden_states)
+    backend = SimpleNamespace(
+        supports=MagicMock(return_value=supported),
+        forward=MagicMock(return_value=fused_output),
+    )
+    layer._comm_fused_moe = backend
+    ordinary_forward = MagicMock(return_value=ordinary_output)
+    monkeypatch.setattr(type(layer), "forward", ordinary_forward)
+
+    output, is_complete = layer.forward_maybe_comm_fused(
+        hidden_states, router_logits, shared_partial
+    )
+
+    assert is_complete is supported
+    if supported:
+        assert output is fused_output
+        backend.forward.assert_called_once_with(
+            layer,
+            hidden_states,
+            router_logits,
+            shared_partial,
+            before_stage2=None,
+            stage2_stream=None,
+        )
+        ordinary_forward.assert_not_called()
+    else:
+        assert output is ordinary_output
+        backend.forward.assert_not_called()
+        ordinary_forward.assert_called_once()
+        call_args = ordinary_forward.call_args.args
+        assert call_args[0] is hidden_states
+        assert call_args[1] is router_logits
+
+
+@pytest.mark.parametrize("supported", [True, False])
+def test_dsv4_single_stream_dispatches_by_token_support(atom_modules, supported):
+    moe = atom_modules.deepseek_v4.MoE.__new__(atom_modules.deepseek_v4.MoE)
+    torch.nn.Module.__init__(moe)
+    hidden_states = torch.randn(4, 8)
+    router_logits = torch.randn(4, 16)
+    shared_partial = torch.randn_like(hidden_states)
+    fused_output = torch.randn_like(hidden_states)
+    routed_output = torch.randn_like(hidden_states)
+    combined_output = torch.randn_like(hidden_states)
+
+    moe.prefix = "model.layers.3.mlp"
+    moe.gate = MagicMock(return_value=router_logits)
+    moe.shared_experts = MagicMock(return_value=shared_partial)
+    moe.experts = MagicMock()
+    moe.experts.forward_maybe_comm_fused.return_value = (
+        fused_output if supported else routed_output,
+        supported,
+    )
+    moe.combine_outputs = MagicMock(return_value=combined_output)
+
+    result = atom_modules.deepseek_v4.MoE.single_stream_moe_forward(moe, hidden_states)
+
+    if supported:
+        assert result is fused_output
+        moe.combine_outputs.assert_not_called()
+    else:
+        assert result is combined_output
+        moe.combine_outputs.assert_called_once_with(
+            routed_output,
+            shared_partial,
+            prefix="model.layers.3.mlp.combine_outputs",
+        )
+    moe.experts.forward_maybe_comm_fused.assert_called_once_with(
+        hidden_states,
+        router_logits,
+        shared_partial,
+        before_stage2=None,
+        stage2_stream=None,
+    )
+
+
+def test_dsv4_forward_keeps_comm_fused_dispatch_opaque_without_dual_stream(
+    monkeypatch, atom_modules
+):
+    moe = atom_modules.deepseek_v4.MoE.__new__(atom_modules.deepseek_v4.MoE)
+    torch.nn.Module.__init__(moe)
+    hidden_states = torch.randn(4, 8)
+    output = torch.randn_like(hidden_states)
+    dispatch = MagicMock(return_value=output)
+
+    moe.dim = hidden_states.shape[1]
+    moe.prefix = "model.layers.3.mlp"
+    moe._use_dual_stream = False
+    moe._use_comm_fused_dispatch = True
+    moe.single_stream_moe_forward = MagicMock()
+    monkeypatch.setattr(
+        atom_modules.deepseek_v4.torch.ops.aiter,
+        "maybe_dual_stream_forward",
+        dispatch,
+    )
+
+    result = atom_modules.deepseek_v4.MoE.forward(moe, hidden_states)
+
+    assert result is output
+    dispatch.assert_called_once_with(hidden_states, moe.prefix)
+    moe.single_stream_moe_forward.assert_not_called()
+
+
+def test_dsv4_ordinary_dual_stream_fallback_waits_on_routed_stream(
+    monkeypatch, atom_modules
+):
+    moe = atom_modules.deepseek_v4.MoE.__new__(atom_modules.deepseek_v4.MoE)
+    torch.nn.Module.__init__(moe)
+    hidden_states = torch.randn(4, 8)
+    routed = torch.randn_like(hidden_states)
+    shared = torch.randn_like(hidden_states)
+    output = torch.randn_like(hidden_states)
+    routed_stream = MagicMock(name="routed_stream")
+    alt_stream = MagicMock(name="alt_stream")
+
+    moe.prefix = "model.layers.3.mlp"
+    moe.alt_stream = alt_stream
+    moe.shared_experts = MagicMock()
+    moe.shared_experts.forward.return_value = shared
+    moe.routed_expert_forward = MagicMock(return_value=(routed, False))
+    moe.combine_outputs = MagicMock(return_value=output)
+    monkeypatch.setattr(
+        atom_modules.deepseek_v4.torch.cuda,
+        "current_stream",
+        lambda _device: routed_stream,
+    )
+    monkeypatch.setattr(
+        atom_modules.deepseek_v4.torch.cuda,
+        "stream",
+        lambda _stream: contextmanager(lambda: (yield))(),
+    )
+
+    result = atom_modules.deepseek_v4.MoE.dual_stream_moe_forward(moe, hidden_states)
+
+    assert result is output
+    assert alt_stream.wait_stream.call_args_list[0].args == (routed_stream,)
+    routed_stream.wait_stream.assert_called_once_with(alt_stream)
+    moe.combine_outputs.assert_called_once_with(
+        routed, shared, prefix="model.layers.3.mlp.combine_outputs"
+    )


### PR DESCRIPTION
## Motivation

Communication-fused MoE currently executes the Stage2 GEMM and TP reduction as
separate operations. For decode-sized batches, kernel launches, intermediate
workspace traffic, and cross-rank synchronization account for a significant
part of the end-to-end latency.

This PR adds a config-driven FlyDSL communication-fused Stage2 path for gfx950
A8W4 MXFP4 MoE workloads. The initial production target is DeepSeek-V4 TP8
decode. Unsupported shapes and token buckets continue to use the existing
ordinary Stage2 + TP AllReduce path.

## Performance

### Single-operator latency

Representative TP8 graph measurements collected during development are shown
below. Each value is the median of three rounds using the maximum latency across
all eight ranks. The fused path includes GEMM2 and the TP collective; the
ordinary path includes Stage2 followed by TP AllReduce.

| M | Routing | Ordinary (us) | Comm-fused (us) | Latency reduction |
|---:|---|---:|---:|---:|
| 1 | uniform | 22.187 | 15.549 | 29.92% |
| 1 | skew | 22.195 | 15.380 | 30.71% |
| 2 | uniform | 24.050 | 15.679 | 34.81% |
| 2 | skew | 23.248 | 15.505 | 33.31% |
| 4 | uniform | 25.173 | 18.147 | 27.91% |
| 4 | skew | 28.175 | 25.742 | 8.64% |
| 8 | uniform | 30.214 | 25.939 | 14.15% |
| 8 | skew | 21.864 | 17.116 | 21.72% |
| 16 | uniform | 42.309 | 37.232 | 12.00% |
| 16 | skew | 25.671 | 23.215 | 9.57% |

The production table enables the direct comm-fused megakernel only for
`M = 1, 2, 4, 8, 16`. Larger buckets remain explicit ordinary fallbacks unless
a fused candidate has been separately validated and selected.

### End-to-end model performance

The end-to-end comparison used DeepSeek-V4-Pro with TP8/EP1, FULL CUDA graph,
ISL=8192, OSL=1024, random-range-ratio=0.8, and concurrency
`1, 2, 4, 8, 16`. Each arm started the model once and ran all five concurrency
levels. Results use three adjacent `A/B` pairs in the fixed order
`A1 -> B1 -> A2 -> B2 -> A3 -> B3`, where A enables comm-fused MoE and B sets
`AITER_DISABLE_COMM_FUSED_MOE=1`. The reported improvements are the median of
the three paired improvements.

| Concurrency | Fused total tok/s | Ordinary total tok/s | Throughput improvement | Fused median TPOT | Ordinary median TPOT | TPOT improvement |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 605.215 | 579.768 | +4.123% | 14.576 ms | 15.188 ms | +4.089% |
| 2 | 1193.275 | 1162.718 | +2.628% | 14.345 ms | 14.744 ms | +2.629% |
| 4 | 2231.085 | 2108.697 | +5.857% | 15.454 ms | 16.360 ms | +5.582% |
| 8 | 4079.240 | 3888.174 | +4.427% | 16.862 ms | 17.591 ms | +4.183% |
| 16 | 6661.362 | 6536.340 | +1.782% | 20.863 ms | 21.249 ms | +1.653% |

All five concurrency levels improved both TPOT and total-token throughput. The
observed paired-median TPOT improvement is 1.65% to 5.58%, while total-token
throughput improves by 1.78% to 5.86%.

## Technical Details

- Add gfx950 A8W4 comm-fused MoE kernels under
  `aiter/ops/flydsl/kernels/comm_fused_moe/gfx950/a8w4/`.
  - Compose the MXMoE GEMM2 tile emitter into one persistent direct megakernel.
  - Keep the collective, completion-ticket, epoch, and graph synchronization
    protocol inside the comm-fused shell.
  - Retain Atomic and Window implementations for continued tuning without
    selecting them in the current production CSV.
  - Support TP2/TP4 direct-kernel shapes in addition to the TP8 production path.

- Add AITER runtime and config dispatch.
  - `CommFusedMoeRuntime` reuses the existing routing and Stage1 implementation,
    then replaces Stage2 + TP AllReduce with a prepared fused runner.
  - Synchronize the caller and Stage2 streams when a distinct Stage2 stream is
    supplied.
  - Select implementations by GPU, CU count, shape, TP degree, and token bucket.
  - Load model-specific rows from
    `configs/model_configs/*tuned_comm_fused_moe*.csv`.
  - Use explicit `fallback` rows for buckets without a validated fused winner.

- Add dynamic MXFP8 TP partials.
  - FP8 partial payloads carry runtime E8M0 scales; the final output remains
    BF16.
  - A compile-time row resolver lets the MXMoE producer read the existing
    comm-fused Stage2 input layout without an extra reorder kernel or workspace.
  - JIT identities include the collective and layout ABI to prevent reuse of an
    incompatible cached code object.

- Add peer-VMM workspace handling.
  - Symmetric workspaces are aligned to 2 MiB to avoid the ROCm 7.2.4
    small-allocation peer-VMM performance cliff.
  - Reuse the existing cross-device monotonic i64 wait primitive.
  - Synchronize ranks after peer-window registration before launching kernels
    that dereference peer mappings.

## Correctness and Accuracy

The current source was validated on gfx950 TP8 with ROCm 7.2.4 using the full
production matrix:

- `M = 1, 2, 4, 8, 16`;
- uniform and skew routing;
- eager execution and three CUDA graph replays;
- runtime padding from M=3 to the M=4 bucket;
- a distinct Stage2 CUDA stream in eager execution.

All cases were finite and passed the error thresholds. Direct-path relative L2
error ranged from `0.013351` to `0.014934`; the complete M=3 to M=4 runtime path
reported `rel_l2=0.021019`.

Full GSM8K regression used 3-shot evaluation over all 1,319 examples with TP8,
FULL CUDA graph, concurrency 8, and the production small-M comm-fused path:

| Metric | Comm-fused | Ordinary | Difference |
|---|---:|---:|---:|
| strict match | 1258/1319 (95.3753%) | 1253/1319 (94.9962%) | +5 examples |
| flexible extract | 1257/1319 (95.2995%) | 1252/1319 (94.9204%) | +5 examples |

The difference is smaller than the single-run statistical uncertainty; the
result is treated as evidence of no observed accuracy regression, not as an
accuracy improvement claim. Both arms completed all requests without NaNs,
rank failures, or invalid server responses.

## Test Plan and Results

- Static validation:
  - Black: passed.
  - Ruff: passed.
  - `git diff --check`: passed.

- TP8 production correctness:

  ```bash
  torchrun --standalone --nproc_per_node=8 \
    op_tests/multigpu_tests/test_comm_fused_moe.py \
    --full \
    --graph-replays 3
  ```

  Result: all 10 production route cases plus runtime padding, distinct-stream
  execution, and graph replay passed.

- Additional retained-kernel validation:
  - Atomic M=2048: `321.584 us` ordinary versus `265.063 us` fused, with
    `max_abs=0.75` and `rel_l2=0.02998`.
  - Window M=4096 compiled and passed correctness, but was slower in the latest
    short run and therefore remains outside the production CSV.


- Native ATOM DSV4 CI:
  - [DeepSeek-V4-Pro TP8 accuracy](https://github.com/ROCm/ATOM/actions/runs/34314514770/job/102386532066) passed on the PR head with `ATOM_MOE_GU_ITLV=1`.
  - The job loaded AITer's `dsv4_fp8fp4_tuned_comm_fused_moe.csv`, completed TP8 model warmup, and completed all 1,319 GSM8K requests (`flexible-extract exact_match=0.9560`).

## Submission Checklist

- [ ] Add the `multigpu` PR label so the gfx950 8-GPU CI job executes the full
  comm-fused MoE test.
- [ ] Look over the contributing guidelines at
  https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
