### PR TITLE
[PCP] Shard `shared_experts` on the folded TP grid, and sync sampled ids outside the speculative branch

### DIFF
--- a/atom/distributed/pcp_utils.py
+++ b/atom/distributed/pcp_utils.py
@@ -22,6 +22,7 @@ from aiter.dist.parallel_state import (
     get_pcp_group,
     get_prefill_context_model_parallel_rank,
     get_prefill_context_model_parallel_world_size,
+    get_tp_group,
 )
 
 
@@ -57,6 +58,28 @@ def get_pcp_rank() -> int:
 
 def pcp_is_enabled() -> bool:
     return get_pcp_world_size() > 1
+
+
+def pcp_merged_tp_grid() -> Optional[tuple[int, int]]:
+    """`(size, rank)` of the pcp-folded TP grid, or None when the fold is off.
+
+    Lets a per-token module that is otherwise pcp-redundant shard on the same
+    `pcp_size * tp_size` grid FusedMoE already uses, so the existing tp
+    all_reduce + pcp reduce_scatter/all_reduce sum its partials for free.
+
+    The flatten must stay `pcp_rank * tp_size + tp_rank`, byte-identical to
+    `moe.py` `_make_parallel_config`: it gives each TP group a contiguous slice
+    and its PCP partner the next one. The reversed mapping overlaps partners and
+    double-counts.
+    """
+    from atom.utils import envs
+
+    pcp_size = get_pcp_world_size()
+    if pcp_size <= 1 or not bool(envs.ATOM_PCP_MOE_MERGE):
+        return None
+    tp_size = get_tp_group().world_size
+    tp_rank = 0 if tp_size == 1 else get_tp_group().rank_in_group
+    return pcp_size * tp_size, get_pcp_rank() * tp_size + tp_rank
 
 
 def pcp_pad_len(

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -134,6 +134,17 @@ class LLMEngine:
                     "ATOM_TBO_PREFILL_TOKEN_SPLIT is ignored under PCP: TBO "
                     "prefill uses request-boundary balanced grouping."
                 )
+            # TBO stripes positions per request group; the draft prefill split
+            # stripes the batch as one flat global sequence. The shards disagree
+            # on length and order, so refuse rather than crash inside the draft.
+            if config.enable_tbo and config.speculative_config is not None:
+                raise ValueError(
+                    "prefill_context_parallel_size > 1 (-pcp) with speculative "
+                    "decoding is not supported under TBO: TBO's PCP prefill "
+                    "splits per request group, which the draft model's global "
+                    "round-robin query split does not match. Drop --enable-tbo "
+                    "or run without a draft model."
+                )
         self.io_processor = InputOutputProcessor(
             config, self.tokenizer, config.kv_cache_block_size
         )

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -19,7 +19,6 @@ import tqdm
 from aiter import destroy_dist_env, init_dist_env
 from aiter.dist.parallel_state import (
     get_dp_group,
-    get_pcp_group,
     get_pp_group,
     get_tp_group,
     graph_capture,
@@ -30,6 +29,7 @@ from torch.profiler import record_function
 from atom.config import Config, CUDAGraphMode, set_current_atom_config
 from atom.distributed.pcp_utils import (
     PcpBalGroup,
+    get_pcp_group,
     get_pcp_world_size,
     pcp_allgather_rerange,
     pcp_pad_len,
@@ -3130,22 +3130,35 @@ class ModelRunner:
                 target_logits,
                 bonus_token_ids,
             )
-            # PCP ranks decode redundantly and are consistent only while their
-            # kernels agree bit-for-bit -- they don't (hidden differs by ~1 bf16
-            # ULP, flipping ~24% of the near-tie verify argmaxes). Accept counts
-            # then differ per rank and the emitted streams fork. Sync the
-            # decision instead: the ids and how many.
-            if get_pcp_world_size() > 1 and hasattr(self, "drafter"):
-                _g = get_pcp_group()
-                sampled_tokens = _g.broadcast(sampled_tokens.contiguous(), src=0)
-                if torch.is_tensor(num_bonus_tokens):
-                    num_bonus_tokens = _g.broadcast(
-                        num_bonus_tokens.contiguous(), src=0
-                    )
+            # How far each request's KV advances. Spec-only, and must be synced
+            # before the two values derived from it below.
+            if get_pcp_world_size() > 1:
+                num_bonus_tokens = get_pcp_group().broadcast(
+                    num_bonus_tokens.contiguous(), src=0
+                )
             num_reject_tokens = self.drafter.mtp_k - num_bonus_tokens
             next_token_locs = num_bonus_tokens
 
+        # PCP ranks run the same forward redundantly and are consistent only
+        # while their kernels agree bit-for-bit -- they don't (~1 bf16 ULP, which
+        # flips near-tie argmaxes). Measured: ~1.8% of sampled ids differ, and
+        # deferred-out feeds them straight back as the next step's input, so the
+        # moe_pcp_merge all_reduce then sums MoE partials from mismatched hidden
+        # states -- the very thing its own comment assumes cannot happen. Pin the
+        # ids to rank 0. Same condition as the TP broadcast below.
+        if get_pcp_world_size() > 1 and (
+            self.tokenID_processor.is_deferred_out or hasattr(self, "drafter")
+        ):
+            sampled_tokens = get_pcp_group().broadcast(
+                sampled_tokens.contiguous(), src=0
+            )
+
         # Drafter input must agree across TP ranks.
+        # Only the ids, on purpose: the sampler is stochastic (independent noise
+        # for n>1 fan-out). num_bonus_tokens is not -- it is a deterministic
+        # function of target_probs and the draft ids, which TP ranks share
+        # bit-for-bit, so broadcasting it here would be a no-op. Only PCP needs
+        # it (its target_probs differ), and syncs it above.
         if get_tp_group().world_size > 1 and (
             self.tokenID_processor.is_deferred_out or hasattr(self, "drafter")
         ):

--- a/atom/model_ops/linear.py
+++ b/atom/model_ops/linear.py
@@ -1258,6 +1258,8 @@ class MergedColumnParallelLinear(LinearBase):
         quant_config: Optional[QuantizationConfig] = None,
         source_quant_dtype: torch.dtype = None,
         prefix: str = "",
+        override_tp_size: int | None = None,
+        override_tp_rank: int | None = None,
         **kwargs,
     ):
         self.output_sizes = output_sizes
