### PR TITLE
[DSA][DCP] Score the sparse decode indexer per query token, unblocking MTP

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1761,11 +1761,9 @@ class Config:
                     f"the persistent cprr MLA kernel); got {gfx}. Disable DCP or "
                     f"speculative decode on this GPU."
                 )
-                # TBO decode splits a decode batch into ubatches, and the
-                # sparse DCP indexer slices its work buffers by query token
-                # rather than by request. The two agree at one query per
-                # sequence, so the combination has never run: refuse it rather
-                # than hand a verify step a ubatch window nothing has checked.
+                # TBO slices its ubatch work buffers by request, while the
+                # sparse DCP indexer indexes them by query token. The two agree
+                # only at one query per sequence.
                 assert not self.enable_tbo_decode, (
                     "Decode TBO (--enable-tbo all) combined with speculative "
                     "decode and DCP is unverified. Use --enable-tbo (prefill "

--- a/atom/config.py
+++ b/atom/config.py
@@ -1761,6 +1761,16 @@ class Config:
                     f"the persistent cprr MLA kernel); got {gfx}. Disable DCP or "
                     f"speculative decode on this GPU."
                 )
+                # TBO decode splits a decode batch into ubatches, and the
+                # sparse DCP indexer slices its work buffers by query token
+                # rather than by request. The two agree at one query per
+                # sequence, so the combination has never run: refuse it rather
+                # than hand a verify step a ubatch window nothing has checked.
+                assert not self.enable_tbo_decode, (
+                    "Decode TBO (--enable-tbo all) combined with speculative "
+                    "decode and DCP is unverified. Use --enable-tbo (prefill "
+                    "only), or drop DCP or speculative decode."
+                )
         # DCP KV-cache interleave granularity S. S=1 (default) = token-level
         # round-robin (unchanged). S>1 = block-level interleave; must divide the
         # KV block so each physical block holds an integer number of S-groups

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -746,13 +746,11 @@ class MLAAttention(nn.Module):
 
         self.dcp_persistent_supported = dcp_persistent_supported()
         self.dcp_prefill_merge_bf16_ok = dcp_prefill_merge_bf16_ok()
-        # Scope sparse persistent DCP to native non-speculative attention.
-        # Decode is q_len=1; sparse prefill is represented as per-token virtual
-        # q_len=1 rows. Plugin DCP reconfigures its group after construction.
+        # Every sparse DCP shape is per-token virtual q_len=1 rows: decode has
+        # one row per sequence, sparse prefill and MTP verify one per query
+        # token. Plugin DCP reconfigures its group after construction.
         self.sparse_dcp_metadata_rebuild = (
-            self.is_sparse_mla
-            and self.dcp_world_size > 1
-            and getattr(atom_config, "speculative_config", None) is None
+            self.is_sparse_mla and self.dcp_world_size > 1
         )
 
         # Compacted per-layer sparse offsets for DCP decode; rebound by the
