### PR TITLE
[atom-vllm ci]: download plugin CI draft models like the target

### DIFF
--- a/.github/actions/prepare-dashboard-data/action.yml
+++ b/.github/actions/prepare-dashboard-data/action.yml
@@ -1,0 +1,48 @@
+name: Prepare dashboard data
+description: Normalize and publish an existing dashboard data file before benchmark action runs.
+
+inputs:
+  data-path:
+    description: Path to data.js on the gh-pages branch.
+    required: true
+
+outputs:
+  entry_count:
+    description: Number of benchmark run entries before the action writes.
+    value: ${{ steps.prepare.outputs.entry_count }}
+
+runs:
+  using: composite
+  steps:
+    - id: prepare
+      shell: bash
+      env:
+        DATA_PATH: ${{ inputs.data-path }}
+      run: |
+        set -euo pipefail
+        SCRIPT_PATH="$RUNNER_TEMP/prepare_dashboard_data.py"
+        cp "$GITHUB_WORKSPACE/.github/scripts/prepare_dashboard_data.py" "$SCRIPT_PATH"
+        CURRENT_SHA=$(git rev-parse HEAD)
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git fetch origin gh-pages
+        git checkout -B gh-pages origin/gh-pages
+
+        output=$(python3 "$SCRIPT_PATH" "$DATA_PATH" --write)
+        printf '%s\n' "$output"
+        entry_count=$(printf '%s\n' "$output" | awk -F= '$1 == "entry_count" { print $2 }')
+        if [ -z "$entry_count" ]; then
+          echo "::error::Dashboard helper did not report entry_count"
+          exit 1
+        fi
+
+        if [ -f "$DATA_PATH" ]; then
+          git add -- "$DATA_PATH"
+          if ! git diff --cached --quiet; then
+            git commit -m "ci(dashboard): normalize benchmark data format"
+            git push origin gh-pages
+          fi
+        fi
+
+        git checkout "$CURRENT_SHA"
+        echo "entry_count=$entry_count" >> "$GITHUB_OUTPUT"

--- a/.github/actions/validate-dashboard-data/action.yml
+++ b/.github/actions/validate-dashboard-data/action.yml
@@ -1,0 +1,25 @@
+name: Validate dashboard data
+description: Verify dashboard data was not reduced while publishing a benchmark result.
+
+inputs:
+  data-path:
+    description: Path to data.js on the gh-pages branch.
+    required: true
+  min-entries:
+    description: Minimum number of run entries expected after publishing.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        DATA_PATH: ${{ inputs.data-path }}
+        MIN_ENTRIES: ${{ inputs.min-entries }}
+      run: |
+        set -euo pipefail
+        DATA_FILE="$RUNNER_TEMP/dashboard-data.js"
+        git show "gh-pages:${DATA_PATH}" > "$DATA_FILE"
+        python3 "$GITHUB_WORKSPACE/.github/scripts/prepare_dashboard_data.py" \
+          "$DATA_FILE" \
+          --min-entries "$MIN_ENTRIES"

--- a/.github/scripts/gpu_preflight_check.sh
+++ b/.github/scripts/gpu_preflight_check.sh
@@ -3,14 +3,16 @@
 #
 # This intentionally avoids importing ATOM or aiter. It records the visible GPU
 # process/memory state, then performs a minimal torch allocation on every visible
-# HIP device. If this fails, the node/container is already unhealthy before ATOM
-# participates in the run.
+# HIP device. Leftover docker cleanup is opt-in via GPU_PREFLIGHT_KILL_DOCKER=1
+# (vLLM/SGLang plugin CI). ATOM native CI leaves it off.
 
 set -euo pipefail
 
 CONTAINER="${1:-}"
 ENGINE="${2:-docker}"
 GPU_PREFLIGHT_ALLOCATION_MB="${GPU_PREFLIGHT_ALLOCATION_MB:-8}"
+GPU_PREFLIGHT_KILL_DOCKER="${GPU_PREFLIGHT_KILL_DOCKER:-0}"
+GPU_PREFLIGHT_KILL_WAIT_SECONDS="${GPU_PREFLIGHT_KILL_WAIT_SECONDS:-30}"
 
 case "$GPU_PREFLIGHT_ALLOCATION_MB" in
     ''|*[!0-9]*)
@@ -41,26 +43,88 @@ print_probe() {
     fi
 }
 
-print_probe "GPU preflight: ROCm memory and processes before HIP smoke test" '
-    set +e
-    command -v rocm-smi >/dev/null 2>&1 || { echo "rocm-smi not found"; exit 127; }
-    rocm-smi --showmemuse || true
-    rocm-smi --showpids || true
-    rocm-smi --showpidgpus || true
-'
-
-print_probe "GPU preflight: device file users before HIP smoke test" '
-    set +e
-    if command -v fuser >/dev/null 2>&1; then
-        fuser -v /dev/kfd /dev/dri/renderD* 2>/dev/null || true
+gpu_vram_in_use_count() {
+    local count
+    count=$(rocm-smi --showmemuse 2>/dev/null | awk '/VRAM%/ { if ($NF+0 > 0) n++ } END { print n+0 }' || true)
+    if [ -z "${count}" ]; then
+        echo 0
     else
-        echo "fuser not found"
+        echo "${count}"
     fi
-'
+}
 
-echo ""
-echo "========== GPU preflight: torch HIP allocation smoke test =========="
-exec_in "GPU_PREFLIGHT_ALLOCATION_MB='${GPU_PREFLIGHT_ALLOCATION_MB}' python3 - <<'PY'
+wait_for_gpu_memory_release() {
+    local i
+    local used=0
+    echo "Waiting for GPU memory to release after docker kill..."
+    for i in $(seq 1 "${GPU_PREFLIGHT_KILL_WAIT_SECONDS}"); do
+        used=$(gpu_vram_in_use_count)
+        if [ "${used}" -eq 0 ]; then
+            echo "GPU memory released after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "WARNING: GPU memory still in use after ${GPU_PREFLIGHT_KILL_WAIT_SECONDS}s (used GPUs=${used})"
+    return 1
+}
+
+kill_leftover_docker() {
+    local id
+    local name
+    local killed=0
+    local running
+
+    if [ "${GPU_PREFLIGHT_KILL_DOCKER}" != "1" ]; then
+        return 0
+    fi
+
+    echo ""
+    echo "========== GPU preflight: leftover docker containers =========="
+    if ! command -v "${ENGINE}" >/dev/null 2>&1; then
+        echo "${ENGINE} not found; skip leftover container cleanup"
+        return 0
+    fi
+
+    running=$("${ENGINE}" ps --format '{{.ID}} {{.Names}}' 2>/dev/null || true)
+    if [ -z "${running}" ]; then
+        echo "No running docker containers"
+        return 0
+    fi
+
+    echo "Running containers:"
+    "${ENGINE}" ps --format 'table {{.ID}}\t{{.Names}}\t{{.Status}}\t{{.Image}}' || true
+
+    while read -r id name; do
+        if [ -z "${id}" ]; then
+            continue
+        fi
+        if [ -n "${CONTAINER}" ] && { [ "${name}" = "${CONTAINER}" ] || [ "${id}" = "${CONTAINER}" ]; }; then
+            echo "  skip current container ${name} (${id})"
+            continue
+        fi
+        echo "  ${ENGINE} kill ${name} (${id})"
+        if "${ENGINE}" kill "${id}"; then
+            killed=1
+        else
+            echo "  ${ENGINE} kill failed; trying rm -f ${name} (${id})"
+            "${ENGINE}" rm -f "${id}" || true
+            killed=1
+        fi
+    done <<< "${running}"
+
+    if [ "${killed}" -eq 0 ]; then
+        echo "No leftover docker containers to kill"
+        return 0
+    fi
+
+    wait_for_gpu_memory_release || true
+}
+
+run_hip_smoke_test() {
+    echo ""
+    echo "========== GPU preflight: torch HIP allocation smoke test =========="
+    exec_in "GPU_PREFLIGHT_ALLOCATION_MB='${GPU_PREFLIGHT_ALLOCATION_MB}' python3 - <<'PY'
 import os
 import sys
 import traceback
@@ -114,3 +178,39 @@ except Exception:
     traceback.print_exc()
     sys.exit(12)
 PY"
+}
+
+print_probe "GPU preflight: ROCm memory and processes before HIP smoke test" '
+    set +e
+    command -v rocm-smi >/dev/null 2>&1 || { echo "rocm-smi not found"; exit 127; }
+    rocm-smi --showmemuse || true
+    rocm-smi --showpids || true
+    rocm-smi --showpidgpus || true
+'
+
+print_probe "GPU preflight: device file users before HIP smoke test" '
+    set +e
+    if command -v fuser >/dev/null 2>&1; then
+        fuser -v /dev/kfd /dev/dri/renderD* 2>/dev/null || true
+    else
+        echo "fuser not found"
+    fi
+'
+
+kill_leftover_docker
+
+set +e
+run_hip_smoke_test
+hip_rc=$?
+set -e
+
+if [ "${hip_rc}" -ne 0 ] && [ "${GPU_PREFLIGHT_KILL_DOCKER}" = "1" ]; then
+    echo "HIP smoke test failed (rc=${hip_rc}); retrying after leftover docker cleanup"
+    kill_leftover_docker
+    set +e
+    run_hip_smoke_test
+    hip_rc=$?
+    set -e
+fi
+
+exit "${hip_rc}"

