### PR TITLE
perf(mla): fold the query-head pad into the fused q write

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -576,19 +576,18 @@ class MLAAttention(nn.Module):
 
         self.min_query_heads = kwargs.get("min_query_heads", _MLA_MIN_HEADS)
         self.padded_num_heads = max(num_heads, self.min_query_heads)
-        self.head_repeat_factor = 1
-        self.head_pad = 0
-        if self.padded_num_heads != num_heads:
-            if self.padded_num_heads % num_heads == 0:
-                self.head_repeat_factor = self.padded_num_heads // num_heads
-                if not getattr(MLAAttention, "_head_repeat_logged", False):
-                    MLAAttention._head_repeat_logged = True
-                    logger.info(
-                        f"MLA head repeat enabled: {num_heads} -> {self.padded_num_heads} "
-                        f"(repeat factor {self.head_repeat_factor})"
-                    )
-            else:
-                self.head_pad = self.padded_num_heads - num_heads
+        # Heads past num_heads are dead lanes: the MLA kernels compute them and
+        # `_restore_query_heads` throws them away. They are zeros rather than
+        # repeats of the real heads because zeros are what a producer can write
+        # once, up front -- under `_fused_q_head_pad` the fused q writer fills a
+        # slice of an already-zeroed padded buffer, which a repeat could not do
+        # (no producer kernel writes a head twice).
+        self.head_pad = self.padded_num_heads - num_heads
+        if self.head_pad and not getattr(MLAAttention, "_head_pad_logged", False):
+            MLAAttention._head_pad_logged = True
+            logger.info(
+                f"MLA query-head padding: {num_heads} -> {self.padded_num_heads}"
+            )
 
         self.q_lora_rank = mla_modules.q_lora_rank
         self.kv_lora_rank = mla_modules.kv_lora_rank
@@ -774,6 +773,20 @@ class MLAAttention(nn.Module):
                 self.dcp_kernel_num_heads,
             )
 