@@ -1269,6 +1271,8 @@ class MergedColumnParallelLinear(LinearBase):
             quant_config=quant_config,
             source_quant_dtype=source_quant_dtype,
             prefix=prefix,
+            override_tp_size=override_tp_size,
+            override_tp_rank=override_tp_rank,
         )
 
     def weight_loader(
@@ -2085,8 +2089,12 @@ class RowParallelLinear(LinearBase):
         reduce_results: bool = True,
         source_quant_dtype: torch.dtype = None,
         prefix: str = "",
+        override_tp_size: int | None = None,
+        override_tp_rank: int | None = None,
         **kwargs,
     ):
+        # Overwritten by super() when an override is given; both sizing and
+        # weight_loader read self.tp_rank/tp_size, so they stay same-sourced.
         self.tp_rank = get_tp_group().rank_in_group
         super().__init__(
             input_size,
@@ -2097,6 +2105,8 @@ class RowParallelLinear(LinearBase):
             reduce_results=reduce_results,
             source_quant_dtype=source_quant_dtype,
             prefix=prefix,
+            override_tp_size=override_tp_size,
+            override_tp_rank=override_tp_rank,
         )
 
     def weight_loader(self, param: nn.Parameter, loaded_weight: torch.Tensor):

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -63,6 +63,7 @@ from atom.distributed.pcp_utils import (
     pcp_all_reduce,
     pcp_allgather_rankmajor,
     pcp_allgather_rerange,
+    pcp_merged_tp_grid,
     pcp_pad_len,
     pcp_reduce_scatter,
     pcp_round_robin_split,
@@ -3590,8 +3591,17 @@ class Expert(nn.Module):
         quant_config: Any | None = None,
         reduce_results: bool = True,
         prefix: str = "",
+        tp_grid: tuple[int, int] | None = None,
     ):
         super().__init__()
+        # `tp_grid` overrides the (size, rank) both projections shard on. The
+        # shared expert passes the pcp-folded grid so it shards like FusedMoE
+        # instead of being replicated on every pcp rank; None keeps the TP group.
+        grid = (
+            {"override_tp_size": tp_grid[0], "override_tp_rank": tp_grid[1]}
+            if tp_grid is not None
+            else {}
+        )
         # Fused [w1; w3] (gate_up_proj): both share input x, both ColumnParallel
         # — standard llama/dsv2 fusion. Disk still split; routed via
         # packed_modules_mapping in DeepseekV4ForCausalLM.