@@ -1962,8 +1960,13 @@ class MLAAttention(nn.Module):
         """
         if not work_prefix:
             assert attn_metadata.max_seqlen_q == 1, (
-                "Sparse DCP persistent decode metadata rebuild currently "
-                "supports non-speculative q_len=1 only."
+                "The unprefixed sparse DCP work buffers describe a q_len=1 step; "
+                'an MTP verify step must pass work_prefix="sparse_mtp_".'
+            )
+        elif work_prefix == "sparse_mtp_":
+            assert attn_metadata.max_seqlen_q > 1, (
+                "sparse_mtp_ work buffers describe the per-token verify layout; "
+                "a q_len=1 step must use the unprefixed ones."
             )
         assert q.shape[1] == self.dcp_kernel_num_heads
         get_mla_metadata_v1(
@@ -2101,8 +2104,11 @@ class MLAAttention(nn.Module):
                     paged_kv_indptr = attn_metadata.sparse_kv_indptr[: B + 1]
                     paged_kv_indices = self.sparse_kv_indices_buffer
                     paged_kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens[:B]
-                    if self.dcp_world_size > 1:
-                        paged_kv_indptr = self.dcp_sparse_kv_indptr_buffer[: B + 1]
+                if self.dcp_world_size > 1:
+                    # The indexer compacted this layer's owned top-k, so the real
+                    # region lengths are here, not in sparse_kv_indptr. `B` is a
+                    # token count on both branches.
+                    paged_kv_indptr = self.dcp_sparse_kv_indptr_buffer[: B + 1]
 
             dp_size = get_dp_group().world_size
             use_persistent_mode = should_use_persistent_mode(
@@ -2112,10 +2118,9 @@ class MLAAttention(nn.Module):
                 dcp_world_size=self.dcp_world_size,
                 dcp_persistent_supported=self.dcp_persistent_supported,
             )
-            # Sparse DCP persistent decode is enabled only for ordinary q_len=1
-            # native serving. Its full IndexShare layers rebuild the work plan
-            # below from the layer-local compact indptr; plugin/speculative paths
-            # retain the established non-persistent fallback.
+            # Sparse DCP persistent decode rebuilds the work plan below from the
+            # layer-local compact indptr. MTP verify is per-token q_len=1 rows
+            # and rebuilds into the sparse_mtp_ buffers, so it stays here too.
             if self.is_sparse_mla and self.dcp_world_size > 1:
                 use_persistent_mode = (
                     use_persistent_mode and self.sparse_dcp_metadata_rebuild
@@ -2134,6 +2139,7 @@ class MLAAttention(nn.Module):
                     paged_cu_seqlens_q,
                     paged_kv_indptr,
                     paged_kv_last_page_lens,
+                    work_prefix="sparse_mtp_" if is_sparse_mtp else "",
                 )
 
             if not use_persistent_mode:

--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -746,9 +746,9 @@ class MLAAttention(nn.Module):
 
         self.dcp_persistent_supported = dcp_persistent_supported()
         self.dcp_prefill_merge_bf16_ok = dcp_prefill_merge_bf16_ok()
-        # Every sparse DCP shape is per-token virtual q_len=1 rows: decode has
-        # one row per sequence, sparse prefill and MTP verify one per query
-        # token. Plugin DCP reconfigures its group after construction.
+        # Every sparse DCP shape is per-token q_len=1 rows -- one per sequence
+        # in decode, one per query token in sparse prefill and MTP verify.
+        # Plugin DCP reconfigures its group after construction.
         self.sparse_dcp_metadata_rebuild = (
             self.is_sparse_mla and self.dcp_world_size > 1
         )
@@ -2105,8 +2105,8 @@ class MLAAttention(nn.Module):
                     paged_kv_indices = self.sparse_kv_indices_buffer
                     paged_kv_last_page_lens = attn_metadata.sparse_kv_last_page_lens[:B]
                 if self.dcp_world_size > 1:
-                    # The indexer compacted this layer's owned top-k, so the real
-                    # region lengths are here, not in sparse_kv_indptr. `B` is a
+                    # The indexer compacted this layer's owned top-k, so the
+                    # real lengths are here, not in sparse_kv_indptr; `B` is a
                     # token count on both branches.
                     paged_kv_indptr = self.dcp_sparse_kv_indptr_buffer[: B + 1]
 
@@ -2118,9 +2118,9 @@ class MLAAttention(nn.Module):
                 dcp_world_size=self.dcp_world_size,
                 dcp_persistent_supported=self.dcp_persistent_supported,
             )
-            # Sparse DCP persistent decode rebuilds the work plan below from the
-            # layer-local compact indptr. MTP verify is per-token q_len=1 rows
-            # and rebuilds into the sparse_mtp_ buffers, so it stays here too.
+            # Sparse DCP persistent decode rebuilds the work plan below from
+            # the layer-local compact indptr; MTP verify is per-token q_len=1
+            # rows and rebuilds into the sparse_mtp_ buffers.
             if self.is_sparse_mla and self.dcp_world_size > 1:
                 use_persistent_mode = (
                     use_persistent_mode and self.sparse_dcp_metadata_rebuild

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -354,8 +354,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         }
         if self._publishes_dcp_local_lens:
             # Layer-invariant sparse-DSA indexer metadata: one row per query
-            # token, derived from context_lens once per step and reused by every
-            # full layer.
+            # token, derived once per step and reused by every full layer.
             mla_metadata["dcp_local_context_lens"] = CpuGpuBuffer(
                 self.max_bs * max_seqlen_qo, **i32_kwargs
             )
@@ -401,10 +400,9 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 dtype=torch.int32,
                 device=self.device,
             )
-            # One block-table row per scored query token; only MTP verify needs
-            # its own copy. Built once per step rather than in the indexer, where
-            # 21 full-index layers would each allocate one into the CUDAGraph
-            # private pool.
+            # One block-table row per query token; only MTP verify needs a
+            # copy. Built once per step, not in the indexer, where every
+            # full-index layer would allocate one into the CUDAGraph pool.
             self._dcp_token_block_tables_gpu = (
                 torch.empty(
                     self.max_bs * max_seqlen_qo,
@@ -925,7 +923,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             local_ctx = (base + remainder).to(torch.int32)  # local KV tokens/blocks
         if self._publishes_dcp_local_lens:
             # A draft step runs one query per sequence, so this is already the
-            # per-query-token map. The verify step's copy is stale after
+            # per-token map. The verify step's copy is stale after
             # context_lens += 1, and a short length drops the newest tokens.
             var["dcp_local_context_lens"].gpu[:running_bs] = local_ctx
         if dcp_local_rebuild:
@@ -1888,10 +1886,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             if self._publishes_dcp_local_lens:
                 # Publish once per step instead of launching 7 elementwise
                 # kernels in every full sparse-indexer layer. One row per query
-                # token: round-robin sharding lands a draft position's extra
-                # token on a single rank, so the per-request length the dense
-                # metadata uses is only right for the last draft position.
-                # max_seqlen_q == 1 reproduces local_context_lens exactly.
+                # token: a draft position's extra token lands on a single rank,
+                # so a per-request length is only right for the last position.
                 var["dcp_local_context_lens"].np[:sum_scheduled_tokens] = (
                     get_dcp_local_window_lens(
                         context_lens,
@@ -2362,8 +2358,8 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         dcp_local_context_lens = None
         if self._publishes_dcp_local_lens:
             # The warmup forward reads this buffer before replay overwrites it.
-            # One local token matches the synthetic capture KV metadata above.
-            # One row per query token, as prepare_decode publishes it.
+            # One local token matches the synthetic capture KV metadata above;
+            # one row per query token, as prepare_decode publishes it.
             var["dcp_local_context_lens"].np[:sum_tokens] = 1
             dcp_local_context_lens = var["dcp_local_context_lens"].copy_to_gpu(
                 sum_tokens

--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -281,7 +281,6 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             and self.dcp_world_size > 1
             and dcp_persistent
             and self.block_size == 1
-            and config.speculative_config is None
         )
         if self.dcp_world_size > 1 and dcp_persistent:
             self.persistent_num_heads = mla_dcp_kernel_num_heads(
@@ -354,10 +353,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             "kv_last_page_lens": CpuGpuBuffer(self.max_bs, **i32_kwargs),
         }
         if self._publishes_dcp_local_lens:
-            # Layer-invariant qlen=1 sparse-DSA indexer metadata. It is derived
-            # from context_lens once per step and reused by every full layer.
+            # Layer-invariant sparse-DSA indexer metadata: one row per query
+            # token, derived from context_lens once per step and reused by every
+            # full layer.
             mla_metadata["dcp_local_context_lens"] = CpuGpuBuffer(
-                self.max_bs, **i32_kwargs
+                self.max_bs * max_seqlen_qo, **i32_kwargs
             )
         mla_metadata["kv_last_page_lens"].cpu.fill_(1)
         mla_metadata["kv_last_page_lens"].copy_to_gpu()
@@ -400,6 +400,19 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
                 self.max_num_batched_tokens,
                 dtype=torch.int32,
                 device=self.device,
+            )
+            # One block-table row per scored query token; only MTP verify needs
+            # its own copy. Built once per step rather than in the indexer, where
+            # 21 full-index layers would each allocate one into the CUDAGraph
+            # private pool.
+            self._dcp_token_block_tables_gpu = (
+                torch.empty(
+                    self.max_bs * max_seqlen_qo,
+                    self.block_table_cols,
+                    **i32_kwargs,
+                )
+                if self.dcp_world_size > 1 and max_seqlen_qo > 1
+                else None
             )
             sparse_prefill_num_heads = (
                 self.persistent_num_heads
@@ -445,6 +458,13 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             # Allocate a second set of persistent work buffers for sparse MTP
             # per-token layout: max_bs*max_seqlen_qo virtual seqs, each q_len=1.
             smt_max_bs = self.max_bs * max_seqlen_qo
+            # Same widening as sparse prefill: the DCP rebuild regenerates these
+            # for the gathered query width, not for a single rank's heads.
+            sparse_mtp_num_heads = (
+                self.persistent_num_heads
+                if self.sparse_dcp_metadata_rebuild
+                else self.padded_num_attention_heads
+            )
             (
                 (smt_wmd_size, smt_wmd_type),
                 (smt_wi_size, smt_wi_type),
@@ -455,7 +475,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             ) = get_mla_metadata_info_v1(
                 smt_max_bs,
                 1,  # max_seqlen_qo=1 for per-token
-                self.padded_num_attention_heads,
+                sparse_mtp_num_heads,
                 self.dtype_q,
                 self.dtype_kv,
                 is_sparse=True,
@@ -896,14 +916,20 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         # i0_max_seqlen_q for its incremental-update fast path — DCP always
         # needs a full local-shard rebuild, no incremental variant exists).
         dcp_local_rebuild = self.dcp_world_size > 1 and not self.is_sparse
-        if dcp_local_rebuild:
-            assert self.block_size == 1
+        if dcp_local_rebuild or self._publishes_dcp_local_lens:
             W = self.dcp_world_size
             r = self.dcp_rank
             ctx_g = var["context_lens"].gpu[:running_bs].to(torch.int64)
             base = ctx_g // W
             remainder = (ctx_g - base * W - r).clamp_(0, 1)
             local_ctx = (base + remainder).to(torch.int32)  # local KV tokens/blocks
+        if self._publishes_dcp_local_lens:
+            # A draft step runs one query per sequence, so this is already the
+            # per-query-token map. The verify step's copy is stale after
+            # context_lens += 1, and a short length drops the newest tokens.
+            var["dcp_local_context_lens"].gpu[:running_bs] = local_ctx
+        if dcp_local_rebuild:
+            assert self.block_size == 1
             kv_indptr[0] = 0
             kv_indptr[1 : running_bs + 1] = torch.cumsum(
                 local_ctx, dim=0, dtype=torch.int32
@@ -1763,6 +1789,24 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             + dcp_local_index(pos, W, S) % block_size
         )
 
+    def _publish_dcp_token_block_tables(
+        self, attn_metadata, running_bs: int, max_seqlen_q: int
+    ) -> None:
+        """Give the DCP sparse indexer one block-table row per query token.
+
+        Both aiter ops it drives address the table by row. A step with one query
+        per sequence already has that table, so only MTP verify copies.
+        """
+        if not (self.is_sparse and self.dcp_world_size > 1):
+            return
+        block_tables = attn_metadata.block_tables
+        if max_seqlen_q == 1:
+            attn_metadata.dcp_token_block_tables = block_tables
+            return
+        rows = self._dcp_token_block_tables_gpu[: running_bs * max_seqlen_q]
+        rows.view(running_bs, max_seqlen_q, -1).copy_(block_tables.unsqueeze(1))
+        attn_metadata.dcp_token_block_tables = rows
+
     def prepare_decode(
         self,
         batch: ScheduledBatch,
@@ -1830,7 +1874,10 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         var["context_lens"].np[scheduled_bs:running_bs] = 0
 
         if self.dcp_world_size > 1:
-            from atom.model_ops.dcp_ops import get_dcp_local_seq_lens
+            from atom.model_ops.dcp_ops import (
+                get_dcp_local_seq_lens,
+                get_dcp_local_window_lens,
+            )
 
             local_context_lens = get_dcp_local_seq_lens(
                 context_lens,
@@ -1840,9 +1887,23 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             )
             if self._publishes_dcp_local_lens:
                 # Publish once per step instead of launching 7 elementwise
-                # kernels in every full sparse-indexer layer.
-                var["dcp_local_context_lens"].np[:scheduled_bs] = local_context_lens
-                var["dcp_local_context_lens"].np[scheduled_bs:running_bs] = 0
+                # kernels in every full sparse-indexer layer. One row per query
+                # token: round-robin sharding lands a draft position's extra
+                # token on a single rank, so the per-request length the dense
+                # metadata uses is only right for the last draft position.
+                # max_seqlen_q == 1 reproduces local_context_lens exactly.
+                var["dcp_local_context_lens"].np[:sum_scheduled_tokens] = (
+                    get_dcp_local_window_lens(
+                        context_lens,
+                        max_seqlen_q,
+                        self.dcp_world_size,
+                        self.dcp_rank,
+                        self.cp_kv_cache_interleave_size,
+                    )
+                )
+                var["dcp_local_context_lens"].np[
+                    sum_scheduled_tokens:running_tokens
+                ] = 0
             num_blocks_per_seq = cdiv(local_context_lens, self.block_size)
         elif any(batch.is_first_decode_without_local_prefill):
             num_blocks_per_seq = [
@@ -1897,7 +1958,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             ("block_tables", running_bs),
         ]
         if self._publishes_dcp_local_lens:
-            vars_used.append(("dcp_local_context_lens", running_bs))
+            vars_used.append(("dcp_local_context_lens", running_tokens))
         metadata_deps = {
             "cu_seqlens_q",
             "kv_last_page_lens",
@@ -2057,6 +2118,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.sparse_kv_last_page_lens = var[
                 "sparse_kv_last_page_lens"
             ].gpu[:running_bs]
+        self._publish_dcp_token_block_tables(attn_metadata, running_bs, max_seqlen_q)
 
         # running_bs, not scheduled_bs: the padded rows have to be split into the
         # ubatches too, or accuracy drifts.
@@ -2301,8 +2363,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
         if self._publishes_dcp_local_lens:
             # The warmup forward reads this buffer before replay overwrites it.
             # One local token matches the synthetic capture KV metadata above.
-            var["dcp_local_context_lens"].np[:bs] = 1
-            dcp_local_context_lens = var["dcp_local_context_lens"].copy_to_gpu(bs)
+            # One row per query token, as prepare_decode publishes it.
+            var["dcp_local_context_lens"].np[:sum_tokens] = 1
+            dcp_local_context_lens = var["dcp_local_context_lens"].copy_to_gpu(
+                sum_tokens
+            )
         if is_sparse_mtp:
             # Two sets: normal for dense layers, sparse_mtp for sparse layers
             ctx_mla_ps = self.set_mla_persistent_worker_buffers(bs, max_q_len)
@@ -2357,6 +2422,7 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             attn_matadata.sparse_kv_last_page_lens = var[
                 "sparse_kv_last_page_lens"
             ].gpu[:bs]
+        self._publish_dcp_token_block_tables(attn_matadata, bs, max_q_len)
         positions = var["positions"].copy_to_gpu(sum_tokens)
         context = Context(
             positions=positions,
@@ -2429,6 +2495,11 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             if self.dcp_world_size > 1
             else None
         )
+        if self.is_sparse and self.dcp_world_size > 1:
+            # Config refuses decode TBO together with speculative decode under
+            # DCP, so a ubatch always runs one query per sequence.
+            assert max_q_len == 1
+            attn.dcp_token_block_tables = attn.block_tables
         return attn
 
     def build_ubatch_prefill_metadata(

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -704,6 +704,27 @@ def get_dcp_local_seq_lens(seq_lens, dcp_size, dcp_rank, cp_kv_cache_interleave_
     return base + remainder
 
 
+def get_dcp_local_window_lens(
+    seq_lens, max_seqlen_q, dcp_size, dcp_rank, cp_kv_cache_interleave_size=1
+):
+    """Per-DCP-rank local KV length of each QUERY TOKEN's causal window.
+
+    Draft position ``j`` attends to global positions ``[0, seq_len -
+    max_seqlen_q + j]``; that one extra position belongs to a single rank, so
+    the ranks' local lengths do not all advance with j. Returns a flat
+    ``[len(seq_lens) * max_seqlen_q]`` array in (sequence, draft position)
+    order. ``max_seqlen_q == 1`` reproduces ``get_dcp_local_seq_lens``.
+
+    Row 0's window is the sequence's committed (non-draft) token count, which a
+    scheduled decode row always has at least one of; the clamp only keeps the
+    helper honest for callers that have not established that.
+    """
+    windows = seq_lens[:, None] - max_seqlen_q + 1 + np.arange(max_seqlen_q)
+    return get_dcp_local_seq_lens(
+        windows.clip(min=0).ravel(), dcp_size, dcp_rank, cp_kv_cache_interleave_size
+    )
+
+
 def dcp_owner_rank(pos, dcp_size, cp_kv_cache_interleave_size=1):
     """Which DCP rank owns global token ``pos`` under interleaved KV storage.
 