--- a/.github/scripts/gpu_preflight_check.sh
+++ b/.github/scripts/gpu_preflight_check.sh
@@ -3,14 +3,17 @@
 #
 # This intentionally avoids importing ATOM or aiter. It records the visible GPU
 # process/memory state, then performs a minimal torch allocation on every visible
-# HIP device. If this fails, the node/container is already unhealthy before ATOM
-# participates in the run.
+# HIP device. Occupant kill is opt-in via GPU_PREFLIGHT_KILL_OCCUPANTS=1 (used by
+# vLLM/SGLang plugin CI). ATOM native CI leaves it off and only reports unhealthy
+# GPU state.
 
 set -euo pipefail
 
 CONTAINER="${1:-}"
 ENGINE="${2:-docker}"
 GPU_PREFLIGHT_ALLOCATION_MB="${GPU_PREFLIGHT_ALLOCATION_MB:-8}"
+GPU_PREFLIGHT_KILL_OCCUPANTS="${GPU_PREFLIGHT_KILL_OCCUPANTS:-0}"
+GPU_PREFLIGHT_KILL_WAIT_SECONDS="${GPU_PREFLIGHT_KILL_WAIT_SECONDS:-30}"
 
 case "$GPU_PREFLIGHT_ALLOCATION_MB" in
     ''|*[!0-9]*)
@@ -41,26 +44,164 @@ print_probe() {
     fi
 }
 
-print_probe "GPU preflight: ROCm memory and processes before HIP smoke test" '
-    set +e
-    command -v rocm-smi >/dev/null 2>&1 || { echo "rocm-smi not found"; exit 127; }
-    rocm-smi --showmemuse || true
-    rocm-smi --showpids || true
-    rocm-smi --showpidgpus || true
-'
+protected_pid_list() {
+    local p=$$
+    while [ -n "${p}" ] && [ "${p}" != "0" ]; do
+        echo "${p}"
+        if [ "${p}" = "1" ]; then
+            break
+        fi
+        p=$(ps -o ppid= -p "${p}" 2>/dev/null | tr -d ' ')
+    done
+}
 
-print_probe "GPU preflight: device file users before HIP smoke test" '
-    set +e
-    if command -v fuser >/dev/null 2>&1; then
-        fuser -v /dev/kfd /dev/dri/renderD* 2>/dev/null || true
-    else
-        echo "fuser not found"
+is_protected_pid() {
+    local pid="$1"
+    local comm
+    if grep -qx "${pid}" <<<"${PROTECTED_PIDS}"; then
+        return 0
     fi
-'
+    comm=$(ps -o comm= -p "${pid}" 2>/dev/null | awk '{print $1}')
+    case "${comm}" in
+        systemd|init|dockerd|docker-proxy|containerd|containerd-shim*|slurmd|slurmstepd|srun|sshd|udevd|dbus-daemon)
+            return 0
+            ;;
+    esac
+    return 1
+}
 
-echo ""
-echo "========== GPU preflight: torch HIP allocation smoke test =========="
-exec_in "GPU_PREFLIGHT_ALLOCATION_MB='${GPU_PREFLIGHT_ALLOCATION_MB}' python3 - <<'PY'
+collect_occupant_pids_from_rocm_smi() {
+    command -v rocm-smi >/dev/null 2>&1 || return 0
+    {
+        rocm-smi --showpids 2>/dev/null | awk '
+            $1 ~ /^[0-9]+$/ {
+                pid=$1
+                gpu=$3
+                vram=$4
+                if (pid+0 > 1 && (gpu+0 > 0 || vram+0 > 0)) print pid
+            }
+        '
+        rocm-smi --showpidgpus 2>/dev/null | awk '
+            /PID [0-9]+ is using [1-9]/ {
+                for (i = 1; i <= NF; i++) {
+                    if ($i == "PID") pid = $(i + 1)
+                    if ($i == "using") n = $(i + 1)
+                }
+                if (pid + 0 > 1 && n + 0 > 0) print pid
+            }
+        '
+    } | grep -E '^[0-9]+$' | sort -u
+}
+
+collect_occupant_pids() {
+    local host_pids=""
+    local container_pids=""
+    host_pids=$(collect_occupant_pids_from_rocm_smi || true)
+    if [ -n "${CONTAINER}" ]; then
+        container_pids=$(exec_in '
+            command -v rocm-smi >/dev/null 2>&1 || exit 0
+            {
+                rocm-smi --showpids 2>/dev/null | awk '"'"'
+                    $1 ~ /^[0-9]+$/ {
+                        pid=$1
+                        gpu=$3
+                        vram=$4
+                        if (pid+0 > 1 && (gpu+0 > 0 || vram+0 > 0)) print pid
+                    }
+                '"'"'
+                rocm-smi --showpidgpus 2>/dev/null | awk '"'"'
+                    /PID [0-9]+ is using [1-9]/ {
+                        for (i = 1; i <= NF; i++) {
+                            if ($i == "PID") pid = $(i + 1)
+                            if ($i == "using") n = $(i + 1)
+                        }
+                        if (pid + 0 > 1 && n + 0 > 0) print pid
+                    }
+                '"'"'
+            } | grep -E "^[0-9]+$" | sort -u
+        ' || true)
+    fi
+    printf '%s\n%s\n' "${host_pids}" "${container_pids}" | grep -E '^[0-9]+$' | sort -u
+}
+
+gpu_vram_in_use_count() {
+    local count
+    count=$(rocm-smi --showmemuse 2>/dev/null | awk '/VRAM%/ { if ($NF+0 > 0) n++ } END { print n+0 }' || true)
+    if [ -z "${count}" ]; then
+        echo 0
+    else
+        echo "${count}"
+    fi
+}
+
+wait_for_gpu_memory_release() {
+    local i
+    local used
+    echo "Waiting for GPU memory to release after killing occupants..."
+    for i in $(seq 1 "${GPU_PREFLIGHT_KILL_WAIT_SECONDS}"); do
+        used=$(gpu_vram_in_use_count)
+        if [ "${used}" -eq 0 ]; then
+            echo "GPU memory released after ${i}s"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "WARNING: GPU memory still in use after ${GPU_PREFLIGHT_KILL_WAIT_SECONDS}s (used GPUs=${used})"
+    return 1
+}
+
+kill_gpu_occupants() {
+    local pid
+    local occupants
+    local killed=0
+
+    if [ "${GPU_PREFLIGHT_KILL_OCCUPANTS}" != "1" ]; then
+        echo "GPU occupant kill disabled (GPU_PREFLIGHT_KILL_OCCUPANTS=${GPU_PREFLIGHT_KILL_OCCUPANTS})"
+        return 0
+    fi
+
+    occupants=$(collect_occupant_pids || true)
+    if [ -z "${occupants}" ]; then
+        echo "No GPU occupant PIDs found"
+        return 0
+    fi
+
+    echo ""
+    echo "========== GPU preflight: killing leftover GPU occupant PIDs =========="
+    echo "Occupant PIDs: ${occupants//$'\n'/ }"
+    for pid in ${occupants}; do
+        if is_protected_pid "${pid}"; then
+            echo "  skip protected PID ${pid} ($(ps -o comm= -p "${pid}" 2>/dev/null | awk '{print $1}'))"
+            continue
+        fi
+        echo "  kill TERM ${pid} ($(ps -o comm= -p "${pid}" 2>/dev/null | tr -s ' ' || echo unknown))"
+        kill -TERM "${pid}" 2>/dev/null || true
+        killed=1
+    done
+
+    if [ "${killed}" -eq 0 ]; then
+        echo "No occupant PIDs were eligible to kill"
+        return 0
+    fi
+
+    sleep 2
+    for pid in ${occupants}; do
+        if is_protected_pid "${pid}"; then
+            continue
+        fi
+        if kill -0 "${pid}" 2>/dev/null; then
+            echo "  kill KILL ${pid}"
+            kill -KILL "${pid}" 2>/dev/null || true
+        fi
+    done
+
+    wait_for_gpu_memory_release || true
+}
+
+run_hip_smoke_test() {
+    echo ""
+    echo "========== GPU preflight: torch HIP allocation smoke test =========="
+    exec_in "GPU_PREFLIGHT_ALLOCATION_MB='${GPU_PREFLIGHT_ALLOCATION_MB}' python3 - <<'PY'
 import os
 import sys
 import traceback
@@ -114,3 +255,43 @@ except Exception:
     traceback.print_exc()
     sys.exit(12)
 PY"
+}
+
+PROTECTED_PIDS="$(protected_pid_list)"
+
+print_probe "GPU preflight: ROCm memory and processes before HIP smoke test" '
+    set +e
+    command -v rocm-smi >/dev/null 2>&1 || { echo "rocm-smi not found"; exit 127; }
+    rocm-smi --showmemuse || true
+    rocm-smi --showpids || true
+    rocm-smi --showpidgpus || true
+'
+
+print_probe "GPU preflight: device file users before HIP smoke test" '
+    set +e
+    if command -v fuser >/dev/null 2>&1; then
+        fuser -v /dev/kfd /dev/dri/renderD* 2>/dev/null || true
+    else
+        echo "fuser not found"
+    fi
+'
+
+if [ "${GPU_PREFLIGHT_KILL_OCCUPANTS}" = "1" ]; then
+    kill_gpu_occupants
+fi
+
+set +e
+run_hip_smoke_test
+hip_rc=$?
+set -e
+
+if [ "${hip_rc}" -ne 0 ] && [ "${GPU_PREFLIGHT_KILL_OCCUPANTS}" = "1" ]; then
+    echo "HIP smoke test failed (rc=${hip_rc}); retrying after killing GPU occupants"
+    kill_gpu_occupants
+    set +e
+    run_hip_smoke_test
+    hip_rc=$?
+    set -e
+fi
+
+exit "${hip_rc}"

--- a/.github/scripts/gpu_preflight_check.sh
+++ b/.github/scripts/gpu_preflight_check.sh
@@ -3,17 +3,14 @@
 #
 # This intentionally avoids importing ATOM or aiter. It records the visible GPU
 # process/memory state, then performs a minimal torch allocation on every visible
-# HIP device. Occupant kill is opt-in via GPU_PREFLIGHT_KILL_OCCUPANTS=1 (used by
-# vLLM/SGLang plugin CI). ATOM native CI leaves it off and only reports unhealthy
-# GPU state.
+# HIP device. If this fails, the node/container is already unhealthy before ATOM
+# participates in the run.
 
 set -euo pipefail
 
 CONTAINER="${1:-}"
 ENGINE="${2:-docker}"
 GPU_PREFLIGHT_ALLOCATION_MB="${GPU_PREFLIGHT_ALLOCATION_MB:-8}"
-GPU_PREFLIGHT_KILL_OCCUPANTS="${GPU_PREFLIGHT_KILL_OCCUPANTS:-0}"
-GPU_PREFLIGHT_KILL_WAIT_SECONDS="${GPU_PREFLIGHT_KILL_WAIT_SECONDS:-30}"
 
 case "$GPU_PREFLIGHT_ALLOCATION_MB" in
     ''|*[!0-9]*)