@@ -3601,6 +3611,7 @@ class Expert(nn.Module):
             bias=False,
             quant_config=quant_config,
             prefix=f"{prefix}.gate_up_proj",
+            **grid,
         )
         self.w2 = RowParallelLinear(
             inter_dim,
@@ -3609,6 +3620,7 @@ class Expert(nn.Module):
             quant_config=quant_config,
             reduce_results=reduce_results,
             prefix=f"{prefix}.w2",
+            **grid,
         )
         self.swiglu_limit = swiglu_limit
         # Switch: route clamp + silu(gate)*up [+ weights] + per-token FP8 1x128
@@ -3754,6 +3766,11 @@ class MoE(nn.Module):
 
         if not self._fuse_shared_into_routed:
             # self.experts.num_fused_shared_experts = 0
+            # Shard on the pcp-folded grid when moe_pcp_merge is on, so the
+            # shared expert stops being a full replica on every pcp rank. Its
+            # partials are then summed by the same tp all_reduce + pcp
+            # reduce_scatter/all_reduce the routed experts already ride.
+            self._shared_pcp_sharded = pcp_merged_tp_grid()
             self.shared_experts = Expert(
                 args.dim,
                 args.moe_inter_dim,
@@ -3761,8 +3778,10 @@ class MoE(nn.Module):
                 quant_config=qc,
                 reduce_results=False,
                 prefix=f"{prefix}.shared_experts",
+                tp_grid=self._shared_pcp_sharded,
             )
         else:
+            self._shared_pcp_sharded = None
             self.shared_experts = None
         if self.is_hash_layer:
             # Inject hash routing into FusedMoE.select_experts via the
@@ -3903,17 +3922,13 @@ class MoE(nn.Module):
         all-reduce across TP ranks.
         """
         if shared is not None:
-            # PCP with ATOM_PCP_MOE_MERGE=1 (non-fused shared only): the shared expert
-            # is NOT pcp-sharded (its MergedColumn/RowParallelLinear bind to the
-            # 4-card tp group, so every pcp rank holds the same shared weights
-            # and computes the same full shared output — pcp-redundant). After
-            # this combine the result rides through Block.forward's pcp
-            # reduce_scatter, which SUMS the pcp partners. Without correction the
-            # shared part would be summed pcp_size times (doubled for pcp=2). So
-            # pre-scale shared by 1/pcp_size: the reduce_scatter then RESTORES it
-            # to 1x instead of multiplying. routed is genuinely pcp-sharded
-            # (partial sum) so it must NOT be scaled — only shared.
-            if _moe_pcp_merge_active() or _moe_pcp_merge_decode_active():
+            # A pcp-sharded shared expert emits a partial sum, like routed, so the
+            # downstream pcp reduce_scatter/all_reduce sums it correctly as-is.
+            # A replicated one gets counted pcp_size times there instead, so it
+            # needs the 1/pcp_size pre-scale to come back out at 1x.
+            if self._shared_pcp_sharded is None and (
+                _moe_pcp_merge_active() or _moe_pcp_merge_decode_active()
+            ):
                 shared = shared * (1.0 / get_pcp_world_size())
             routed = routed + shared
         if self.tp_size > 1:

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -47,7 +47,7 @@ def _pcp_split_draft_inputs(
     A draft prefill reuses the target's attn_metadata, already reindexed to
     1/pcp by the builder, so its q rows must be split to match or aiter aborts
     on `kv_indptr_prefix length must be N+1`. Both draft prefill entry points
-    need this: `propose()`'s i==0 step and `precompute_context_kv`.
+    need this: `propose()`'s i==0 step and `compute_draft_kv`.
 
     Callers gate on `_pcp_active_for_draft_model` first. Returns the shards
     plus (n_global, pcp_ws) for callers that must all-gather back.
@@ -318,9 +318,6 @@ class EagleProposer(Drafter):
         `propose(align_only=True)` for its collectives -- the same redo -- so
         `draft_kv_duplicates_propose` has the runner skip this call there.
 
-        NOTE: unverified against real weights. `build_drafter` routes anything
-        carrying `dspark_block_size` to `DSparkProposer`, and every model on
-        hand takes that branch.
         """
         if not next_token_ids:
             return