@@ -764,7 +785,7 @@ def dcp_local_context_lens(
     cp_kv_cache_interleave_size: int,
     num_rows: int,
 ) -> torch.Tensor:
-    """This rank's per-request LOCAL KV length under interleave-S sharding.
+    """This rank's LOCAL KV length for each of ``num_rows`` query tokens.
 
     Matches get_dcp_local_seq_lens / prepare_decode's slot split: each full S*W
     super-block gives every rank S tokens, and the tail remainder is handed out
@@ -781,6 +802,13 @@ def dcp_local_context_lens(
     if local_ctx is not None:
         return local_ctx
     g_ctx = attn_metadata.context_lens
+    if g_ctx.shape[0] != num_rows:
+        # This fallback only sees per-request lengths; a verify step's
+        # per-draft windows have to come from the published buffer.
+        raise ValueError(
+            f"no published DCP local context lengths, and context_lens holds "
+            f"{g_ctx.shape[0]} rows for {num_rows} query tokens"
+        )
     S = cp_kv_cache_interleave_size
     W = dcp_world_size
     full_chunks = g_ctx // (S * W)
@@ -852,11 +880,18 @@ def dcp_decode_candidate_exchange_fused(
     # scheduled -- NOT padded_q_fp8_decode_tokens.shape, which is the padded
     # capture width. Sizing off the padded array walks rows nothing scheduled
     # and hands attention a width it did not ask for (upstream 0b4f1ddba).
-    next_n = padded_q_fp8_decode_tokens.shape[1]
-    assert attn_metadata.max_seqlen_q == 1, (
-        "DCP + DeepSeek-V3.2 sparse indexer (DSA) currently supports "
-        "qlen=1 decode only (MTP verify not yet supported)."
+    #
+    # The row unit is the QUERY TOKEN, so the (batch, next_n) query is flattened
+    # here and next_n never reaches aiter. Its own window formula
+    # `seqLens[row // next_n] - next_n + row % next_n + 1` advances every rank's
+    # LOCAL length once per draft position, which holds only if this rank owns
+    # all of the last next_n global positions; at next_n == 1 it degenerates to
+    # `seqLens[row]` and local_ctx below says what each window really is.
+    q_rows = padded_q_fp8_decode_tokens.reshape(
+        num_decode_tokens, 1, *padded_q_fp8_decode_tokens.shape[2:]
     )
+    # One block-table row per query token; both aiter ops address it by row.
+    block_tables = attn_metadata.dcp_token_block_tables[:num_decode_tokens]
 
     local_ctx = dcp_local_context_lens(
         attn_metadata,
@@ -870,12 +905,12 @@ def dcp_decode_candidate_exchange_fused(
         [num_decode_tokens, l_max], dtype=torch.float32, device="cuda"
     )
     deepgemm_fp8_paged_mqa_logits(
-        padded_q_fp8_decode_tokens,
+        q_rows,
         kv_cache,
         weights[:num_decode_tokens],
         local_logits,
         local_ctx,
-        attn_metadata.block_tables,
+        block_tables,
         l_max,
         KVBlockSize=runner_block_size,
         Preshuffle=True,
@@ -898,7 +933,7 @@ def dcp_decode_candidate_exchange_fused(
     )
     top_k_per_row_decode(
         local_logits,
-        next_n,
+        1,  # next_n: one row per query token, windows come from local_ctx
         local_ctx,
         local_idx,
         num_decode_tokens,
@@ -923,7 +958,7 @@ def dcp_decode_candidate_exchange_fused(
     flydsl_dcp_topk_merge(
         gathered_sc.view(torch.float32),
         local_idx,
-        attn_metadata.block_tables[:num_decode_tokens],
+        block_tables,
         out_kv_indices,
         out_kv_indptr,
         owned_counts,

--- a/atom/model_ops/dcp_ops.py
+++ b/atom/model_ops/dcp_ops.py
@@ -707,21 +707,22 @@ def get_dcp_local_seq_lens(seq_lens, dcp_size, dcp_rank, cp_kv_cache_interleave_
 def get_dcp_local_window_lens(
     seq_lens, max_seqlen_q, dcp_size, dcp_rank, cp_kv_cache_interleave_size=1
 ):
-    """Per-DCP-rank local KV length of each QUERY TOKEN's causal window.
+    """Per-DCP-rank local KV length of each query token's causal window.
 
     Draft position ``j`` attends to global positions ``[0, seq_len -
-    max_seqlen_q + j]``; that one extra position belongs to a single rank, so
-    the ranks' local lengths do not all advance with j. Returns a flat
+    max_seqlen_q + j]``; that extra position belongs to a single rank, so the
+    ranks' local lengths do not all advance with j. Returns a flat
     ``[len(seq_lens) * max_seqlen_q]`` array in (sequence, draft position)
     order. ``max_seqlen_q == 1`` reproduces ``get_dcp_local_seq_lens``.
-
-    Row 0's window is the sequence's committed (non-draft) token count, which a
-    scheduled decode row always has at least one of; the clamp only keeps the
-    helper honest for callers that have not established that.
     """
     windows = seq_lens[:, None] - max_seqlen_q + 1 + np.arange(max_seqlen_q)
     return get_dcp_local_seq_lens(
-        windows.clip(min=0).ravel(), dcp_size, dcp_rank, cp_kv_cache_interleave_size
+        # Row 0 is the committed token count, which a scheduled decode row
+        # always has at least one of; the clip is for callers that do not.
+        windows.clip(min=0).ravel(),
+        dcp_size,
+        dcp_rank,
+        cp_kv_cache_interleave_size,
     )
 
 
@@ -803,8 +804,8 @@ def dcp_local_context_lens(
         return local_ctx
     g_ctx = attn_metadata.context_lens
     if g_ctx.shape[0] != num_rows:
-        # This fallback only sees per-request lengths; a verify step's
-        # per-draft windows have to come from the published buffer.
+        # This fallback only sees per-request lengths; per-draft windows
+        # have to come from the published buffer.
         raise ValueError(
             f"no published DCP local context lengths, and context_lens holds "
             f"{g_ctx.shape[0]} rows for {num_rows} query tokens"
@@ -881,12 +882,11 @@ def dcp_decode_candidate_exchange_fused(
     # capture width. Sizing off the padded array walks rows nothing scheduled
     # and hands attention a width it did not ask for (upstream 0b4f1ddba).
     #
-    # The row unit is the QUERY TOKEN, so the (batch, next_n) query is flattened
-    # here and next_n never reaches aiter. Its own window formula
-    # `seqLens[row // next_n] - next_n + row % next_n + 1` advances every rank's
-    # LOCAL length once per draft position, which holds only if this rank owns
-    # all of the last next_n global positions; at next_n == 1 it degenerates to
-    # `seqLens[row]` and local_ctx below says what each window really is.
+    # Rows are query tokens, so the (batch, next_n) query is flattened here and
+    # next_n never reaches aiter: its window formula `seqLens[row // next_n] -
+    # next_n + row % next_n + 1` advances every rank's LOCAL length once per
+    # draft position, but that extra position belongs to one rank. At next_n ==
+    # 1 it degenerates to `seqLens[row]` and local_ctx carries the real windows.
     q_rows = padded_q_fp8_decode_tokens.reshape(
         num_decode_tokens, 1, *padded_q_fp8_decode_tokens.shape[2:]
     )

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -54,10 +54,9 @@ class EagleProposer(Drafter):
         # draft backends are unchanged. (DSpark is DSparkProposer, not this
         # class, so it cannot reach here.)
         #
-        # Not under DCP: the reuse is a fixed-stride gather of the indices alone,
-        # while DCP compacts each rank's owned slots to a data-dependent length
-        # held in dcp_sparse_kv_indptr_buffer. Without those, the regions are
-        # wrong.
+        # Not under DCP: the reuse gathers indices at a fixed stride, while DCP
+        # compacts each rank's owned slots to a data-dependent length recorded
+        # in dcp_sparse_kv_indptr_buffer.
         draft_hf = self.speculative_config.draft_model_hf_config
         mtp_inner = getattr(self.model, "model", None)
         self._share_mtp_indices = (
@@ -428,8 +427,7 @@ class EagleProposer(Drafter):
         attn_metadata.block_tables = var["block_tables"].gpu[:running_bs]
         if attn_metadata.dcp_token_block_tables is not None:
             # One query per sequence, so the per-token table is block_tables
-            # itself; the verify step left one with the right row count and the
-            # wrong rows.
+            # itself; the verify step's has the right row count, wrong rows.
             attn_metadata.dcp_token_block_tables = attn_metadata.block_tables
         attn_metadata.context_lens = var["context_lens"].gpu[:running_bs]
         if "sparse_kv_indptr" in var:

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -6,6 +6,7 @@ from torch import nn
 from torch.profiler import record_function
 
 from atom.config import CompilationLevel
+from atom.distributed.dcp_utils import get_dcp_world_size
 from atom.distributed.pcp_utils import (
     get_pcp_world_size,
     pcp_allgather_rerange,
@@ -52,6 +53,11 @@ class EagleProposer(Drafter):
         # Gated on method=mtp, DSA index_topk and the config flag, so other
         # draft backends are unchanged. (DSpark is DSparkProposer, not this
         # class, so it cannot reach here.)
+        #
+        # Not under DCP: the reuse is a fixed-stride gather of the indices alone,
+        # while DCP compacts each rank's owned slots to a data-dependent length
+        # held in dcp_sparse_kv_indptr_buffer. Without those, the regions are
+        # wrong.
         draft_hf = self.speculative_config.draft_model_hf_config
         mtp_inner = getattr(self.model, "model", None)
         self._share_mtp_indices = (
@@ -60,6 +66,7 @@ class EagleProposer(Drafter):
             and hasattr(draft_hf, "index_topk")
             and mtp_inner is not None
             and hasattr(mtp_inner, "set_skip_topk")
+            and get_dcp_world_size() == 1
         )
         if self._share_mtp_indices:
             logger.info(
@@ -419,6 +426,11 @@ class EagleProposer(Drafter):
         # block_tables, context_lens, and sparse_kv_indptr are
         # needed by both MHA and MLA+sparse attention
         attn_metadata.block_tables = var["block_tables"].gpu[:running_bs]
+        if attn_metadata.dcp_token_block_tables is not None:
+            # One query per sequence, so the per-token table is block_tables
+            # itself; the verify step left one with the right row count and the
+            # wrong rows.
+            attn_metadata.dcp_token_block_tables = attn_metadata.block_tables
         attn_metadata.context_lens = var["context_lens"].gpu[:running_bs]
         if "sparse_kv_indptr" in var:
             attn_metadata.sparse_kv_indptr = var["sparse_kv_indptr"].gpu[

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -587,9 +587,16 @@ class AttentionMetaData:
     # prefill/MTP-verify and per seq in decode. Separate from kv_last_page_lens
     # (the dense per-seq buffer) so the two never clobber each other.
     sparse_kv_last_page_lens: torch.Tensor | None = None
-    # Precomputed per-rank context lengths for qlen=1 sparse DSA + DCP decode.
-    # The padded running-width buffer is shared by eager, graph and TBO paths.
+    # Per-rank KV length of each SCORED QUERY TOKEN's causal window, for sparse
+    # DSA + DCP decode -- one row per query token, since MTP verify gives each
+    # draft position its own window. The padded running-width buffer is shared
+    # by eager, graph and TBO paths.
     dcp_local_context_lens: torch.Tensor | None = None
+    # Block-table row per scored query token, for the same indexer; both aiter
+    # ops address the table by row. Aliases block_tables when the step runs one
+    # query per sequence. Every producer that rewrites block_tables must rewrite
+    # this too -- a stale verify table has the right length but the wrong rows.
+    dcp_token_block_tables: torch.Tensor | None = None
 
     work_meta_data: torch.Tensor | None = None
     work_indptr: torch.Tensor | None = None

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -587,15 +587,14 @@ class AttentionMetaData:
     # prefill/MTP-verify and per seq in decode. Separate from kv_last_page_lens
     # (the dense per-seq buffer) so the two never clobber each other.
     sparse_kv_last_page_lens: torch.Tensor | None = None
-    # Per-rank KV length of each SCORED QUERY TOKEN's causal window, for sparse
-    # DSA + DCP decode -- one row per query token, since MTP verify gives each
-    # draft position its own window. The padded running-width buffer is shared
-    # by eager, graph and TBO paths.
+    # Per-rank KV length of each query token's causal window, for the sparse
+    # DSA + DCP indexer: MTP verify gives each draft position its own window.
+    # The padded running-width buffer is shared by eager, graph and TBO paths.
     dcp_local_context_lens: torch.Tensor | None = None
-    # Block-table row per scored query token, for the same indexer; both aiter
-    # ops address the table by row. Aliases block_tables when the step runs one
-    # query per sequence. Every producer that rewrites block_tables must rewrite
-    # this too -- a stale verify table has the right length but the wrong rows.
+    # Block-table row per query token, for the same indexer -- both aiter ops
+    # address the table by row. Aliases block_tables at one query per sequence.
+    # Every producer that rewrites block_tables must rewrite this too: a stale
+    # one has the right length and the wrong rows.
     dcp_token_block_tables: torch.Tensor | None = None
 
     work_meta_data: torch.Tensor | None = None

--- a/tests/test_dcp_topk.py
+++ b/tests/test_dcp_topk.py
@@ -26,15 +26,34 @@ can differ from a gid-stable local top-k and the merged answer can be a DIFFEREN
 valid top-k. It is still valid (same score multiset) and the ranks still partition
 the KV disjointly, which is what the partition needs. The assertions below are
 written to that weaker, real contract.
+
+A row is a QUERY TOKEN, not a request. At qlen=1 the distinction never shows. An
+MTP verify step scores ``next_n`` draft positions per sequence, and draft
+position j attends to one more global position than j-1 -- a position that under
+DCP belongs to exactly ONE rank, so the ranks' local lengths do not all advance
+with j. aiter's paged MQA-logits kernel derives row (b, j)'s window as
+``context_lens[b] - next_n + j + 1``, which assumes every rank owns all of the
+last ``next_n``; handing it per-token lengths at ``next_n == 1`` instead is what
+makes it right. The last section pins the two pieces that substitution rests on.
 """
 
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 import torch
 
 try:
     from aiter.ops.topk import flydsl_dcp_topk_merge, top_k_per_row_decode
 
-    from atom.model_ops.dcp_ops import dcp_local_context_lens
+    from atom.model_ops import dcp_ops
+    from atom.model_ops.attentions.aiter_mla import AiterMLAMetadataBuilder
+    from atom.model_ops.dcp_ops import (
+        dcp_decode_candidate_exchange_fused,
+        dcp_local_context_lens,
+        get_dcp_local_seq_lens,
+        get_dcp_local_window_lens,
+    )
 except ImportError as _e:  # triton/aiter absent on a CPU-only runner
     pytest.skip(f"requires full atom import env: {_e}", allow_module_level=True)
 
@@ -50,6 +69,12 @@ MAX_MODEL_LEN = 1 << 20
 PAGE = 16
 
 
+def _ctx_rows(ctx, rows, dev):
+    """Per-row context length; a scalar means every row has the same window."""
+    t = torch.as_tensor(ctx, device=dev).to(torch.int64).reshape(-1)
+    return t.expand(rows) if t.numel() == 1 else t
+
+
 def _build_gathered(global_logits, ctx, world, k=TOPK):
     """Everything up to and including the all-gather, for all ranks.
 
@@ -57,22 +82,27 @@ def _build_gathered(global_logits, ctx, world, k=TOPK):
     carved out of the global plane by the round-robin rule (position p lives on
     rank p % W, at local index p // W).
 
+    ``ctx`` is per row, since rows of one sequence differ in length by a token
+    on an MTP verify step; a scalar is the qlen=1 case.
+
     Returns what production hands the merge: the [rows, W*k] score plane with
     column block r owned by rank r, plus each rank's local_idx.
     """
     rows = global_logits.shape[0]
     dev = global_logits.device
+    ctx_rows = _ctx_rows(ctx, rows, dev)
     l_max = (MAX_MODEL_LEN + world - 1) // world
     scores, idxs = [], []
 
     for r in range(world):
-        local_ctx = (ctx - r + world - 1) // world  # #positions p<ctx, p%W==r
-        # torch.empty in the real path: everything past local_ctx is garbage, so
-        # seed it with garbage that would WIN if it were ever read.
+        # torch.empty in the real path: everything past the local length is
+        # garbage, so seed it with garbage that would WIN if it were ever read.
         local = torch.rand(rows, l_max, device=dev, dtype=torch.float32) * 1e4
-        if local_ctx > 0:
-            local[:, :local_ctx] = global_logits[:, r:ctx:world]
-        lens = torch.full((rows,), local_ctx, dtype=torch.int32, device=dev)
+        lens = torch.zeros(rows, dtype=torch.int32, device=dev)
+        for row in range(rows):
+            shard = global_logits[row, r : int(ctx_rows[row]) : world]
+            local[row, : shard.numel()] = shard
+            lens[row] = shard.numel()
 
         idx = torch.empty(rows, k, dtype=torch.int32, device=dev)
         val = torch.empty(rows, k, dtype=torch.float32, device=dev)
@@ -146,7 +176,8 @@ def _owned_global_positions(gathered, idxs, ctx, world, k=TOPK):
     round-robin shard: local index j on rank r is global position j*W + r.
     """
     rows = gathered.shape[0]
-    bt, n_blocks = _identity_block_table(rows, ctx, world, gathered.device)
+    ctx_max = int(_ctx_rows(ctx, rows, gathered.device).max())
+    bt, n_blocks = _identity_block_table(rows, ctx_max, world, gathered.device)
     per_rank = []
     for r in range(world):
         out, indptr = _merge_owned(gathered, idxs[r], bt, r, world, k)
@@ -166,6 +197,11 @@ def _global_reference(global_logits, ctx, k=TOPK):
     # stable argsort on -score keeps ascending position order within a tie
     idx = torch.argsort(-sc, dim=-1, stable=True)[:, :n_keep]
     return idx.to(torch.int32)
+
+
+def _owned_before(limit, rank, world, interleave):
+    """How many global positions p < limit does `rank` own? The slow way."""
+    return sum(1 for p in range(int(limit)) if (p // interleave) % world == rank)
 
 
 def _make_logits(rows, ctx, seed, tie_frac=0.0):
@@ -236,6 +272,60 @@ def test_candidate_exchange_reproduces_global_topk(
         assert torch.equal(
             got.sort(-1).values, ref.sort(-1).values.long()
         ), f"[{name}] ids differ from the reference with no threshold tie"
+
+
+@pytest.mark.parametrize(
+    "bs, next_n, base_ctx, world, seed",
+    [
+        (4, 4, 131072, 8, 11),  # long context, production verify width
+        (4, 2, 65536, 4, 12),
+        (8, 3, 4096, 4, 13),  # short rows: every candidate selected, padding path
+        (2, 4, 2500, 8, 14),  # ctx just over topk
+        (4, 4, 131071, 8, 15),  # ctx not divisible by W
+        (4, 4, 900, 8, 16),  # ctx below topk: nothing is selected away
+    ],
+)
+def test_each_draft_position_gets_its_own_global_topk(
+    bs, next_n, base_ctx, world, seed
+):
+    """Same question, MTP row shape: is each row's union still ITS OWN top-k?
+
+    Rows of a sequence differ in length by one token, the case a per-request
+    length cannot express. Ties resolve by the kernel's own rule, so the
+    assertion is on the score multiset -- the weaker contract above.
+    """
+    rows = bs * next_n
+    seq_ctx = base_ctx + torch.arange(bs, device=DEV) * 7
+    ctx_rows = (
+        seq_ctx[:, None] - next_n + 1 + torch.arange(next_n, device=DEV)
+    ).reshape(-1)
+    gl = _make_logits(rows, int(ctx_rows.max()), seed)
+
+    gathered, idxs = _build_gathered(gl, ctx_rows, world)
+    per_rank = _owned_global_positions(gathered, idxs, ctx_rows, world)
+
+    for row in range(rows):
+        ctx = int(ctx_rows[row])
+        owned = [per_rank[w][row] for w in range(world)]
+        union = torch.cat(owned)
+        n_keep = min(TOPK, ctx)
+
+        assert (
+            union.numel() == n_keep
+        ), f"row {row}: {union.numel()} owned, want {n_keep}"
+        assert union.unique().numel() == n_keep, f"row {row}: the same token twice"
+        assert bool(
+            ((union >= 0) & (union < ctx)).all()
+        ), f"row {row}: a position outside its own window"
+        for w in range(world):
+            assert bool(
+                ((owned[w] % world) == w).all()
+            ), f"row {row}: rank {w} claimed a position it does not own"
+
+        ref = _global_reference(gl[row : row + 1], ctx)[0].long()
+        assert torch.equal(
+            gl[row][union].sort().values, gl[row][ref].sort().values
+        ), f"row {row}: selected scores are not this row's top-k"
 
 
 # Re-merging the SAME gathered buffer must return the same answer, or two ranks
@@ -429,6 +519,181 @@ def test_prefill_filter_is_layout_independent(
         )
 
 
+# ─────────────────────────────────────────── per-query-token row metadata ──
+#
+# The end-to-end test above assumes each row was handed its own window and its
+# own request's block table. These pin the two producers of that.
+
+
+@pytest.mark.parametrize("world", [2, 4, 8])
+@pytest.mark.parametrize("interleave", [1, 16])
+@pytest.mark.parametrize("max_seqlen_q", [1, 2, 4])
+def test_window_lens_count_the_positions_this_rank_owns(
+    world, interleave, max_seqlen_q
+):
+    # Lengths straddling a super-block boundary in both directions, so the tail
+    # remainder is exercised on every rank rather than only the first.
+    seq_lens = np.array(
+        [1, max_seqlen_q, 97, 128, 129, world * interleave * 3 + 1, 1024],
+        dtype=np.int64,
+    )
+    for rank in range(world):
+        got = get_dcp_local_window_lens(seq_lens, max_seqlen_q, world, rank, interleave)
+        want = [
+            _owned_before(ctx - max_seqlen_q + 1 + j, rank, world, interleave)
+            for ctx in seq_lens
+            for j in range(max_seqlen_q)
+        ]
+        assert list(got) == want, f"rank {rank}"
+
+
+@pytest.mark.parametrize("world", [4, 8])
+@pytest.mark.parametrize("interleave", [1, 16])
+def test_one_query_per_sequence_reproduces_the_per_request_lengths(world, interleave):
+    """qlen=1 is not a special case in the code, so it must not be one here."""
+    seq_lens = np.array([1, 63, 64, 65, 4096], dtype=np.int64)
+    for rank in range(world):
+        assert list(
+            get_dcp_local_window_lens(seq_lens, 1, world, rank, interleave)
+        ) == list(get_dcp_local_seq_lens(seq_lens, world, rank, interleave))
+
+
+def test_window_lens_advance_only_on_the_rank_that_owns_the_new_token():
+    """Summed over ranks, the per-row advance is exactly one token per position.
+
+    This is the property the aiter kernel's uniform `- next_n + j` gets wrong:
+    it advances EVERY rank's length by one per draft position, so W-1 of the W
+    ranks over-read while the owner under-reads.
+    """
+    world, q, ctx = 4, 4, 1000
+    per_rank = np.stack(
+        [
+            get_dcp_local_window_lens(np.array([ctx]), q, world, r, 1)
+            for r in range(world)
+        ]
+    )
+    advances = np.diff(per_rank, axis=1)
+    assert advances.sum(axis=0).tolist() == [1] * (q - 1)
+    # ...and each single advance lands on one rank alone.
+    assert set(advances.ravel().tolist()) <= {0, 1}
+
+
+def _publish(bs, q, world, cols=6, is_sparse=True):
+    block_tables = torch.arange(bs * cols, dtype=torch.int32, device=DEV).reshape(
+        bs, cols
+    )
+    stub = SimpleNamespace(
+        is_sparse=is_sparse,
+        dcp_world_size=world,
+        _dcp_token_block_tables_gpu=torch.zeros(
+            bs * q, cols, dtype=torch.int32, device=DEV
+        ),
+    )
+    meta = SimpleNamespace(block_tables=block_tables, dcp_token_block_tables=None)
+    AiterMLAMetadataBuilder._publish_dcp_token_block_tables(stub, meta, bs, q)
+    return meta
+
+
+@pytest.mark.parametrize("bs, q", [(1, 4), (3, 2), (8, 3), (5, 4)])
+def test_token_block_table_row_belongs_to_the_draft_position_s_request(bs, q):
+    meta = _publish(bs, q, world=4)
+    rows = meta.dcp_token_block_tables
+    assert rows.shape == (bs * q, meta.block_tables.shape[1])
+    assert rows.dtype == torch.int32
+    for b in range(bs):
+        for j in range(q):
+            assert torch.equal(rows[b * q + j], meta.block_tables[b]), (b, j)
+
+
+def test_one_query_per_sequence_aliases_the_request_table():
+    """No copy when there is nothing to expand -- and no chance of drift."""
+    meta = _publish(bs=8, q=1, world=4)
+    assert meta.dcp_token_block_tables is meta.block_tables
+
+
+def test_nothing_published_off_the_dcp_sparse_path():
+    """A leftover table is worse than none: same row count, wrong rows."""
+    assert _publish(bs=4, q=2, world=1).dcp_token_block_tables is None
+    assert _publish(bs=4, q=2, world=4, is_sparse=False).dcp_token_block_tables is None
+
+
+def test_fused_exchange_passes_the_kernels_one_row_per_query_token(monkeypatch):
+    """Pin what the ops receive: the flatten to next_n=1 is invisible to every
+    assertion above, and getting it wrong faults nothing and produces no NaN."""
+    import importlib
+    import sys
+
+    import aiter.ops.topk as topk_mod
+
+    # aiter binds this one lazily, so patch the sys.modules entry -- the module
+    # attribute of the same name is a second, stale copy.
+    importlib.import_module("aiter.ops.triton.pa_mqa_logits")
+    logits_mod = sys.modules["aiter.ops.triton.pa_mqa_logits"]
+
+    bs, q, world, cols = 3, 4, 4, 6
+    rows = bs * q
+    seen = {}
+
+    def fake_logits(q_rows, kv, w, out, ctx, bt, *a, **kw):
+        seen["q_rows"], seen["logits_ctx"], seen["logits_bt"] = q_rows, ctx, bt
+
+    def fake_topk(logits, next_n, ctx, idx, n_rows, *a, **kw):
+        seen["next_n"], seen["topk_ctx"], seen["topk_rows"] = next_n, ctx, n_rows
+
+    def fake_merge(scores, local_idx, bt, *a, **kw):
+        seen["merge_bt"] = bt
+
+    monkeypatch.setattr(logits_mod, "deepgemm_fp8_paged_mqa_logits", fake_logits)
+    monkeypatch.setattr(topk_mod, "top_k_per_row_decode", fake_topk)
+    monkeypatch.setattr(topk_mod, "flydsl_dcp_topk_merge", fake_merge)
+    monkeypatch.setattr(dcp_ops, "get_dcp_world_size", lambda: world)
+    monkeypatch.setattr(
+        dcp_ops,
+        "get_dcp_group",
+        lambda: SimpleNamespace(
+            all_gather=lambda t, dim: t.repeat(world, *([1] * (t.dim() - 1)))
+        ),
+    )
+
+    # A recognisable value per row, so a slice or permute cannot pass.
+    windows = torch.arange(1, rows + 1, dtype=torch.int32, device=DEV)
+    token_bt = torch.arange(rows * cols, dtype=torch.int32, device=DEV).reshape(
+        rows, cols
+    )
+    meta = SimpleNamespace(
+        dcp_local_context_lens=windows,
+        dcp_token_block_tables=token_bt,
+        context_lens=torch.full((bs,), 64, dtype=torch.int32, device=DEV),
+    )
+    query = torch.randn(bs, q, 8, 16, device=DEV)
+    dcp_decode_candidate_exchange_fused(
+        meta,
+        query,
+        kv_cache=torch.empty(0, device=DEV),
+        weights=torch.empty(rows, 8, device=DEV),
+        dcp_rank=0,
+        num_decode_tokens=rows,
+        topk_tokens=TOPK,
+        max_model_len=MAX_MODEL_LEN,
+        runner_block_size=PAGE,
+        stable_topk=True,
+        cp_kv_cache_interleave_size=1,
+        out_kv_indices=torch.empty(rows * TOPK, dtype=torch.int32, device=DEV),
+        out_kv_indptr=torch.empty(rows + 1, dtype=torch.int32, device=DEV),
+        owned_counts=torch.empty(rows, dtype=torch.int32, device=DEV),
+    )
+
+    assert seen["next_n"] == 1 and seen["topk_rows"] == rows
+    assert seen["q_rows"].shape == (rows, 1, 8, 16)
+    for b in range(bs):
+        for j in range(q):
+            assert torch.equal(seen["q_rows"][b * q + j, 0], query[b, j])
+    for name in ("logits_ctx", "topk_ctx"):
+        assert torch.equal(seen[name], windows), name
+    for name in ("logits_bt", "merge_bt"):
+        assert torch.equal(seen[name], token_bt), name
+
+
 # ---------------------------------------------------------------------------
 # Regression guards for the fusions themselves.
 #
@@ -467,15 +732,10 @@ def test_local_context_lens_fallback_matches_reference(world, interleave):
     """No published buffer (or a stale one) -> derive, and match the split."""
     rows = 37
     ctx = torch.randint(1, 100000, (rows,), dtype=torch.int32, device=DEV)
-    ref = torch.stack(
-        [
-            torch.tensor(
-                sum(1 for p in range(int(c)) if (p // interleave) % world == 0),
-                dtype=torch.int32,
-                device=DEV,
-            )
-            for c in ctx
-        ]
+    ref = torch.tensor(
+        [_owned_before(c, 0, world, interleave) for c in ctx],
+        dtype=torch.int32,
+        device=DEV,
     )
     for meta in (
         _FakeMeta(ctx),  # non-DCP or non-sparse metadata builder
@@ -484,6 +744,13 @@ def test_local_context_lens_fallback_matches_reference(world, interleave):
         got = dcp_local_context_lens(meta, 0, world, interleave, rows)
         assert got.dtype == torch.int32
         torch.testing.assert_close(got, ref, rtol=0, atol=0)
+
+
+def test_local_context_lens_refuses_a_multi_token_step_with_nothing_published():
+    """The fallback reads per-request lengths, so it cannot answer for MTP."""
+    meta = _FakeMeta(torch.tensor([64, 64], dtype=torch.int32, device=DEV))
+    with pytest.raises(ValueError, match="query tokens"):
+        dcp_local_context_lens(meta, 0, 4, 1, num_rows=8)
 
 
 @pytest.mark.parametrize("world", [2, 8])


### PR DESCRIPTION
## Summary

DCP decode's DSA sparse indexer worked in `(batch, next_n)` shape and refused
anything else: `dcp_decode_candidate_exchange_fused` asserted
`max_seqlen_q == 1`, so an MTP verify step never reached it. This makes the
indexer's row unit the **query token** — which is what the rest of the sparse
path already is — so MTP verify becomes the multi-row case of ordinary decode
rather than a shape of its own.

GLM-5.2-MXFP4, tp4 × dcp4 + MTP-3, sharded index cache: **GSM8K 0.9682**
against 0.9651 for both the no-MTP and the dcp1 controls, and MTP acceptance
79.4% (3.38 tokens/forward).

## Why the refusal was load-bearing, not conservative

Simply relaxing the assert does not fault — it loses accuracy silently.

aiter's paged MQA-logits kernel derives draft row `j`'s causal window as
`seqLens[row // next_n] - next_n + row % next_n + 1`, i.e. it advances every
rank's length by one per draft position. That is correct against a global
length. Under round-robin sharding, though, the position each advance refers to
belongs to exactly **one** rank, so applying the same advance to every rank's
*local* length makes the window too strict on the other W-1 — each silently
drops up to `next_n - 1` of its most recent KV positions, the ones the indexer
most wants. Never too loose, so it never reads out of bounds.

With seq_len 12, W=4 and next_n=4, every rank holds 3 local tokens and the
kernel computes windows `0, 1, 2, 3` for all four ranks, where the true counts
are `3,3,3,3` (rank 0), `2,3,3,3` (rank 1), `2,2,3,3` (rank 2), `2,2,2,3`
(rank 3). The first query token should see 9 KV positions across the group and
sees none.

## The indexer: rows become query tokens

`token_to_seq_idxs`, `sparse_cu_seqlens_q`, `sparse_kv_last_page_lens`,
`dcp_sparse_kv_indptr_buffer` and `_dcp_owned_counts_gpu` are all already sized
`max_num_batched_tokens`. Two pieces were still per-request:

* **`dcp_local_context_lens`** — one entry per query token, from the new
  `get_dcp_local_window_lens`, which computes each draft position's global
  window first and then asks the existing ownership split how many of those
  positions this rank holds. At `max_seqlen_q == 1` it reproduces
  `get_dcp_local_seq_lens` exactly, so ordinary decode is unchanged.
* **`dcp_token_block_tables`** — one block-table row per query token, since both
  aiter ops address the table by row. It *is* `block_tables` whenever a step
  runs one query per sequence, so only MTP verify materialises a copy — once
  per step in the builder, never per layer, which keeps allocations out of the
  CUDAGraph private pool.

With those the exchange flattens `(batch, next_n)` to `next_n = 1` and the
concept leaves the op entirely.

## The attention side

`speculative_config is None` in `sparse_dcp_metadata_rebuild` took MTP off the
sparse DCP persistent kernel and onto the split-KV fallback, which gives every
row the same split count and cannot describe DCP's compacted variable-length
rows — a `MEMORY_VIOLATION` in `_fwd_kernel_stage2_asm`, root-caused in
`docs/dcp_mtp_decode_fault.md`. Note the variable row lengths are not
MTP-specific; MTP's only role was flipping the kernel path.

Dropped in both spellings. The MTP rebuild is routed into the `sparse_mtp_`
work buffers, those buffers are sized for the DCP-gathered query width rather
than a single rank's heads (the same widening sparse prefill already has), and
the MTP branch reads the compacted `dcp_sparse_kv_indptr_buffer` — it was
reading the uniform-stride `sparse_kv_indptr` and walking past each written
region.

## Draft steps

`prepare_mtp_decode` republishes the local lengths, which its own
`context_lens` bump has moved past, and resets `dcp_token_block_tables` to
`block_tables` — the verify step leaves one with the right row count and the
wrong rows. `index_share_for_mtp_iteration` is gated off under DCP: that reuse
gathers the top-k indices at a fixed stride, while DCP's row lengths are
data-dependent and recorded in a buffer it does not touch. Non-DCP MTP keeps
it.

## Decode TBO is refused

TBO slices its ubatch work buffers by request, while the sparse DCP indexer
indexes them by query token. The two agree only at one query per sequence,
which is the only shape this combination has ever run at, so it fails at
`Config` construction — before any GPU is touched — rather than hand a verify
step an unverified ubatch window.

## Validation

One node, MI355X (gfx950), GLM-5.2-MXFP4, tp4 × dcp4, `--method mtp
--num-speculative-tokens 3`, level 3 / cudagraph FULL, SHARDED index cache
(`ATOM_DCP_REPLICATE_INDEX_CACHE` unset).

GSM8K 1319, 5-shot, `lm_eval` local-chat-completions, `apply_chat_template`,
`max_tokens=16384`, `num_concurrent=16` — the invocation `recipes/GLM-5.md`
publishes its reference against:

| config | strict | flexible |
|---|---|---|
| tp4 × dcp4 + MTP-3 | 0.9682 ± 0.0048 | 0.9674 |
| tp4 × dcp4, no MTP | 0.9651 ± 0.0051 | 0.9644 |
| tp4 × dcp1 + MTP-3 | 0.9651 ± 0.0051 | 0.9651 |
| `recipes/GLM-5.md` TP4 | 0.9727 | 0.9742 |

The three configs agree inside their stderr, which is the comparison that
matters: DCP+MTP costs nothing against either control. All three sit ~0.7pp
under the published TP4 row, and so does dcp1+MTP, so that gap is the fp8 KV /
online-quant harness, not DCP.

MTP acceptance 79.4% (3.38 tokens/forward, 66% of steps taking all 3).
`Sparse DCP persistent attention enabled` logs 4 times, one per rank — 0 is the
split-KV fallback the doc above faults on.

GSM8K cannot see the indexer at `index_topk=2048` with ~1k prompts, so the
ranking is validated separately: a 1k–128k MTP acceptance sweep sits inside
dcp1's own repeat noise (0.6298 against 0.6306 / 0.6393 over two dcp1 repeats),
needle-in-haystack is 12/12 at 7k and 57.6k, and SWE-bench Lite 10 resolves
7/10.

`tests/test_dcp_topk.py` grows the MTP row shape next to the qlen=1 case it
already covers, on the same helpers: the per-token windows against a
brute-force ownership count, the block-table expansion, what the two aiter ops
are actually handed, and end to end that each draft position's owned set is
still its own global top-k. 70 passed; `tests/test_dcp_*.py`, 304.