@@ -44,164 +41,26 @@ print_probe() {
     fi
 }
 
-protected_pid_list() {
-    local p=$$
-    while [ -n "${p}" ] && [ "${p}" != "0" ]; do
-        echo "${p}"
-        if [ "${p}" = "1" ]; then
-            break
-        fi
-        p=$(ps -o ppid= -p "${p}" 2>/dev/null | tr -d ' ')
-    done
-}
+print_probe "GPU preflight: ROCm memory and processes before HIP smoke test" '
+    set +e
+    command -v rocm-smi >/dev/null 2>&1 || { echo "rocm-smi not found"; exit 127; }
+    rocm-smi --showmemuse || true
+    rocm-smi --showpids || true
+    rocm-smi --showpidgpus || true
+'
 
-is_protected_pid() {
-    local pid="$1"
-    local comm
-    if grep -qx "${pid}" <<<"${PROTECTED_PIDS}"; then
-        return 0
-    fi
-    comm=$(ps -o comm= -p "${pid}" 2>/dev/null | awk '{print $1}')
-    case "${comm}" in
-        systemd|init|dockerd|docker-proxy|containerd|containerd-shim*|slurmd|slurmstepd|srun|sshd|udevd|dbus-daemon)
-            return 0
-            ;;
-    esac
-    return 1
-}
-
-collect_occupant_pids_from_rocm_smi() {
-    command -v rocm-smi >/dev/null 2>&1 || return 0
-    {
-        rocm-smi --showpids 2>/dev/null | awk '
-            $1 ~ /^[0-9]+$/ {
-                pid=$1
-                gpu=$3
-                vram=$4
-                if (pid+0 > 1 && (gpu+0 > 0 || vram+0 > 0)) print pid
-            }
-        '
-        rocm-smi --showpidgpus 2>/dev/null | awk '
-            /PID [0-9]+ is using [1-9]/ {
-                for (i = 1; i <= NF; i++) {
-                    if ($i == "PID") pid = $(i + 1)
-                    if ($i == "using") n = $(i + 1)
-                }
-                if (pid + 0 > 1 && n + 0 > 0) print pid
-            }
-        '
-    } | grep -E '^[0-9]+$' | sort -u
-}
-
-collect_occupant_pids() {
-    local host_pids=""
-    local container_pids=""
-    host_pids=$(collect_occupant_pids_from_rocm_smi || true)
-    if [ -n "${CONTAINER}" ]; then
-        container_pids=$(exec_in '
-            command -v rocm-smi >/dev/null 2>&1 || exit 0
-            {
-                rocm-smi --showpids 2>/dev/null | awk '"'"'
-                    $1 ~ /^[0-9]+$/ {
-                        pid=$1
-                        gpu=$3
-                        vram=$4
-                        if (pid+0 > 1 && (gpu+0 > 0 || vram+0 > 0)) print pid
-                    }
-                '"'"'
-                rocm-smi --showpidgpus 2>/dev/null | awk '"'"'
-                    /PID [0-9]+ is using [1-9]/ {
-                        for (i = 1; i <= NF; i++) {
-                            if ($i == "PID") pid = $(i + 1)
-                            if ($i == "using") n = $(i + 1)
-                        }
-                        if (pid + 0 > 1 && n + 0 > 0) print pid
-                    }
-                '"'"'
-            } | grep -E "^[0-9]+$" | sort -u
-        ' || true)
-    fi
-    printf '%s\n%s\n' "${host_pids}" "${container_pids}" | grep -E '^[0-9]+$' | sort -u
-}
-
-gpu_vram_in_use_count() {
-    local count
-    count=$(rocm-smi --showmemuse 2>/dev/null | awk '/VRAM%/ { if ($NF+0 > 0) n++ } END { print n+0 }' || true)
-    if [ -z "${count}" ]; then
-        echo 0
+print_probe "GPU preflight: device file users before HIP smoke test" '
+    set +e
+    if command -v fuser >/dev/null 2>&1; then
+        fuser -v /dev/kfd /dev/dri/renderD* 2>/dev/null || true
     else
-        echo "${count}"
+        echo "fuser not found"
     fi
-}
+'
 
-wait_for_gpu_memory_release() {
-    local i
-    local used
-    echo "Waiting for GPU memory to release after killing occupants..."
-    for i in $(seq 1 "${GPU_PREFLIGHT_KILL_WAIT_SECONDS}"); do
-        used=$(gpu_vram_in_use_count)
-        if [ "${used}" -eq 0 ]; then
-            echo "GPU memory released after ${i}s"
-            return 0
-        fi
-        sleep 1
-    done
-    echo "WARNING: GPU memory still in use after ${GPU_PREFLIGHT_KILL_WAIT_SECONDS}s (used GPUs=${used})"
-    return 1
-}
-
-kill_gpu_occupants() {
-    local pid
-    local occupants
-    local killed=0
-
-    if [ "${GPU_PREFLIGHT_KILL_OCCUPANTS}" != "1" ]; then
-        echo "GPU occupant kill disabled (GPU_PREFLIGHT_KILL_OCCUPANTS=${GPU_PREFLIGHT_KILL_OCCUPANTS})"
-        return 0
-    fi
-
-    occupants=$(collect_occupant_pids || true)
-    if [ -z "${occupants}" ]; then
-        echo "No GPU occupant PIDs found"
-        return 0
-    fi
-
-    echo ""
-    echo "========== GPU preflight: killing leftover GPU occupant PIDs =========="
-    echo "Occupant PIDs: ${occupants//$'\n'/ }"
-    for pid in ${occupants}; do
-        if is_protected_pid "${pid}"; then
-            echo "  skip protected PID ${pid} ($(ps -o comm= -p "${pid}" 2>/dev/null | awk '{print $1}'))"
-            continue
-        fi
-        echo "  kill TERM ${pid} ($(ps -o comm= -p "${pid}" 2>/dev/null | tr -s ' ' || echo unknown))"
-        kill -TERM "${pid}" 2>/dev/null || true
-        killed=1
-    done
-
-    if [ "${killed}" -eq 0 ]; then
-        echo "No occupant PIDs were eligible to kill"
-        return 0
-    fi
-
-    sleep 2
-    for pid in ${occupants}; do
-        if is_protected_pid "${pid}"; then
-            continue
-        fi
-        if kill -0 "${pid}" 2>/dev/null; then
-            echo "  kill KILL ${pid}"
-            kill -KILL "${pid}" 2>/dev/null || true
-        fi
-    done
-
-    wait_for_gpu_memory_release || true
-}
-
-run_hip_smoke_test() {
-    echo ""
-    echo "========== GPU preflight: torch HIP allocation smoke test =========="
-    exec_in "GPU_PREFLIGHT_ALLOCATION_MB='${GPU_PREFLIGHT_ALLOCATION_MB}' python3 - <<'PY'
+echo ""
+echo "========== GPU preflight: torch HIP allocation smoke test =========="
+exec_in "GPU_PREFLIGHT_ALLOCATION_MB='${GPU_PREFLIGHT_ALLOCATION_MB}' python3 - <<'PY'
 import os
 import sys
 import traceback
@@ -255,43 +114,3 @@ except Exception:
     traceback.print_exc()
     sys.exit(12)
 PY"
-}
-
-PROTECTED_PIDS="$(protected_pid_list)"
-
-print_probe "GPU preflight: ROCm memory and processes before HIP smoke test" '
-    set +e
-    command -v rocm-smi >/dev/null 2>&1 || { echo "rocm-smi not found"; exit 127; }
-    rocm-smi --showmemuse || true
-    rocm-smi --showpids || true
-    rocm-smi --showpidgpus || true
-'
-
-print_probe "GPU preflight: device file users before HIP smoke test" '
-    set +e
-    if command -v fuser >/dev/null 2>&1; then
-        fuser -v /dev/kfd /dev/dri/renderD* 2>/dev/null || true
-    else
-        echo "fuser not found"
-    fi
-'
-
-if [ "${GPU_PREFLIGHT_KILL_OCCUPANTS}" = "1" ]; then
-    kill_gpu_occupants
-fi
-
-set +e
-run_hip_smoke_test
-hip_rc=$?
-set -e
-
-if [ "${hip_rc}" -ne 0 ] && [ "${GPU_PREFLIGHT_KILL_OCCUPANTS}" = "1" ]; then
-    echo "HIP smoke test failed (rc=${hip_rc}); retrying after killing GPU occupants"
-    kill_gpu_occupants
-    set +e
-    run_hip_smoke_test
-    hip_rc=$?
-    set -e
-fi
-
-exit "${hip_rc}"

--- a/.github/scripts/plugin_ci/cache_model.sh
+++ b/.github/scripts/plugin_ci/cache_model.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Shared Hugging Face cache helpers for plugin CI (vLLM / SGLang).
+# Callers must set CONTAINER_NAME. MODEL_CACHE_MOUNT and HF_TOKEN are optional.
+
+plugin_ci_hf_id() {
+  local model_id="${1:-}"
+  model_id="${model_id#/models/}"
+  printf '%s' "${model_id}"
+}
+
+plugin_ci_download_model() {
+  local model_id="${1:-}"
+  local hf_id
+  hf_id="$(plugin_ci_hf_id "${model_id}")"
+  if [[ -z "${hf_id}" ]]; then
+    echo "ERROR: plugin_ci_download_model requires a model id" >&2
+    return 2
+  fi
+  if [[ -z "${MODEL_CACHE_MOUNT:-}" ]]; then
+    printf '%s' "${hf_id}"
+    return 0
+  fi
+
+  local model_dir="/models/${hf_id}"
+  docker exec \
+    -e HF_TOKEN="${HF_TOKEN:-}" \
+    -e MODEL_ID="${hf_id}" \
+    -e TARGET_DIR="${model_dir}" \
+    -e MODEL_USE_LOCK="true" \
+    -e MODEL_DOWNLOAD_TIMEOUT="3h" \
+    -e MODEL_LOCK_WAIT_SECONDS="7200" \
+    -e MODEL_LOCK_POLL_INTERVAL="30" \
+    -e MODEL_PROGRESS_INTERVAL="60" \
+    "${CONTAINER_NAME}" \
+    bash -lc 'bash /workspace/.github/scripts/download_model_with_lock.sh "$MODEL_ID" "$TARGET_DIR"' >&2
+  printf '%s' "${model_dir}"
+}
+
+plugin_ci_infer_draft_model_id() {
+  DRAFT_MODEL_PATH="${1:-}" EXTRA_ARGS="${2:-}" python3 - <<'PY'
+import os
+import re
+import shlex
+
+explicit = os.environ.get("DRAFT_MODEL_PATH", "").strip()
+if explicit:
+    print(explicit)
+    raise SystemExit(0)
+
+raw = os.environ.get("EXTRA_ARGS", "")
+tokens = []
+try:
+    tokens = shlex.split(raw)
+except ValueError:
+    tokens = raw.split()
+
+for flag in ("--speculative-draft-model-path", "--draft-model"):
+    if flag in tokens:
+        index = tokens.index(flag)
+        if index + 1 < len(tokens):
+            print(tokens[index + 1])
+            raise SystemExit(0)
+
+match = re.search(r'"model"\s*:\s*"([^"]+)"', raw)
+if match:
+    print(match.group(1))
+PY
+}
+
+plugin_ci_rewrite_extra_args() {
+  EXTRA_ARGS="${1:-}" DRAFT_ID="${2:-}" RESOLVED_PATH="${3:-}" python3 - <<'PY'
+import os
+
+args = os.environ.get("EXTRA_ARGS", "")
+draft_id = os.environ.get("DRAFT_ID", "").strip()
+resolved = os.environ.get("RESOLVED_PATH", "").strip()
+if not args or not draft_id or not resolved:
+    print(args, end="")
+    raise SystemExit(0)
+
+hf_id = draft_id[len("/models/") :] if draft_id.startswith("/models/") else draft_id
+variants = []
+for value in (draft_id, hf_id, f"/models/{hf_id}"):
+    if value and value not in variants:
+        variants.append(value)
+
+for value in sorted(variants, key=len, reverse=True):
+    args = args.replace(value, "@@PLUGIN_CI_DRAFT@@")
+args = args.replace("@@PLUGIN_CI_DRAFT@@", resolved)
+print(args, end="")
+PY
+}

--- a/.github/scripts/plugin_ci/run_sglang_ci.sh
+++ b/.github/scripts/plugin_ci/run_sglang_ci.sh
@@ -188,6 +188,8 @@ docker run -dt --device=/dev/kfd ${DEVICE_FLAG} \
   --name "${CONTAINER_NAME}" \
   "${SGLANG_IMAGE_TAG}"
 
+GPU_PREFLIGHT_KILL_OCCUPANTS=1 bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
+
 model_dir="/models/${MODEL_PATH}"
 if [[ -n "${MODEL_CACHE_MOUNT}" ]]; then
   docker exec \

--- a/.github/scripts/plugin_ci/run_sglang_ci.sh
+++ b/.github/scripts/plugin_ci/run_sglang_ci.sh
@@ -41,6 +41,7 @@ trap cleanup EXIT
 
 MODEL_NAME="${MATRIX_MODEL_NAME:-}"
 MODEL_PATH="${MATRIX_MODEL_PATH:-}"
+DRAFT_MODEL_PATH="${MATRIX_DRAFT_MODEL_PATH:-}"
 EXTRA_ARGS="${MATRIX_EXTRA_ARGS:-}"
 ENV_VARS="${MATRIX_ENV_VARS:-}"
 LM_EVAL_NUM_FEWSHOT="${MATRIX_LM_EVAL_NUM_FEWSHOT:-3}"
@@ -48,6 +49,9 @@ LM_EVAL_NUM_CONCURRENT="${MATRIX_LM_EVAL_NUM_CONCURRENT:-65}"
 LM_EVAL_USE_CHAT_COMPLETIONS="${MATRIX_LM_EVAL_USE_CHAT_COMPLETIONS:-0}"
 LM_EVAL_EXTRA_MODEL_ARGS="${MATRIX_LM_EVAL_EXTRA_MODEL_ARGS:-}"
 ACCURACY_TEST_THRESHOLD="${MATRIX_ACCURACY_TEST_THRESHOLD:-0.0}"
+
+# shellcheck disable=SC1091
+source .github/scripts/plugin_ci/cache_model.sh
 
 if [[ -z "${MODEL_NAME}" || -z "${MODEL_PATH}" ]]; then
   echo "ERROR: MATRIX_MODEL_NAME and MATRIX_MODEL_PATH are required" >&2
@@ -190,22 +194,14 @@ docker run -dt --device=/dev/kfd ${DEVICE_FLAG} \
 
 GPU_PREFLIGHT_KILL_DOCKER=1 bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
 
-model_dir="/models/${MODEL_PATH}"
-if [[ -n "${MODEL_CACHE_MOUNT}" ]]; then
-  docker exec \
-    -e HF_TOKEN="${HF_TOKEN:-}" \
-    -e MODEL_ID="${MODEL_PATH}" \
-    -e TARGET_DIR="${model_dir}" \
-    -e MODEL_USE_LOCK="true" \
-    -e MODEL_DOWNLOAD_TIMEOUT="3h" \
-    -e MODEL_LOCK_WAIT_SECONDS="7200" \
-    -e MODEL_LOCK_POLL_INTERVAL="30" \
-    -e MODEL_PROGRESS_INTERVAL="60" \
-    "${CONTAINER_NAME}" \
-    bash -lc 'bash /workspace/.github/scripts/download_model_with_lock.sh "$MODEL_ID" "$TARGET_DIR"'
-  SGLANG_RESOLVED_MODEL_PATH="/models/${MODEL_PATH}"
-else
-  SGLANG_RESOLVED_MODEL_PATH="${MODEL_PATH}"
+SGLANG_RESOLVED_MODEL_PATH="$(plugin_ci_download_model "${MODEL_PATH}")"
+DRAFT_ID="$(plugin_ci_infer_draft_model_id "${DRAFT_MODEL_PATH}" "${EXTRA_ARGS}")"
+if [[ -n "${DRAFT_ID}" ]]; then
+  DRAFT_HF_ID="$(plugin_ci_hf_id "${DRAFT_ID}")"
+  if [[ "${DRAFT_HF_ID}" != "$(plugin_ci_hf_id "${MODEL_PATH}")" ]]; then
+    DRAFT_RESOLVED_PATH="$(plugin_ci_download_model "${DRAFT_HF_ID}")"
+    EXTRA_ARGS="$(plugin_ci_rewrite_extra_args "${EXTRA_ARGS}" "${DRAFT_HF_ID}" "${DRAFT_RESOLVED_PATH}")"
+  fi
 fi
 
 docker exec \

--- a/.github/scripts/plugin_ci/run_sglang_ci.sh
+++ b/.github/scripts/plugin_ci/run_sglang_ci.sh
@@ -188,8 +188,6 @@ docker run -dt --device=/dev/kfd ${DEVICE_FLAG} \
   --name "${CONTAINER_NAME}" \
   "${SGLANG_IMAGE_TAG}"
 
-GPU_PREFLIGHT_KILL_OCCUPANTS=1 bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
-
 model_dir="/models/${MODEL_PATH}"
 if [[ -n "${MODEL_CACHE_MOUNT}" ]]; then
   docker exec \

--- a/.github/scripts/plugin_ci/run_sglang_ci.sh
+++ b/.github/scripts/plugin_ci/run_sglang_ci.sh
@@ -188,6 +188,8 @@ docker run -dt --device=/dev/kfd ${DEVICE_FLAG} \
   --name "${CONTAINER_NAME}" \
   "${SGLANG_IMAGE_TAG}"
 
+GPU_PREFLIGHT_KILL_DOCKER=1 bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
+
 model_dir="/models/${MODEL_PATH}"
 if [[ -n "${MODEL_CACHE_MOUNT}" ]]; then
   docker exec \

--- a/.github/scripts/plugin_ci/run_vllm_ci.sh
+++ b/.github/scripts/plugin_ci/run_vllm_ci.sh
@@ -204,7 +204,7 @@ docker run -dt --device=/dev/kfd ${DEVICE_FLAG} \
   --name "${CONTAINER_NAME}" \
   "${OOT_IMAGE_TAG}"
 
-bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
+GPU_PREFLIGHT_KILL_DOCKER=1 bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
 
 model_dir="/models/${MODEL_PATH}"
 if [[ -n "${MODEL_CACHE_MOUNT}" ]]; then

--- a/.github/scripts/plugin_ci/run_vllm_ci.sh
+++ b/.github/scripts/plugin_ci/run_vllm_ci.sh
@@ -42,6 +42,7 @@ trap cleanup EXIT
 
 MODEL_NAME="${MATRIX_MODEL_NAME:-}"
 MODEL_PATH="${MATRIX_MODEL_PATH:-}"
+DRAFT_MODEL_PATH="${MATRIX_DRAFT_MODEL_PATH:-}"
 EXTRA_ARGS="${MATRIX_EXTRA_ARGS:-}"
 CLIENT_COMMAND="${MATRIX_CLIENT_COMMAND:-}"
 ENV_VARS="${MATRIX_ENV_VARS:-}"
@@ -55,6 +56,8 @@ fi
 
 # shellcheck disable=SC1091
 source atom/plugin/vllm/vllm-version.env
+# shellcheck disable=SC1091
+source .github/scripts/plugin_ci/cache_model.sh
 
 REBUILD_ATOM_BASE=false
 if [[ -n "${PR_BASE_SHA}" && -n "${PR_HEAD_SHA}" ]]; then
@@ -206,22 +209,14 @@ docker run -dt --device=/dev/kfd ${DEVICE_FLAG} \
 
 GPU_PREFLIGHT_KILL_DOCKER=1 bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
 
-model_dir="/models/${MODEL_PATH}"
-if [[ -n "${MODEL_CACHE_MOUNT}" ]]; then
-  docker exec \
-    -e HF_TOKEN="${HF_TOKEN:-}" \
-    -e MODEL_ID="${MODEL_PATH}" \
-    -e TARGET_DIR="${model_dir}" \
-    -e MODEL_USE_LOCK="true" \
-    -e MODEL_DOWNLOAD_TIMEOUT="3h" \
-    -e MODEL_LOCK_WAIT_SECONDS="7200" \
-    -e MODEL_LOCK_POLL_INTERVAL="30" \
-    -e MODEL_PROGRESS_INTERVAL="60" \
-    "${CONTAINER_NAME}" \
-    bash -lc 'bash /workspace/.github/scripts/download_model_with_lock.sh "$MODEL_ID" "$TARGET_DIR"'
-  OOT_RESOLVED_MODEL_PATH="/models/${MODEL_PATH}"
-else
-  OOT_RESOLVED_MODEL_PATH="${MODEL_PATH}"
+OOT_RESOLVED_MODEL_PATH="$(plugin_ci_download_model "${MODEL_PATH}")"
+DRAFT_ID="$(plugin_ci_infer_draft_model_id "${DRAFT_MODEL_PATH}" "${EXTRA_ARGS}")"
+if [[ -n "${DRAFT_ID}" ]]; then
+  DRAFT_HF_ID="$(plugin_ci_hf_id "${DRAFT_ID}")"
+  if [[ "${DRAFT_HF_ID}" != "$(plugin_ci_hf_id "${MODEL_PATH}")" ]]; then
+    DRAFT_RESOLVED_PATH="$(plugin_ci_download_model "${DRAFT_HF_ID}")"
+    EXTRA_ARGS="$(plugin_ci_rewrite_extra_args "${EXTRA_ARGS}" "${DRAFT_HF_ID}" "${DRAFT_RESOLVED_PATH}")"
+  fi
 fi
 
 docker exec \

--- a/.github/scripts/plugin_ci/run_vllm_ci.sh
+++ b/.github/scripts/plugin_ci/run_vllm_ci.sh
@@ -204,7 +204,7 @@ docker run -dt --device=/dev/kfd ${DEVICE_FLAG} \
   --name "${CONTAINER_NAME}" \
   "${OOT_IMAGE_TAG}"
 
-bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
+GPU_PREFLIGHT_KILL_OCCUPANTS=1 bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
 
 model_dir="/models/${MODEL_PATH}"
 if [[ -n "${MODEL_CACHE_MOUNT}" ]]; then

--- a/.github/scripts/plugin_ci/run_vllm_ci.sh
+++ b/.github/scripts/plugin_ci/run_vllm_ci.sh
@@ -204,7 +204,7 @@ docker run -dt --device=/dev/kfd ${DEVICE_FLAG} \
   --name "${CONTAINER_NAME}" \
   "${OOT_IMAGE_TAG}"
 
-GPU_PREFLIGHT_KILL_OCCUPANTS=1 bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
+bash .github/scripts/gpu_preflight_check.sh "${CONTAINER_NAME}" docker
 
 model_dir="/models/${MODEL_PATH}"
 if [[ -n "${MODEL_CACHE_MOUNT}" ]]; then

--- a/.github/scripts/prepare_dashboard_data.py
+++ b/.github/scripts/prepare_dashboard_data.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Validate and normalize a github-action-benchmark data.js file.
+
+github-action-benchmark reads data.js by passing everything after
+``window.BENCHMARK_DATA = `` directly to ``JSON.parse``.  Keep the file valid
+for that parser while preserving the existing formatting and history.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Tuple
+
+PREFIX = "window.BENCHMARK_DATA = "
+
+
+def parse_data(text: str) -> Tuple[Any, bool]:
+    """Parse data.js and return ``(data, has_trailing_semicolon)``."""
+    if not text.startswith(PREFIX):
+        raise ValueError(f"missing {PREFIX!r} prefix")
+
+    payload = text[len(PREFIX) :].strip()
+    has_trailing_semicolon = payload.endswith(";")
+    if has_trailing_semicolon:
+        payload = payload[:-1].rstrip()
+
+    data = json.loads(payload)
+    if not isinstance(data, dict):
+        raise ValueError("dashboard data must be a JSON object")
+
+    entries = data.get("entries")
+    if not isinstance(entries, dict):
+        raise ValueError("dashboard data must contain an 'entries' object")
+    if not entries or not any(
+        isinstance(value, list) and value for value in entries.values()
+    ):
+        raise ValueError("dashboard data contains no benchmark entries")
+
+    return data, has_trailing_semicolon
+
+
+def normalize(text: str) -> Tuple[str, bool]:
+    """Validate text and remove only a terminal JavaScript semicolon."""
+    _, has_trailing_semicolon = parse_data(text)
+    if not has_trailing_semicolon:
+        return text, False
+
+    content_end = len(text.rstrip())
+    normalized = text[: content_end - 1] + text[content_end:]
+    return normalized, True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("data_js", type=Path)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Remove a terminal semicolon in place after validation.",
+    )
+    args = parser.parse_args()
+
+    if not args.data_js.exists():
+        print(f"{args.data_js}: does not exist; allowing first dashboard run")
+        return 0
+
+    try:
+        original = args.data_js.read_text(encoding="utf-8")
+        normalized, changed = normalize(original)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"{args.data_js}: invalid dashboard data: {exc}", file=sys.stderr)
+        return 1
+
+    if changed and args.write:
+        args.data_js.write_text(normalized, encoding="utf-8")
+        print(f"{args.data_js}: removed terminal semicolon")
+    elif changed:
+        print(f"{args.data_js}: valid but requires normalization")
+    else:
+        print(f"{args.data_js}: valid")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/prepare_dashboard_data.py
+++ b/.github/scripts/prepare_dashboard_data.py
@@ -12,42 +12,50 @@ import sys
 from pathlib import Path
 from typing import Any
 