--- a/tests/test_pcp_ops.py
+++ b/tests/test_pcp_ops.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""CPU unit tests for the Prefill Context Parallel (PCP) pure helpers.
+
+PCP's failure mode is not a wrong number, it is two places disagreeing about
+which rows a rank owns. The draft-prefill crash this suite starts from was
+exactly that: `compute_draft_kv` fed full-size q against attn_metadata already
+reindexed to 1/pcp, and aiter aborted on `kv_indptr_prefix length must be N+1`.
+So the tests here pin the *conventions* --- pad first, then round-robin; dense
+pads with zeros while indptr repeats the last prefix-sum --- and, where two
+functions have to agree, assert them against each other rather than separately.
+
+Everything here is pure tensor work plus parallel-state reads that are
+monkeypatched, so it runs on CPU with no process group.
+
+Groups:
+  * draft prefill split  --- `_pcp_split_draft_inputs`
+  * row ownership        --- `pcp_round_robin_split` vs `pcp_round_robin_query_indices`
+  * metadata padding     --- `pcp_pad_dense` vs `pcp_pad_indptr`
+  * ragged reindex       --- `pcp_reindex_ragged`
+"""
+
+import pytest
+import torch
+
+try:
+    import atom.distributed.pcp_utils as pu
+    from atom.spec_decode import eagle_proposer as ep
+
+    _IMPORT_ERR = None
+except Exception as exc:  # pragma: no cover - env without aiter/triton
+    _IMPORT_ERR = exc
+
+pytestmark = pytest.mark.skipif(
+    _IMPORT_ERR is not None,
+    reason=f"requires full atom import env: {_IMPORT_ERR}",
+)
+
+HID = 4
+WS = 4
+
+
+def _inputs(n):
+    """Row i carries the value i everywhere, so a shard's provenance is readable."""
+    ids = torch.arange(n, dtype=torch.int32)
+    pos = torch.arange(n, dtype=torch.int32)
+    hid = torch.arange(n, dtype=torch.float32)[:, None].repeat(1, HID)
+    return ids, pos, hid
+
+
+def _split(monkeypatch, ids, pos, hid, rank, ws=WS):
+    """Run the helper as PCP rank `rank` of `ws`.
+
+    `get_pcp_world_size` is read by the helper itself (eagle_proposer's
+    namespace); `get_pcp_rank` is read by `pcp_round_robin_split` further down
+    (pcp_utils' namespace). The sizes are passed explicitly by the helper, so
+    only the rank lookup needs patching on the callee side.
+    """
+    monkeypatch.setattr(ep, "get_pcp_world_size", lambda: ws)
+    monkeypatch.setattr(pu, "get_pcp_rank", lambda: rank)
+    return ep._pcp_split_draft_inputs(ids, pos, hid)
+
+
+def test_pads_to_a_multiple_and_splits_round_robin(monkeypatch):
+    """n_global=10, pcp=4 -> pad to 12 -> 3 rows per rank, stride 4."""
+    ids, pos, hid = _inputs(10)
+    seen = {}
+    for rank in range(WS):
+        with monkeypatch.context() as m:
+            d_ids, d_pos, d_hid, n_global, ws = _split(m, ids, pos, hid, rank)
+        assert (n_global, ws) == (10, WS)
+        assert d_ids.shape[0] == 3, f"rank {rank} got {d_ids.shape[0]} rows"
+        assert d_pos.shape[0] == 3 and d_hid.shape == (3, HID)
+        seen[rank] = d_ids.tolist()
+
+    # Round-robin, NOT contiguous chunks -- this is the convention the metadata
+    # builder reindexes to, so a chunked split would silently mismatch it.
+    assert seen[0] == [0, 4, 8]
+    assert seen[1] == [1, 5, 9]
+    assert seen[2] == [2, 6, 0]  # global row 10 is pad -> zero
+    assert seen[3] == [3, 7, 0]  # global row 11 is pad -> zero
+
+    # Every real row is owned by exactly one rank.
+    real = [v for rows in seen.values() for v in rows]
+    for row in range(10):
+        assert real.count(row) == 1 or row == 0, f"row {row} owned {real.count(row)}x"
+
+
+def test_all_three_tensors_shard_identically(monkeypatch):
+    """ids / positions / hidden must stay row-aligned after the split."""
+    ids, pos, hid = _inputs(10)
+    d_ids, d_pos, d_hid, _, _ = _split(monkeypatch, ids, pos, hid, rank=2)
+    assert d_ids.tolist() == d_pos.tolist()
+    assert d_hid[:, 0].to(torch.int32).tolist() == d_ids.tolist()
+    assert torch.equal(d_hid[:, 0], d_hid[:, -1])
+
+
+def test_exact_multiple_needs_no_pad(monkeypatch):
+    ids, pos, hid = _inputs(8)
+    d_ids, _, _, n_global, _ = _split(monkeypatch, ids, pos, hid, rank=3)
+    assert n_global == 8
+    assert d_ids.tolist() == [3, 7]
+
+
+def test_pcp1_is_a_no_op(monkeypatch):
+    ids, pos, hid = _inputs(5)
+    d_ids, d_pos, d_hid, n_global, ws = _split(monkeypatch, ids, pos, hid, rank=0, ws=1)
+    assert (n_global, ws) == (5, 1)
+    assert d_ids.tolist() == list(range(5))
+    assert d_hid.shape == (5, HID)
+
+
+def test_row_misalignment_is_rejected(monkeypatch):
+    """The assert that turns a silent miscompute into a crash.
+
+    PCP+TBO rewrites `context.positions` into per-request-group local stripes
+    while ids/hidden stay global-length. Without this check the helper derives
+    `n_pad` from the long tensor and pads the short one by it, producing
+    garbage; now it refuses. (That combination is additionally rejected at
+    startup in llm_engine.)
+    """
+    ids, pos, hid = _inputs(10)
+    monkeypatch.setattr(ep, "get_pcp_world_size", lambda: WS)
+    with pytest.raises(AssertionError, match="row-aligned"):
+        ep._pcp_split_draft_inputs(ids, pos[:4], hid)
+    with pytest.raises(AssertionError, match="row-aligned"):
+        ep._pcp_split_draft_inputs(ids, pos, hid[:4])
+
+
+# ---------------------------------------------------------------- ownership --
+# `pcp_round_robin_split` extracts this rank's DATA rows; the metadata builder
+# uses `pcp_round_robin_query_indices` to decide which METADATA rows to keep.
+# They are separate functions with separate implementations (`view()[:, rank]`
+# vs `arange(rank, n, pcp)`), and the whole class of bug this suite exists for
+# is the two disagreeing. Assert them against each other, not just separately.
+
+
+@pytest.mark.parametrize("n_global,ws", [(12, 4), (8, 4), (16, 8), (6, 2), (5, 1)])
+def test_split_and_query_indices_agree_on_ownership(monkeypatch, n_global, ws):
+    data = torch.arange(n_global, dtype=torch.int32)
+    for rank in range(ws):
+        monkeypatch.setattr(pu, "get_pcp_rank", lambda r=rank: r)
+        rows = pu.pcp_round_robin_split(data, ws).tolist()
+        owned = pu.pcp_round_robin_query_indices(n_global, ws, rank).tolist()
+        assert rows == owned, f"rank {rank}/{ws}: data {rows} != metadata {owned}"
+
+
+def test_ownership_partitions_every_row_exactly_once(monkeypatch):
+    n_global, ws = 12, 4
+    seen = []
+    for rank in range(ws):
+        seen += pu.pcp_round_robin_query_indices(n_global, ws, rank).tolist()
+    assert sorted(seen) == list(range(n_global))
+
+
+def test_pad_len_rounds_up_to_a_pcp_multiple():
+    assert pu.pcp_pad_len(10, 4) == 12
+    assert pu.pcp_pad_len(12, 4) == 12  # already aligned, no growth
+    assert pu.pcp_pad_len(1, 8) == 8
+    assert pu.pcp_pad_len(10, 1) == 10  # pcp=1 is a no-op
+    # `multiple` stacks on top of pcp_size (used when a kernel also wants a
+    # tile-aligned row count).
+    assert pu.pcp_pad_len(10, 4, multiple=2) == 16
+
+
+# ------------------------------------------------------------------ padding --
+# pcp_pad_dense and pcp_pad_indptr share a (tensor, n_pad) signature but pad two
+# different shapes, and pcp_utils carries a long comment warning not to confuse
+# them. Pin the distinction: a padded dummy query must end up with an EMPTY KV
+# segment, which only happens if indptr repeats its last prefix-sum value.
+
+
+def test_pad_dense_appends_zero_rows():
+    t = torch.tensor([[5.0, 5.0], [3.0, 3.0]])
+    out = pu.pcp_pad_dense(t, 2)
+    assert out.shape == (4, 2)
+    assert torch.equal(out[:2], t)
+    assert torch.count_nonzero(out[2:]) == 0
+
+
+def test_pad_indptr_gives_dummy_queries_empty_segments():
+    # kv_indptr [0,2,5,6] over kv_indices [a,b | c,d,e | f]
+    kv_indptr = torch.tensor([0, 2, 5, 6], dtype=torch.int32)
+    kv_indices = torch.arange(6, dtype=torch.int32)
+    padded = pu.pcp_pad_indptr(kv_indptr, 1)
+    assert padded.tolist() == [0, 2, 5, 6, 6]
+    # the dummy query's slice is empty -- it contributes nothing to attention
+    lo, hi = int(padded[3]), int(padded[4])
+    assert kv_indices[lo:hi].numel() == 0
+    # and the real segments are untouched
+    assert kv_indices[int(padded[0]) : int(padded[1])].tolist() == [0, 1]
+
+
+def test_pad_helpers_are_no_ops_at_zero():
+    t = torch.arange(3, dtype=torch.int32)
+    assert pu.pcp_pad_dense(t, 0) is t
+    assert pu.pcp_pad_indptr(t, 0) is t
+
+
+# ----------------------------------------------------------- ragged reindex --
+# `pcp_reindex_ragged` compacts per-query ragged metadata down to this rank's
+# queries via a searchsorted gather map. Its docstring states the invariant
+# exactly, so test that rather than hand-computed expected arrays.
+
+
+def _ragged(lens):
+    indptr = torch.zeros(len(lens) + 1, dtype=torch.int32)
+    torch.cumsum(torch.tensor(lens, dtype=torch.int32), 0, out=indptr[1:])
+    indices = torch.arange(int(indptr[-1]), dtype=torch.int32) + 100
+    return indptr, indices
+
+
+@pytest.mark.parametrize("lens", [[2, 3, 1, 4, 0, 2], [1, 1, 1, 1], [0, 0, 5, 0]])
+@pytest.mark.parametrize("rank,ws", [(0, 2), (1, 2), (2, 3)])
+def test_reindex_ragged_preserves_each_owned_segment(lens, rank, ws):
+    kv_indptr, kv_indices = _ragged(lens)
+    owned = pu.pcp_round_robin_query_indices(len(lens), ws, rank)
+    ip_local, idx_local = pu.pcp_reindex_ragged(kv_indptr, kv_indices, owned)
+
+    assert ip_local.shape[0] == owned.shape[0] + 1
+    assert int(ip_local[0]) == 0
+    for i, g in enumerate(owned.tolist()):
+        got = idx_local[int(ip_local[i]) : int(ip_local[i + 1])].tolist()
+        want = kv_indices[int(kv_indptr[g]) : int(kv_indptr[g + 1])].tolist()
+        assert got == want, f"owned query {i} (global {g}): {got} != {want}"
+
+
+def test_reindex_ragged_handles_an_all_empty_shard():
+    # every owned query has a zero-length segment -> the `total == 0` fast path
+    kv_indptr, kv_indices = _ragged([0, 3, 0, 4])
+    owned = torch.tensor([0, 2], dtype=torch.long)  # both empty
+    ip_local, idx_local = pu.pcp_reindex_ragged(kv_indptr, kv_indices, owned)
+    assert ip_local.tolist() == [0, 0, 0]
+    assert idx_local.numel() == 0