+        # Fold the query-head pad into the fused q write instead of paying a
+        # separate pad kernel per layer: allocate q_out at the padded width and
+        # hand the writer the real-head slice, which it fills through the
+        # runtime q_out strides it already takes. Restricted to the plain aiter
+        # write -- the seg and shuffled-KV kernels own byte layouts this has not
+        # been checked against, and under DCP q_out is all-gathered on the head
+        # dim, so the pad must go on after the gather, not before it.
+        self._fused_q_head_pad = (
+            self.head_pad > 0
+            and self.dcp_world_size <= 1
+            and not self.use_seg_mla
+            and not (self.use_triton_mla and envs.ATOM_USE_TRITON_MLA_SHUFFLE_KV)
+        )
+
     def _configure_dcp_decode_head_padding(self, dcp_world_size: int) -> None:
         """Configure the kernel width used after DCP gathers query heads.
 
@@ -878,8 +891,6 @@ class MLAAttention(nn.Module):
         return self._restore_query_heads(x, num_heads)
 
     def _pad_query_heads(self, q: torch.Tensor) -> torch.Tensor:
-        if self.head_repeat_factor > 1:
-            return q.repeat_interleave(self.head_repeat_factor, dim=1)
         if self.head_pad > 0:
             return torch.nn.functional.pad(q, (0, 0, 0, self.head_pad))
         return q
@@ -887,10 +898,14 @@ class MLAAttention(nn.Module):
     def _restore_query_heads(
         self, output: torch.Tensor, num_heads: int | None = None
     ) -> torch.Tensor:
-        if self.head_repeat_factor > 1:
-            return output[:, :: self.head_repeat_factor, ...].contiguous()
+        """Drop the dead pad lanes off an MLA output or per-head LSE.
+
+        Returns a view, not a copy: the only consumer is the v-up bmm, which
+        takes its operand strides at runtime and reads the real heads in place.
+        Materialising them instead costs a full-output copy per layer.
+        """
         if self.head_pad > 0:
-            return output[:, : (num_heads or self.num_heads), ...].contiguous()
+            return output[:, : (num_heads or self.num_heads), ...]
         return output
 
     def _seg_kv_cache_view(self, kv_cache: torch.Tensor) -> torch.Tensor:
@@ -1740,21 +1755,27 @@ class MLAAttention(nn.Module):
         kv_c_and_k_pe_cache: torch.Tensor,
         attn_metadata: AttentionMetaData,
         return_lse: bool = False,
+        q_prepadded: bool = False,
     ) -> torch.Tensor:
         assert attn_metadata is not None
         B = q.shape[0]
-        num_heads_q = q.shape[1]
 
         # Under DCP the sparse path has already gathered the group's query heads,
         # so it pads to its own kernel width -- NOT decode's, whose persistence
         # gate differs (see mla_dcp_sparse_prefill_is_persistent). Every other
         # caller pads the per-rank count.
         dcp_sparse = self.is_sparse_mla and self.dcp_world_size > 1
-        q = (
-            self._pad_sparse_prefill_query_heads(q)
-            if dcp_sparse
-            else self._pad_query_heads(q)
-        )
+        if q_prepadded:
+            # The fused q write already produced the padded width, so q.shape[1]
+            # is the kernel width and the real head count is this rank's own.
+            num_heads_q = self.num_heads
+        else:
+            num_heads_q = q.shape[1]
+            q = (
+                self._pad_sparse_prefill_query_heads(q)
+                if dcp_sparse
+                else self._pad_query_heads(q)
+            )
 
         # In the seg path q arrives with a padded per-head row stride
         # (_MLA_Q_OUT_PADDED_DIM); slice back to the logical
@@ -1934,7 +1955,9 @@ class MLAAttention(nn.Module):
                 o = torch.where(
                     torch.isfinite(final_lse).unsqueeze(-1), o, torch.zeros_like(o)
                 )
-            return o, final_lse
+            # These feed a cross-rank combine, not the bmm, so the head slice
+            # has to be materialised rather than left as a view.
+            return o.contiguous(), final_lse.contiguous()
 
         return self._v_up_proj_and_o_proj(o)
 
@@ -2023,6 +2046,7 @@ class MLAAttention(nn.Module):
         kv_c_and_k_pe_cache: torch.Tensor,
         attn_metadata: AttentionMetaData,
         return_lse: bool = False,
+        q_prepadded: bool = False,
     ) -> torch.Tensor:
         # attn_metadata.causal is True for the target; False only for DSpark's
         # bidirectional draft block (set by the proposer). The asm kernel picks
@@ -2031,9 +2055,14 @@ class MLAAttention(nn.Module):
         assert kv_c_and_k_pe_cache.numel() > 0
         assert attn_metadata is not None
         B = q.shape[0]
-        num_heads_q = q.shape[1]
 
-        q = self._pad_decode_query_heads(q)
+        if q_prepadded:
+            # The fused q write already produced the padded width, so q.shape[1]
+            # is the kernel width and the real head count is this rank's own.
+            num_heads_q = self.num_heads
+        else:
+            num_heads_q = q.shape[1]
+            q = self._pad_decode_query_heads(q)
 
         # In the seg path q arrives with a padded per-head row stride
         # (_MLA_Q_OUT_PADDED_DIM); slice back to the logical
@@ -2253,7 +2282,8 @@ class MLAAttention(nn.Module):
             final_lse = self._restore_decode_query_heads(final_lse, num_heads_q)
 
         if return_lse:
-            return o, final_lse
+            # Bound for a cross-rank combine rather than the bmm: materialise.
+            return o.contiguous(), final_lse.contiguous()
 
         return self._v_up_proj_and_o_proj(o)
 
@@ -2535,6 +2565,20 @@ class MLAAttention(nn.Module):
                     dtype=attn_metadata.dtype_q,
                     device=q_nope.device,
                 )
+            elif self._fused_q_head_pad:
+                # Allocate at the width the MLA kernels dispatch on, zeroed so
+                # the dead lanes match what F.pad used to produce, and let the
+                # fused write below fill the real-head slice in place. `q_out`
+                # therefore reaches attention already padded.
+                q_out = torch.zeros(
+                    (
+                        q_nope.shape[0],
+                        self.padded_num_heads,
+                        self.kv_lora_rank + self.qk_rope_head_dim,
+                    ),
+                    dtype=attn_metadata.dtype_q,
+                    device=q_nope.device,
+                )
             else:
                 q_out = torch.empty(
                     (
@@ -2545,6 +2589,12 @@ class MLAAttention(nn.Module):
                     dtype=attn_metadata.dtype_q,
                     device=q_nope.device,
                 )
+            # What the fused writer fills: the real heads only. Under
+            # `_fused_q_head_pad` that is a slice of the padded buffer above,
+            # reached through the kernel's runtime q_out strides.
+            q_out_write = (
+                q_out[:, : self.num_heads] if self._fused_q_head_pad else q_out
+            )
             if kv_cache.numel() > 0:
                 if (
                     envs.ATOM_USE_TRITON_MLA
@@ -2601,7 +2651,7 @@ class MLAAttention(nn.Module):
                             -1,
                             self.kv_lora_rank + self.qk_rope_head_dim,
                         ),
-                        q_out,
+                        q_out_write,
                         write_slot_mapping,
                         self._k_scale,
                         self._q_scale,
@@ -2634,11 +2684,21 @@ class MLAAttention(nn.Module):
                 if self.is_sparse_mla and self.dcp_world_size > 1:
                     output = self._dcp_sparse_prefill(q_out, kv_cache, attn_metadata)
                 else:
-                    output = self._forward_prefill_mla(q_out, kv_cache, attn_metadata)
+                    output = self._forward_prefill_mla(
+                        q_out,
+                        kv_cache,
+                        attn_metadata,
+                        q_prepadded=self._fused_q_head_pad,
+                    )
             elif self.dcp_world_size > 1:
                 output = self._dcp_decode(q_out, kv_cache, attn_metadata, use_qrep)
             else:
-                output = self._forward_decode(q_out, kv_cache, attn_metadata)
+                output = self._forward_decode(
+                    q_out,
+                    kv_cache,
+                    attn_metadata,
+                    q_prepadded=self._fused_q_head_pad,
+                )
 
         return output
 

--- a/atom/plugin/vllm/attention/layer_mla.py
+++ b/atom/plugin/vllm/attention/layer_mla.py
@@ -798,10 +798,16 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
         q,
         kv_c_and_k_pe_cache,
         attn_metadata,
+        q_prepadded: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         assert isinstance(q, torch.Tensor)
-        original_num_heads = q.shape[1]
-        q = self._pad_decode_query_heads(q)
+        if q_prepadded:
+            # The fused q write already produced the padded width, so q.shape[1]
+            # is the kernel width and the real head count is this rank's own.
+            original_num_heads = self.num_heads
+        else:
+            original_num_heads = q.shape[1]
+            q = self._pad_decode_query_heads(q)
         B = q.shape[0]
         num_heads_q = q.shape[1]
         o = torch.empty(
@@ -1118,20 +1124,37 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                     transpose_bm=True,
                 )
 
+            # Fold the query-head pad into the fused q write instead of paying a
+            # separate pad kernel per layer: allocate at the width the MLA kernel
+            # dispatches on, zeroed so the dead lanes match what F.pad produced,
+            # and hand the writer the real-head slice, which it fills through the
+            # runtime q_out strides it already takes. Only the fused write can do
+            # this, and not under DCP -- decode_q is all-gathered on the head dim
+            # below, so there the pad has to go on after the gather.
+            fused_q_head_pad = (
+                decode_only and self.head_pad > 0 and self.dcp_world_size <= 1
+            )
             if decode_only:
-                decode_q = torch.empty(
-                    (
-                        decode_ql_nope.shape[0],
-                        self.num_heads,
-                        self.kv_lora_rank + self.qk_rope_head_dim,
-                    ),
-                    dtype=(
-                        dtypes.fp8
-                        if self.kv_cache_dtype.startswith("fp8")
-                        else self.dtype
-                    ),
-                    device=decode_ql_nope.device,
+                decode_q_dtype = (
+                    dtypes.fp8 if self.kv_cache_dtype.startswith("fp8") else self.dtype
                 )
+                decode_q_shape = (
+                    decode_ql_nope.shape[0],
+                    self.padded_num_heads if fused_q_head_pad else self.num_heads,
+                    self.kv_lora_rank + self.qk_rope_head_dim,
+                )
+                if fused_q_head_pad:
+                    decode_q = torch.zeros(
+                        decode_q_shape,
+                        dtype=decode_q_dtype,
+                        device=decode_ql_nope.device,
+                    )
+                else:
+                    decode_q = torch.empty(
+                        decode_q_shape,
+                        dtype=decode_q_dtype,
+                        device=decode_ql_nope.device,
+                    )
                 aiter.fused_qk_rope_concat_and_cache_mla(
                     decode_ql_nope,
                     decode_q_pe,
@@ -1142,7 +1165,7 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                         -1,
                         self.kv_lora_rank + self.qk_rope_head_dim,
                     ),
-                    decode_q,
+                    decode_q[:, : self.num_heads] if fused_q_head_pad else decode_q,
                     attn_metadata.slot_mapping,
                     self._k_scale,
                     self._q_scale,
@@ -1195,7 +1218,9 @@ class AttentionForVllmMLA(MLAAttention, AttentionLayerBase):
                 decode_q = dcp_all_gather_query_heads(self.dcp_group, decode_q)
 
             # call decode attn
-            attn_out, lse = self._forward_decode(decode_q, kv_cache, attn_metadata)
+            attn_out, lse = self._forward_decode(
+                decode_q, kv_cache, attn_metadata, q_prepadded=fused_q_head_pad
+            )
 
             # correct dcp attn_out with lse.
             if self.dcp_world_size > 1:


### PR DESCRIPTION
## Summary

MLA on 12 query heads per rank has to reach a width aiter dispatches on (16), and today that pad is paid twice per layer: `F.pad` materialises a padded copy of `q` before attention, and `_restore_query_heads` materialises an unpadded copy of the output after it. Neither copy is needed off the DCP path. This PR eliminate this pad.