-PREFIX = "window.BENCHMARK_DATA = "
+PREFIX = b"window.BENCHMARK_DATA = "
 
 
-def parse_data(text: str) -> tuple[Any, bool]:
-    """Parse data.js and return ``(data, has_trailing_semicolon)``."""
-    if not text.startswith(PREFIX):
-        raise ValueError(f"missing {PREFIX!r} prefix")
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON constant {value!r}")
 
-    payload = text[len(PREFIX) :].strip()
-    has_trailing_semicolon = payload.endswith(";")
-    if has_trailing_semicolon:
-        payload = payload[:-1].rstrip()
 
-    data = json.loads(payload)
-    if not isinstance(data, dict):
-        raise TypeError("dashboard data must be a JSON object")
-
+def entry_count(data: Any) -> int:
     entries = data.get("entries")
     if not isinstance(entries, dict):
         raise TypeError("dashboard data must contain an 'entries' object")
-    if not entries or not any(
-        isinstance(value, list) and value for value in entries.values()
-    ):
-        raise ValueError("dashboard data contains no benchmark entries")
+    return sum(len(value) for value in entries.values() if isinstance(value, list))
+
+
+def parse_data(text: bytes) -> tuple[Any, bool]:
+    """Parse data.js and return ``(data, has_trailing_semicolon)``."""
+    if not text.startswith(PREFIX):
+        raise ValueError(f"missing {PREFIX.decode()!r} prefix")
+
+    payload = text[len(PREFIX) :].strip()
+    has_trailing_semicolon = False
+    while payload.endswith(b";"):
+        has_trailing_semicolon = True
+        payload = payload[:-1].rstrip()
+
+    data = json.loads(payload.decode("utf-8"), parse_constant=_reject_json_constant)
+    if not isinstance(data, dict):
+        raise TypeError("dashboard data must be a JSON object")
+
+    entry_count(data)
 
     return data, has_trailing_semicolon
 
 