### PR DESCRIPTION
Two commits on the PCP path. They are separate changes, but the same shape underneath: a collective sums per-rank contributions, and its correctness rests on an assumption about what each rank holds. In one case that assumption was being papered over with a scale factor; in the other it was simply false.

| | `d0111cde` Use TP for `shared_experts` | `3d91671e` Sync sampled ids outside the spec branch |
|---|---|---|
| Kind | Performance / memory | Invariant repair + startup guard |
| Effect | TTFT **−15 %**, ITL **−1.1 ms**, peak_torch **−3.35 GB**, throughput **+7.5 / +13.9 %** | Closes a declared-but-false invariant; no measurable accuracy change |
| Risk | Sharding must match `moe.py`'s flatten exactly | One extra broadcast per decode step (< 0.1 % ITL) |

## Sharding the shared expert

Under PCP with `ATOM_PCP_MOE_MERGE=1` (default), MoE all-gathers hidden back to the full token set before the experts run and the routed experts shard across the folded `pcp_size * tp_size` grid. The **shared expert did not** — its linear layers bind to the TP group, which at `tp=1` is no sharding at all — so it saw every token with unsharded weights, the only large term neither axis cut. Per card per global token (prefill, excluding attention):

| Term | MFLOP | Sharded by |
|---|---|---|
| dense attention projections | 654 / 8 = 82 | PCP (token rows) |
| routed experts (top-6) | 793 / 8 = 99 | merge (expert weights) |
| **shared expert** | **132 → 16.5** | **neither → folded grid** |

At **42 % of the 313 MFLOP per card**, that is why the win far exceeds what a memory saving would suggest — and why every previously recorded `pcp8` TTFT was measured while carrying it.

`pcp_merged_tp_grid()` returns the folded `(size, rank)` or `None` when the fold is off; `Expert` takes it as an optional `tp_grid`, and `linear.py` now forwards the `override_tp_size` / `override_tp_rank` it used to swallow into `**kwargs`. Two invariants ride on it. **The flatten must stay `pcp_rank * tp_size + tp_rank`**, byte-identical to `moe.py`'s `_make_parallel_config` — reversed, PCP partners overlap and double-count. **And the `1/pcp_size` pre-scale in `combine_outputs` must flip in the same commit**: a replicated shared output is a full result the pcp reduce_scatter would sum `pcp_size` times, while a sharded one is a genuine partial sum like routed. Out of step is an 8× error.

## Syncing the sampled ids

The previous PR's PCP broadcast sat inside `if spec_decode_metadata is not None:`, leaving two paths unsynced: **PCP without speculative decoding** (no drafter ⇒ every decode step takes the `None` branch) and **prefill steps with MTP** (always `None` there). At `tp=1` the PCP ranks decode redundantly with no collective, consistent only while their kernels agree bit-for-bit — they do not, and ~1 bf16 ULP flips near-tie argmaxes. Probes on DeepSeek-V3.2: **32.8 % of decode steps** sample divergent ids, **1.61 %** of tokens differ, **1.48 %** reach the next forward's `input_ids` via `prev_token_ids`. No resync point exists, and `deepseek_v2.py:1283` then runs a decode-time `pcp_all_reduce` whose own comment asserts *"Decode and short dense prefill already hold the same token rows on every PCP rank"*.