-def normalize(text: str) -> tuple[str, bool]:
+def normalize(text: bytes) -> tuple[bytes, bool]:
     """Validate text and remove only a terminal JavaScript semicolon."""
     _, has_trailing_semicolon = parse_data(text)
     if not has_trailing_semicolon:
         return text, False
 
-    content_end = len(text.rstrip())
-    normalized = text[: content_end - 1] + text[content_end:]
+    content = text.rstrip()
+    while content.endswith(b";"):
+        content = content[:-1].rstrip()
+    normalized = content + text[len(text.rstrip()) :]
     return normalized, True
 
 
@@ -59,27 +67,42 @@ def main() -> int:
         action="store_true",
         help="Remove a terminal semicolon in place after validation.",
     )
+    parser.add_argument(
+        "--min-entries",
+        type=int,
+        default=None,
+        help="Require at least this many benchmark entries after validation.",
+    )
     args = parser.parse_args()
 
-    if not args.data_js.exists():
+    if not args.data_js.is_file():
         print(f"{args.data_js}: does not exist; allowing first dashboard run")
+        print("entry_count=0")
         return 0
 
     try:
-        original = args.data_js.read_text(encoding="utf-8")
+        original = args.data_js.read_bytes()
         normalized, changed = normalize(original)
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        data, _ = parse_data(normalized)
+        count = entry_count(data)
+        if args.min_entries is not None and count < args.min_entries:
+            raise ValueError(
+                f"dashboard entry count decreased from {args.min_entries} to {count}"
+            )
+    except (OSError, TypeError, ValueError) as exc:
         print(f"{args.data_js}: invalid dashboard data: {exc}", file=sys.stderr)
         return 1
 
     if changed and args.write:
-        args.data_js.write_text(normalized, encoding="utf-8")
+        args.data_js.write_bytes(normalized)
         print(f"{args.data_js}: removed terminal semicolon")
     elif changed:
-        print(f"{args.data_js}: valid but requires normalization")
+        print(f"{args.data_js}: valid but requires normalization", file=sys.stderr)
+        return 1
     else:
         print(f"{args.data_js}: valid")
 
+    print(f"entry_count={count}")
     return 0
 
 

--- a/.github/scripts/prepare_dashboard_data.py
+++ b/.github/scripts/prepare_dashboard_data.py
@@ -10,12 +10,12 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any
 
 PREFIX = "window.BENCHMARK_DATA = "
 
 
-def parse_data(text: str) -> Tuple[Any, bool]:
+def parse_data(text: str) -> tuple[Any, bool]:
     """Parse data.js and return ``(data, has_trailing_semicolon)``."""
     if not text.startswith(PREFIX):
         raise ValueError(f"missing {PREFIX!r} prefix")
@@ -27,11 +27,11 @@ def parse_data(text: str) -> Tuple[Any, bool]:
 
     data = json.loads(payload)
     if not isinstance(data, dict):
-        raise ValueError("dashboard data must be a JSON object")
+        raise TypeError("dashboard data must be a JSON object")
 
     entries = data.get("entries")
     if not isinstance(entries, dict):
-        raise ValueError("dashboard data must contain an 'entries' object")
+        raise TypeError("dashboard data must contain an 'entries' object")
     if not entries or not any(
         isinstance(value, list) and value for value in entries.values()
     ):
@@ -40,7 +40,7 @@ def parse_data(text: str) -> Tuple[Any, bool]:
     return data, has_trailing_semicolon
 
 
-def normalize(text: str) -> Tuple[str, bool]:
+def normalize(text: str) -> tuple[str, bool]:
     """Validate text and remove only a terminal JavaScript semicolon."""
     _, has_trailing_semicolon = parse_data(text)
     if not has_trailing_semicolon:

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -261,6 +261,22 @@ jobs:
             --default-backend ATOM \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Prepare existing dashboard data
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
+          if [ -f benchmark-dashboard/data.js ]; then
+            git add benchmark-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store benchmark result to dashboard
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -268,6 +284,7 @@ jobs:
           output-file-path: benchmark-action-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
+          skip-fetch-gh-pages: true
           auto-push: false
           alert-threshold: "80%"
           comment-on-alert: true

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -262,20 +262,10 @@ jobs:
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Prepare existing dashboard data
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
-          if [ -f benchmark-dashboard/data.js ]; then
-            git add benchmark-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
 
       - name: Store benchmark result to dashboard
         uses: benchmark-action/github-action-benchmark@v1
@@ -284,13 +274,18 @@ jobs:
           output-file-path: benchmark-action-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
-          skip-fetch-gh-pages: true
           auto-push: false
           alert-threshold: "80%"
           comment-on-alert: true
           fail-on-alert: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
 
       - name: Deploy custom dashboard to gh-pages
         run: |

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -746,6 +746,9 @@ jobs:
     name: Update SGLANG accuracy dashboard
     needs: [sglang-model-accuracy-mi355, sglang-model-accuracy-mi308]
     if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard)) }}
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -800,20 +803,10 @@ jobs:
 
       - name: Prepare existing dashboard data
         if: steps.transform.outputs.entries_count != '0' && steps.transform.outputs.entries_count != ''
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
-          if [ -f benchmark-dashboard/data.js ]; then
-            git add benchmark-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
 
       - name: Store SGLANG accuracy result to dashboard
         if: steps.transform.outputs.entries_count != '0' && steps.transform.outputs.entries_count != ''