**This repairs an invariant the code declares and the measurements contradict — not an observed accuracy loss.** gsm8k moves 0.9538 → 0.9553, i.e. 0.26σ; whether the divergence is genuinely harmless is not established.

`sampled_tokens` moves out to the TP broadcast's level and **same condition** (`is_deferred_out or hasattr(self, "drafter")`), so both axes align wherever ids feed back as the next step's input. `num_bonus_tokens` stays in the spec branch — it must precede the `num_reject_tokens` / `next_token_locs` derived from it — and TP's ids-only scope is now documented: it is deterministic given `target_probs` and the draft ids, which TP ranks share bit-for-bit, so only PCP needs it. Separately, **PCP + TBO + spec is refused at startup**: TBO stripes positions per request group while the draft split stripes the batch as one flat sequence, so the shards disagree on length and order.

## Test Plan

```bash
pytest tests/test_pcp_ops.py -q

# perf A/B: same node, same harness, the change is the only variable (control via git stash)
CONFIGS=pcp8 REPS=2 bash run_len_sweep.sh          # out=1024, conc=32, mbt=32768, util=0.9

# accuracy: tp4pcp2 / tp2pcp4 are the arms that can falsify a reversed flatten
bash run_lmeval_pcp_mtp.sh {pcp8,pcp8_mtp,tp4pcp2,tp2pcp4} 5 20

# token-sync probes on DSV3.2 — its dense-MHA fallback below index_topk is the path
# where ranks redundantly run a full prefill; DSV4 always splits, so it cannot show this
ATOM_PCP_TOKEN_PROBE=1 bash run_lmeval_dsv32_mtp.sh {pcp8,pcp8_mtp,tp8,tp8_mtp}
```

`tests/test_pcp_ops.py` pins the *conventions*, not the arithmetic — PCP's failure mode is two places disagreeing about which rows a rank owns. Where two functions must agree (`pcp_round_robin_split` vs `pcp_round_robin_query_indices`, `pcp_pad_dense` vs `pcp_pad_indptr`) they are asserted against each other rather than separately. CPU-only, no process group.

## Test Result

### `shared_experts` — A/B on `crsuse2-m2m-v2-024`

| Metric | in_len | control | sharded | Δ |
|---|---|---|---|---|
| Median ITL | 8192 / 65536 | 22.67 / 23.39 ms | **21.61 / 22.16 ms** | **−1.06 / −1.23 ms** |
| Median TTFT | 8192 / 65536 | 4816 / 30212 ms | **4092 / 25639 ms** | **−15.0 / −15.1 %** |
| Throughput | 8192 / 65536 | 9781 / 27008 tok/s | **10517 / 30763 tok/s** | **+7.5 / +13.9 %** |
| `peak_torch` | — | 130.10 GB | **126.75 GB** | **−3.35 GB** |

ITL and memory match the analytic prediction (−1.05 ms from 3.36 GB ÷ 3.27 TB/s; −3.36 GB) to within 0.3 %. Inter-rep noise is 0.02–0.22 ms, so the ITL effect is 5–50× noise. Memory reproduced on a second harness (130.18 → 126.83).

**The flatten order is verified, not merely asserted.** `pcp8` is `tp=1`, where `combine_outputs`' TP all-reduce never fires and both flatten orders are equivalent — it *cannot* distinguish a reversed mapping. `tp4pcp2` / `tp2pcp4` exercise both orthogonal groups, and a reversed flatten would double-count the shared expert on every layer of every token:

| config | 5-shot | 20-shot | asserts |
|---|---|---|---|
| `tp4pcp2` | 0.9538 | 0.9507 | 0 |
| `tp2pcp4` | 0.9538 | 0.9515 | 0 |

Both sit inside the 0.9484–0.9553 reference band set by the `pcp8` and `tp8` baselines, and `tp4pcp2`'s 20-shot is bit-identical to the `pcp8` baseline ⇒ the two groups cover half of the 8 each, no overlap, no gap.

**`pcp8 + MTP`** (full 1319, real rejection sampling) is the highest-risk combination, since this change touches MoE's summation path. Acceptance **66.28 % → 66.24 %** (−0.04 pp) with the accept-length distribution matching bucket by bucket; gsm8k 0.9484 / 0.9515. Acceptance is the sensitive statistic here — ~250 k draft tokens against gsm8k's 0.6 pp SE — and it was 4 pp low when the ranks genuinely disagreed. ⇒ no new cross-rank divergence.

### Token sync — DeepSeek-V3.2, full 1319

All four arms clean: `pcp8` 0.9553, `pcp8+MTP` 0.9560 (94.64 % acceptance), `tp8` 0.9515, `tp8+MTP` 0.9507 (94.69 %). Acceptance differs by 0.05 pp, and DSV3.2 + PCP + MTP is confirmed working as a combination. `tests/test_pcp_ops.py`: 25 cases pass.

## Known Limitations

1. **DSpark + PCP has a low acceptance rate. Accuracy is unaffected and we are still working on it.** gsm8k is at parity with TP — every draft is verified by the target, so a poor draft costs throughput, never output correctness. Root cause not yet located. Independent of both commits here.
2. **The TBO guard keys on the config flag**, so it refuses at startup whenever TBO and speculative decoding are both configured under PCP, including runs whose token counts would never actually trigger TBO. Conservative on purpose, but a safe run is refused too.
3. **Mixed parallelism is verified for accuracy only.** `tp4pcp2` / `tp2pcp4` were not benchmarked; mixed configs are already known to trail both endpoints and are not a tuning target.
4. **`pcp8 + MTP` throughput is unmeasured** — the bench harness has no MTP arm. The 3.35 GB/step saving is orthogonal to MTP and amortises over K+1 tokens, so the ratio should hold, but it is untested.

## Submission Checklist
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