@@ -823,7 +816,17 @@ jobs:
           output-file-path: accuracy-benchmark-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
-          skip-fetch-gh-pages: true
-          auto-push: true
+          auto-push: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        if: steps.transform.outputs.entries_count != '0' && steps.transform.outputs.entries_count != ''
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
+
+      - name: Push dashboard data
+        if: steps.transform.outputs.entries_count != '0' && steps.transform.outputs.entries_count != ''
+        run: git push origin gh-pages

--- a/.github/workflows/atom-sglang-accuracy-validation.yaml
+++ b/.github/workflows/atom-sglang-accuracy-validation.yaml
@@ -798,6 +798,23 @@ jobs:
             echo "::warning::No valid SGLANG accuracy entries were produced. Check that the result JSON files contain 'results.gsm8k[\"exact_match,flexible-extract\"]'."
           fi
 
+      - name: Prepare existing dashboard data
+        if: steps.transform.outputs.entries_count != '0' && steps.transform.outputs.entries_count != ''
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
+          if [ -f benchmark-dashboard/data.js ]; then
+            git add benchmark-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store SGLANG accuracy result to dashboard
         if: steps.transform.outputs.entries_count != '0' && steps.transform.outputs.entries_count != ''
         uses: benchmark-action/github-action-benchmark@v1
@@ -806,6 +823,7 @@ jobs:
           output-file-path: accuracy-benchmark-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
+          skip-fetch-gh-pages: true
           auto-push: true
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -1638,20 +1638,10 @@ jobs:
 
       - name: Prepare existing dashboard data
         if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
-          if [ -f benchmark-dashboard/data.js ]; then
-            git add benchmark-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
 
       - name: Store benchmark result to dashboard
         if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
@@ -1661,13 +1651,19 @@ jobs:
           output-file-path: benchmark-action-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
-          skip-fetch-gh-pages: true
           auto-push: false
           alert-threshold: "80%"
           comment-on-alert: true
           fail-on-alert: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
 
       - name: Push dashboard data to gh-pages
         if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'

--- a/.github/workflows/atom-sglang-benchmark.yaml
+++ b/.github/workflows/atom-sglang-benchmark.yaml
@@ -1636,6 +1636,23 @@ jobs:
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --default-backend "ATOM-SGLang"
 
+      - name: Prepare existing dashboard data
+        if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
+          if [ -f benchmark-dashboard/data.js ]; then
+            git add benchmark-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store benchmark result to dashboard
         if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
         uses: benchmark-action/github-action-benchmark@v1
@@ -1644,6 +1661,7 @@ jobs:
           output-file-path: benchmark-action-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
+          skip-fetch-gh-pages: true
           auto-push: false
           alert-threshold: "80%"
           comment-on-alert: true

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -752,6 +752,22 @@ jobs:
           echo "=== Generated entries ==="
           cat accuracy-benchmark-input.json
 
+      - name: Prepare existing dashboard data
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
+          if [ -f benchmark-dashboard/data.js ]; then
+            git add benchmark-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store accuracy result to dashboard
         if: hashFiles('accuracy-benchmark-input.json') != ''
         uses: benchmark-action/github-action-benchmark@v1
@@ -760,6 +776,7 @@ jobs:
           output-file-path: accuracy-benchmark-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
+          skip-fetch-gh-pages: true
           auto-push: true
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -753,20 +753,11 @@ jobs:
           cat accuracy-benchmark-input.json
 
       - name: Prepare existing dashboard data
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
-          if [ -f benchmark-dashboard/data.js ]; then
-            git add benchmark-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        if: hashFiles('accuracy-benchmark-input.json') != ''
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
 
       - name: Store accuracy result to dashboard
         if: hashFiles('accuracy-benchmark-input.json') != ''
@@ -776,7 +767,17 @@ jobs:
           output-file-path: accuracy-benchmark-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
-          skip-fetch-gh-pages: true
-          auto-push: true
+          auto-push: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        if: hashFiles('accuracy-benchmark-input.json') != ''
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
+
+      - name: Push dashboard data
+        if: hashFiles('accuracy-benchmark-input.json') != ''
+        run: git push origin gh-pages

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -1616,6 +1616,23 @@ jobs:
           echo "=== Generated entries ==="
           cat accuracy-benchmark-input.json
 
+      - name: Prepare existing dashboard data
+        if: steps.downloaded.outputs.json_count != '0'
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
+          if [ -f benchmark-dashboard/data.js ]; then
+            git add benchmark-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store OOT accuracy result to dashboard
         if: steps.downloaded.outputs.json_count != '0'
         uses: benchmark-action/github-action-benchmark@v1
@@ -1624,6 +1641,7 @@ jobs:
           output-file-path: accuracy-benchmark-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
+          skip-fetch-gh-pages: true
           auto-push: true
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/atom-vllm-accuracy-validation.yaml
+++ b/.github/workflows/atom-vllm-accuracy-validation.yaml
@@ -1570,6 +1570,9 @@ jobs:
       - oot-model-accuracy-priority-2
       - oot-model-accuracy-priority-3
     if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.upload_accuracy_to_dashboard)) }}
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -1618,20 +1621,10 @@ jobs:
 
       - name: Prepare existing dashboard data
         if: steps.downloaded.outputs.json_count != '0'
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
-          if [ -f benchmark-dashboard/data.js ]; then
-            git add benchmark-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
 
       - name: Store OOT accuracy result to dashboard
         if: steps.downloaded.outputs.json_count != '0'
@@ -1641,7 +1634,17 @@ jobs:
           output-file-path: accuracy-benchmark-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
-          skip-fetch-gh-pages: true
-          auto-push: true
+          auto-push: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        if: steps.downloaded.outputs.json_count != '0'
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
+
+      - name: Push dashboard data
+        if: steps.downloaded.outputs.json_count != '0'
+        run: git push origin gh-pages

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -2220,6 +2220,23 @@ jobs:
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --default-backend "ATOM-vLLM"
 
+      - name: Prepare existing dashboard data
+        if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
+          if [ -f benchmark-dashboard/data.js ]; then
+            git add benchmark-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store benchmark result to dashboard
         if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
         uses: benchmark-action/github-action-benchmark@v1
@@ -2228,6 +2245,7 @@ jobs:
           output-file-path: benchmark-action-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
+          skip-fetch-gh-pages: true
           auto-push: false
           alert-threshold: "80%"
           comment-on-alert: true

--- a/.github/workflows/atom-vllm-benchmark.yaml
+++ b/.github/workflows/atom-vllm-benchmark.yaml
@@ -2222,20 +2222,10 @@ jobs:
 
       - name: Prepare existing dashboard data
         if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
-          if [ -f benchmark-dashboard/data.js ]; then
-            git add benchmark-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
 
       - name: Store benchmark result to dashboard
         if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
@@ -2245,13 +2235,19 @@ jobs:
           output-file-path: benchmark-action-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
-          skip-fetch-gh-pages: true
           auto-push: false
           alert-threshold: "80%"
           comment-on-alert: true
           fail-on-alert: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
 
       - name: Push dashboard data to gh-pages
         if: needs.resolve-atom-source.outputs.publish_to_dashboard == 'true' && steps.summary-stats.outputs.passed_cases != '0'

--- a/.github/workflows/atomesh-accuracy-validation.yaml
+++ b/.github/workflows/atomesh-accuracy-validation.yaml
@@ -567,20 +567,10 @@ jobs:
 
       - name: Prepare existing dashboard data
         if: hashFiles('accuracy-benchmark-input.json') != ''
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py atomesh-accuracy-dashboard/data.js --write
-          if [ -f atomesh-accuracy-dashboard/data.js ]; then
-            git add atomesh-accuracy-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: atomesh-accuracy-dashboard/data.js
 
       - name: Store Atomesh accuracy data
         if: hashFiles('accuracy-benchmark-input.json') != ''
@@ -590,8 +580,18 @@ jobs:
           output-file-path: accuracy-benchmark-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: atomesh-accuracy-dashboard
-          skip-fetch-gh-pages: true
-          auto-push: true
+          auto-push: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        if: hashFiles('accuracy-benchmark-input.json') != ''
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: atomesh-accuracy-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
+
+      - name: Push dashboard data
+        if: hashFiles('accuracy-benchmark-input.json') != ''
+        run: git push origin gh-pages
 

--- a/.github/workflows/atomesh-accuracy-validation.yaml
+++ b/.github/workflows/atomesh-accuracy-validation.yaml
@@ -565,6 +565,23 @@ jobs:
           echo "=== Generated entries ==="
           cat accuracy-benchmark-input.json
 
+      - name: Prepare existing dashboard data
+        if: hashFiles('accuracy-benchmark-input.json') != ''
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py atomesh-accuracy-dashboard/data.js --write
+          if [ -f atomesh-accuracy-dashboard/data.js ]; then
+            git add atomesh-accuracy-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store Atomesh accuracy data
         if: hashFiles('accuracy-benchmark-input.json') != ''
         uses: benchmark-action/github-action-benchmark@v1
@@ -573,6 +590,7 @@ jobs:
           output-file-path: accuracy-benchmark-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: atomesh-accuracy-dashboard
+          skip-fetch-gh-pages: true
           auto-push: true
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -1386,20 +1386,10 @@ jobs:
           cp .github/dashboard/index.html /tmp/atomesh_dashboard_index.html
 
       - name: Prepare existing dashboard data
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
-          if [ -f benchmark-dashboard/data.js ]; then
-            git add benchmark-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
 
       - name: Store ATOMesh benchmark result to dashboard
         uses: benchmark-action/github-action-benchmark@v1
@@ -1408,10 +1398,15 @@ jobs:
           output-file-path: atomesh-dashboard-input/atomesh-benchmark-action.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
-          skip-fetch-gh-pages: true
-          auto-push: true
+          auto-push: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: benchmark-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
 
       - name: Deploy ATOMesh dashboard shell to gh-pages
         run: |

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -1385,6 +1385,22 @@ jobs:
           test -s atomesh-dashboard-input/atomesh-benchmark-action.json
           cp .github/dashboard/index.html /tmp/atomesh_dashboard_index.html
 
+      - name: Prepare existing dashboard data
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py benchmark-dashboard/data.js --write
+          if [ -f benchmark-dashboard/data.js ]; then
+            git add benchmark-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store ATOMesh benchmark result to dashboard
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -1392,6 +1408,7 @@ jobs:
           output-file-path: atomesh-dashboard-input/atomesh-benchmark-action.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmark-dashboard
+          skip-fetch-gh-pages: true
           auto-push: true
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/atomesh-mocker-benchmark.yaml
+++ b/.github/workflows/atomesh-mocker-benchmark.yaml
@@ -261,20 +261,10 @@ jobs:
 
       - name: Prepare existing dashboard data
         if: hashFiles('atomesh-mocker-dashboard-input.json') != ''
-        run: |
-          set -euo pipefail
-          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
-          CURRENT_SHA=$(git rev-parse HEAD)
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages
-          git checkout gh-pages
-          python3 /tmp/prepare_dashboard_data.py atomesh-mocker-dashboard/data.js --write
-          if [ -f atomesh-mocker-dashboard/data.js ]; then
-            git add atomesh-mocker-dashboard/data.js
-            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
-          fi
-          git checkout "$CURRENT_SHA"
+        id: prepare_dashboard_data
+        uses: ./.github/actions/prepare-dashboard-data
+        with:
+          data-path: atomesh-mocker-dashboard/data.js
 
       - name: Store benchmark result to dashboard
         if: hashFiles('atomesh-mocker-dashboard-input.json') != ''
@@ -284,10 +274,16 @@ jobs:
           output-file-path: atomesh-mocker-dashboard-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: atomesh-mocker-dashboard
-          skip-fetch-gh-pages: true
           auto-push: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate dashboard data after write
+        if: hashFiles('atomesh-mocker-dashboard-input.json') != ''
+        uses: ./.github/actions/validate-dashboard-data
+        with:
+          data-path: atomesh-mocker-dashboard/data.js
+          min-entries: ${{ steps.prepare_dashboard_data.outputs.entry_count }}
 
       - name: Deploy mocker benchmark dashboard to gh-pages
         if: hashFiles('atomesh-mocker-dashboard-input.json') != ''

--- a/.github/workflows/atomesh-mocker-benchmark.yaml
+++ b/.github/workflows/atomesh-mocker-benchmark.yaml
@@ -259,6 +259,23 @@ jobs:
           print(f"Generated {len(entries)} dashboard entries")
           PY
 
+      - name: Prepare existing dashboard data
+        if: hashFiles('atomesh-mocker-dashboard-input.json') != ''
+        run: |
+          set -euo pipefail
+          cp .github/scripts/prepare_dashboard_data.py /tmp/prepare_dashboard_data.py
+          CURRENT_SHA=$(git rev-parse HEAD)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git checkout gh-pages
+          python3 /tmp/prepare_dashboard_data.py atomesh-mocker-dashboard/data.js --write
+          if [ -f atomesh-mocker-dashboard/data.js ]; then
+            git add atomesh-mocker-dashboard/data.js
+            git diff --cached --quiet || git commit -m "ci(dashboard): normalize benchmark data format"
+          fi
+          git checkout "$CURRENT_SHA"
+
       - name: Store benchmark result to dashboard
         if: hashFiles('atomesh-mocker-dashboard-input.json') != ''
         uses: benchmark-action/github-action-benchmark@v1
@@ -267,6 +284,7 @@ jobs:
           output-file-path: atomesh-mocker-dashboard-input.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: atomesh-mocker-dashboard
+          skip-fetch-gh-pages: true
           auto-push: false
           max-items-in-chart: 300
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -61,7 +61,7 @@ jobs:
             -name="ruff" \
             -reporter=github-pr-review \
             -filter-mode=diff_context \
-            -fail-on-error=true
+            -fail-level=any
 
   validate-catalog:
     name: Validate accuracy catalogs against schema

--- a/.github/workflows/pre-checks.yaml
+++ b/.github/workflows/pre-checks.yaml
@@ -61,7 +61,7 @@ jobs:
             -name="ruff" \
             -reporter=github-pr-review \
             -filter-mode=diff_context \
-            -fail-level=any
+            -fail-on-error=true
 
   validate-catalog:
     name: Validate accuracy catalogs against schema

--- a/tests/test_prepare_dashboard_data.py
+++ b/tests/test_prepare_dashboard_data.py
@@ -36,10 +36,7 @@ def test_normalize_leaves_valid_data_unchanged():
 
 
 def test_parse_data_rejects_javascript_nonstandard_constants():
-    text = (
-        b'window.BENCHMARK_DATA = {"entries":{"Benchmark":['
-        b'{"value":NaN}]}}'
-    )
+    text = b'window.BENCHMARK_DATA = {"entries":{"Benchmark":[' b'{"value":NaN}]}}'
 
     with pytest.raises(ValueError, match="non-standard JSON constant"):
         parse_data(text)

--- a/tests/test_prepare_dashboard_data.py
+++ b/tests/test_prepare_dashboard_data.py
@@ -1,0 +1,59 @@
+"""Tests for benchmark dashboard data validation and normalization."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / ".github" / "scripts"))
+
+from prepare_dashboard_data import entry_count, normalize, parse_data
+
+
+def dashboard_data(suffix=b""):
+    payload = b'{"entries":{"Benchmark":[{"commit":{"id":"abc"},"benches":[]}]}}'
+    return b"window.BENCHMARK_DATA = " + payload + suffix
+
+
+def test_normalize_removes_all_terminal_semicolons_and_preserves_crlf():
+    original = dashboard_data(b";;\r\n")
+
+    normalized, changed = normalize(original)
+
+    assert changed
+    assert normalized == dashboard_data(b"\r\n")
+    assert entry_count(parse_data(normalized)[0]) == 1
+
+
+def test_normalize_leaves_valid_data_unchanged():
+    original = dashboard_data()
+
+    normalized, changed = normalize(original)
+
+    assert not changed
+    assert normalized == original
+
+
+def test_parse_data_rejects_javascript_nonstandard_constants():
+    text = (
+        b'window.BENCHMARK_DATA = {"entries":{"Benchmark":['
+        b'{"value":NaN}]}}'
+    )
+
+    with pytest.raises(ValueError, match="non-standard JSON constant"):
+        parse_data(text)
+
+
+def test_parse_data_allows_empty_entries_for_first_write():
+    text = b'window.BENCHMARK_DATA = {"entries":{}}'
+
+    data, changed = parse_data(text)
+
+    assert not changed
+    assert entry_count(data) == 0
+
+
+def test_parse_data_reports_wrong_types():
+    with pytest.raises(TypeError, match="entries"):
+        parse_data(b'window.BENCHMARK_DATA = {"entries": []}')


### PR DESCRIPTION
Summary

- Plugin CI 对 speculative draft 走和 target 相同的 /models/<org>/<name> 下载。
- 从 draft_model_path 或 extra_args 解析 draft，并把路径改成本地目录。
- 修复 Kimi-K3 DSpark：/models/Inferact/Kimi-K3-DSpark 被引用但从未下载。
- 

Test plan

- 重跑 Accuracy (Kimi-K3 DSpark DCP8 TP8)，确认 draft 下载后再 vllm serve。
- 确认 speculative-config 指向 /models/Inferact/Kimi-K3-DSpark 且服务能起来。
- 抽查非 speculative job 仍只下载 target。