### PR TITLE
feat(dp): DP-vocab-sharded greedy argmax for speculative drafting

### DIFF
--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -272,11 +272,18 @@ class ParallelLMHead(VocabParallelEmbedding):
 
         For greedy speculative drafting only the argmax is needed, so each rank
         reduces its own vocab shard to ``(max_val, global_idx)`` and we all-gather
-        just those ``[N, 2]`` (tp small) instead of the O(vocab) logits. Token
-        selection is identical to a full-logits ``argmax``: the values compared
-        are the same bf16 logits (fp32-packed exactly), and tie-breaking matches
-        the lowest global index — ``torch.max`` picks the lowest local index, and
-        ``argmax`` over ranks picks the lowest rank (== lowest vocab range).
+        just those ``[N, 2]`` (tp small) instead of the O(vocab) logits.
+
+        On the TP path the GEMM is unchanged, so this is bitwise-identical to a
+        full-logits ``argmax`` -- the values compared are the same bf16 logits
+        (fp32-packed exactly), and tie-breaking matches the lowest global index
+        (``torch.max`` picks the lowest local index, ``argmax`` over ranks the
+        lowest rank == lowest vocab range). The DP path (``ATOM_DP_DRAFT_ARGMAX``,
+        via ``_dp_sharded_logits(mode="argmax")``) reshapes the GEMM ([M, V] ->
+        [dp*M, V/dp]), which ``tgemm`` may tile differently, so its logits are not
+        bitwise-identical to the replicated ones and a near-tie can flip. The pick
+        itself is still exact over whatever logits it is given; only the GEMM's
+        rounding differs.
         """
         if out is not None:
             assert out.shape == x.shape[:-1], (
@@ -287,10 +294,13 @@ class ParallelLMHead(VocabParallelEmbedding):
                 out.dtype == torch.long and out.device == x.device
             ), "argmax out must be an int64 tensor on the input device"
         # Pure-DP draft: shard the vocab across the DP group instead of a
-        # replicated full-vocab GEMM. Env first so a disabled build skips the
-        # context lookup.
-        if envs.ATOM_DP_DRAFT_ARGMAX and self._can_use_dp_sharded_argmax(
-            get_forward_context().context
+        # replicated full-vocab GEMM. Skip plugin mode -- its caller decides the
+        # collective count per chunk (a mismatch would deadlock DP) -- and skip
+        # the context lookup entirely when the env is off.
+        if (
+            envs.ATOM_DP_DRAFT_ARGMAX
+            and not is_plugin_mode()
+            and self._can_use_dp_sharded_argmax(get_forward_context().context)
         ):
             return self._dp_sharded_logits(x, "argmax", out)
         logits = tgemm.mm(x, self.weight, self.bias)  # [N, vocab/tp]
@@ -444,19 +454,30 @@ class ParallelLMHead(VocabParallelEmbedding):
     def _can_use_dp_sharded_argmax(self, context) -> bool:
         """Whether a draft step may run the DP-sharded argmax.
 
-        Every DP rank must reach the same verdict, so every gated value is
-        DP-agreed. `running_tokens_are_unified` marks a rectangular draft (a
-        ragged one falls back); `running_tokens` is bounded because the hidden
-        gather outgrows the weight-read saving past ATOM_DP_DRAFT_ARGMAX_MAX_ROWS.
+        Total predicate -- returns False, never raises, outside a DP-reduced
+        rectangular pure-DP draft. Every DP rank must reach the same verdict, so
+        every gated value is DP-agreed: `running_tokens_are_unified` marks a
+        rectangular draft, `running_tokens` is bounded past
+        ATOM_DP_DRAFT_ARGMAX_MAX_ROWS (the gather outgrows the weight-read win),
+        and `dp_metadata is not None` is the proof `running_tokens` was actually
+        reduced across DP -- absent under SGLang dp-attention (where aiter's DP
+        group is >1 but ATOM's data_parallel_size is 1) and single-GPU. That
+        check also gates the raising `get_dp_group()`: dp_metadata is built via
+        the DP group, so its presence means the group exists.
         """
-        if not envs.ATOM_DP_DRAFT_ARGMAX or self.tp_size != 1:
+        if not envs.ATOM_DP_DRAFT_ARGMAX or is_plugin_mode() or self.tp_size != 1:
+            return False
+        fc = get_forward_context()
+        if (
+            context is None
+            or fc.dp_metadata is None
+            or not getattr(context, "is_draft", False)
+            or getattr(context, "is_prefill", False)
+            or not getattr(context, "running_tokens_are_unified", False)
+            or int(context.running_tokens) > envs.ATOM_DP_DRAFT_ARGMAX_MAX_ROWS
+        ):
             return False
         dp_group = get_dp_group()
-        if dp_group.world_size <= 1 or self.num_embeddings % dp_group.world_size != 0:
-            return False
         return (
-            context is not None
-            and getattr(context, "is_draft", False)
-            and getattr(context, "running_tokens_are_unified", False)
-            and int(context.running_tokens) <= envs.ATOM_DP_DRAFT_ARGMAX_MAX_ROWS
+            dp_group.world_size > 1 and self.num_embeddings % dp_group.world_size == 0
         )

--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -250,7 +250,7 @@ class ParallelLMHead(VocabParallelEmbedding):
                 last_indices = attn_metadata.cu_seqlens_q[1:] - 1
                 x = x[last_indices].contiguous()
             if self._can_use_dp_sharded_head(context):
-                return self._dp_sharded_logits(x)
+                return self._dp_sharded_logits(x, envs.ATOM_DP_LM_HEAD_MODE)
         logits = tgemm.mm(x, self.weight, self.bias)
         if self.tp_size > 1:
             use_custom = envs.ATOM_USE_CUSTOM_ALL_GATHER
@@ -286,6 +286,13 @@ class ParallelLMHead(VocabParallelEmbedding):
             assert (
                 out.dtype == torch.long and out.device == x.device
             ), "argmax out must be an int64 tensor on the input device"
+        # Pure-DP draft: shard the vocab across the DP group instead of a
+        # replicated full-vocab GEMM. Env first so a disabled build skips the
+        # context lookup.
+        if envs.ATOM_DP_DRAFT_ARGMAX and self._can_use_dp_sharded_argmax(
+            get_forward_context().context
+        ):
+            return self._dp_sharded_logits(x, "argmax", out)
         logits = tgemm.mm(x, self.weight, self.bias)  # [N, vocab/tp]
         if self.tp_size <= 1:
             token = logits.argmax(dim=-1)
@@ -347,33 +354,37 @@ class ParallelLMHead(VocabParallelEmbedding):
             return False
         return get_forward_context().dp_metadata is not None
 
-    def _dp_sharded_logits(self, x: torch.Tensor) -> torch.Tensor:
-        """Full-vocab logits for this rank's own rows via a DP-sharded head.
+    def _dp_sharded_logits(
+        self, x: torch.Tensor, mode: str, out: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        """This rank's own rows out of a DP-vocab-sharded lm_head.
 
-        x: ``[local_rows, dim]`` (this DP rank's tokens). Under uniform decode
-        every rank pads to the DP-wide ``running_tokens`` so the collective is
-        fixed-size and identical on all ranks; the padded tail is dropped at the
-        end. returns: ``[local_rows, vocab]``.
+        Shared front half: pad x to the DP-agreed ``running_tokens``, all-gather
+        hidden across DP (fixed-size, identical on all ranks), and project onto
+        this rank's vocab slice. ``mode`` then picks the exchange:
+
+        - ``"argmax"``: reduce each shard to a packed ``(max, global_id)`` and
+          all-gather only ``[Σrows, 2]``, then pick the winner -> ``[local_rows]``
+          int64 ids (drafting; ``out``, if given, receives them).
+        - ``"all2all"`` / ``"allgather"``: exchange full-vocab logits ->
+          ``[local_rows, vocab]`` (the decode head).
         """
-        mode = envs.ATOM_DP_LM_HEAD_MODE
         dp_group = get_dp_group()
         dp_size = dp_group.world_size
         dp_rank = dp_group.rank_in_group
         vshard = self.num_embeddings // dp_size
+        use_custom = envs.ATOM_USE_CUSTOM_ALL_GATHER
 
-        fc = get_forward_context()
         local_rows = x.shape[0]
-        max_rows = int(fc.context.running_tokens)
+        max_rows = int(get_forward_context().context.running_tokens)
         # running_tokens is the padded height, so local_rows <= max_rows always;
-        # keep the guard as a loud tripwire rather than a silent DP-wide hang.
+        # a loud tripwire beats a silent DP-wide hang on a size mismatch.
         assert local_rows <= max_rows, (
-            f"DP LM head: local_rows={local_rows} > running_tokens={max_rows}; "
+            f"DP sharded head: local_rows={local_rows} > running_tokens={max_rows}; "
             "hidden height exceeds the DP-uniform gather bucket."
         )
         if local_rows < max_rows:
             x = torch.cat([x, x.new_zeros(max_rows - local_rows, x.shape[1])], dim=0)
-
-        use_custom = envs.ATOM_USE_CUSTOM_ALL_GATHER
 
         # [max_rows, dim] -> [dp_size * max_rows, dim] (rank-major concat).
         gathered = dp_group.all_gather(x.contiguous(), dim=0, use_custom=use_custom)
@@ -384,31 +395,68 @@ class ParallelLMHead(VocabParallelEmbedding):
             else self.bias[dp_rank * vshard : (dp_rank + 1) * vshard]
         )
         logits_shard = tgemm.mm(gathered, w, b)  # [dp_size * max_rows, V/dp]
+        start = dp_rank * max_rows
+
+        if mode == "argmax":
+            # Reduce each shard to (max, global_id); exchange only [Σrows, 2].
+            packed = lm_head_argmax_pack(logits_shard, dp_rank * vshard)
+            gathered_packed = dp_group.all_gather(
+                packed, dim=0, use_custom=use_custom
+            ).view(dp_size, dp_size * max_rows, 2)
+            winner = gathered_packed[:, :, 0].argmax(dim=0)  # [Σrows] winning shard
+            token = (
+                gathered_packed[:, :, 1]
+                .gather(0, winner.unsqueeze(0))
+                .squeeze(0)
+                .to(torch.long)
+            )[
+                start : start + local_rows
+            ]  # keep own rows
+            return token if out is None else out.copy_(token)
 
         if mode == "all2all":
-            # Send each destination rank only the block of rows it owns; receive
-            # this rank's rows on every peer's vocab shard.
+            # Send each destination rank only the rows it owns; receive this
+            # rank's rows on every peer's vocab shard.
             logits_shard = logits_shard.contiguous()
-            out = torch.empty_like(logits_shard)
+            recv = torch.empty_like(logits_shard)
             torch.distributed.all_to_all_single(
-                out.view(-1), logits_shard.view(-1), group=dp_group.device_group
+                recv.view(-1), logits_shard.view(-1), group=dp_group.device_group
             )
-            # out is source-major [dp_size, max_rows, vshard]; the sampler wants
-            # the vocab shards concatenated along dim 1. The (dp <-> rows) axis
-            # swap is non-contiguous, so the following reshape materialises one
-            # copy — inherent to converting all-to-all's source-major output to
-            # row-major full-vocab logits. Slice to the real rows *before* the
-            # reshape so the copy only touches local_rows (not the padded tail).
+            # recv is source-major [dp_size, max_rows, vshard]; the sampler wants
+            # the vocab shards along dim 1. That (dp <-> rows) swap is
+            # non-contiguous, so the reshape copies -- slice to the real rows
+            # first so the copy only touches local_rows, not the padded tail.
             return (
-                out.view(dp_size, max_rows, vshard)[:, :local_rows, :]
+                recv.view(dp_size, max_rows, vshard)[:, :local_rows, :]
                 .permute(1, 0, 2)
                 .reshape(local_rows, dp_size * vshard)
             )
 
-        # mode == "allgather": all-gather every rank's [Σrows, V/dp] shard into
-        # the full vocab, then scatter this rank's own row block.
+        # "allgather": materialise the full vocab on every rank, keep own rows.
         global_logits = dp_group.all_gather(
             logits_shard, dim=1, use_custom=use_custom
         )  # [Σrows, V]
-        start = dp_rank * max_rows
         return global_logits[start : start + local_rows].contiguous()
+
+    # Draft greedy argmax reuses `_dp_sharded_logits(mode="argmax")`: a draft's
+    # replicated [N, V] GEMM is weight-read bound at the tiny draft M, so sharding
+    # the vocab ([H, V/dp]) and exchanging only the packed [N, 2] argmax pays.
+    def _can_use_dp_sharded_argmax(self, context) -> bool:
+        """Whether a draft step may run the DP-sharded argmax.
+
+        Every DP rank must reach the same verdict, so every gated value is
+        DP-agreed. `running_tokens_are_unified` marks a rectangular draft (a
+        ragged one falls back); `running_tokens` is bounded because the hidden
+        gather outgrows the weight-read saving past ATOM_DP_DRAFT_ARGMAX_MAX_ROWS.
+        """
+        if not envs.ATOM_DP_DRAFT_ARGMAX or self.tp_size != 1:
+            return False
+        dp_group = get_dp_group()
+        if dp_group.world_size <= 1 or self.num_embeddings % dp_group.world_size != 0:
+            return False
+        return (
+            context is not None
+            and getattr(context, "is_draft", False)
+            and getattr(context, "running_tokens_are_unified", False)
+            and int(context.running_tokens) <= envs.ATOM_DP_DRAFT_ARGMAX_MAX_ROWS
+        )

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -368,6 +368,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_DP_LM_HEAD_MODE": lambda: os.getenv(
         "ATOM_DP_LM_HEAD_MODE", "all2all"
     ).lower(),
+    # Pure-DP draft greedy argmax: shard the draft lm_head vocab across the DP
+    # group so each rank reads [H, V/dp] instead of the full [H, V], exchanging
+    # only the packed [N, 2]. Active only for a unified (rectangular) pure-DP
+    # draft step; everything else falls back to the replicated local argmax.
+    "ATOM_DP_DRAFT_ARGMAX": lambda: os.getenv("ATOM_DP_DRAFT_ARGMAX", "1").lower()
+    in ("1", "true"),
+    # Row count (running_tokens) above which it falls back: the hidden gather
+    # grows with rows, so the shard only pays at small M. ~256 is the V4-Pro
+    # crossover.
+    "ATOM_DP_DRAFT_ARGMAX_MAX_ROWS": lambda: int(
+        os.getenv("ATOM_DP_DRAFT_ARGMAX_MAX_ROWS", "256")
+    ),
     "ATOM_USE_FLYDSL_GDR": lambda: os.getenv("ATOM_USE_FLYDSL_GDR", "0").lower() == "1",
     # Capture each declared draft pass into a per-captured-size CUDAGraph as it is
     # warmed, so the draft replays instead of relaunching every kernel. 0 drafts

--- a/tests/test_dp_sharded_argmax.py
+++ b/tests/test_dp_sharded_argmax.py
@@ -1,0 +1,193 @@
+"""CPU-only coverage for the DP-vocab-sharded draft argmax.
+
+Two things need no GPU and no real process group:
+  - the gate `_can_use_dp_sharded_argmax` is pure predicate logic, and must be
+    TOTAL (return False, never raise) outside a DP-reduced pure-DP draft;
+  - the argmax exchange's offset arithmetic (`start = dp_rank * max_rows` and the
+    rank-major `.view(dp_size, dp_size * max_rows, 2)` unpack) must slice back
+    exactly this rank's own rows.
+"""
+
+import pytest
+import torch
+
+embed_head = pytest.importorskip(
+    "atom.model_ops.embed_head",
+    reason="embed_head requires the Triton/AITER runtime",
+    exc_type=ImportError,
+)
+
+
+class _Ctx:
+    def __init__(self, *, is_draft=True, unified=True, running_tokens=4):
+        self.is_draft = is_draft
+        self.running_tokens_are_unified = unified
+        self.running_tokens = running_tokens
+
+
+class _FwdCtx:
+    def __init__(self, *, dp_metadata, context):
+        self.dp_metadata = dp_metadata
+        self.context = context
+
+
+class _Group:
+    def __init__(self, *, world_size, rank_in_group=0, all_gather=None):
+        self.world_size = world_size
+        self.rank_in_group = rank_in_group
+        self.device_group = object()
+        self._all_gather = all_gather
+
+    def all_gather(self, x, dim=0, use_custom=False):
+        return self._all_gather(x, dim)
+
+
+def _head(*, tp_size=1, num_embeddings=8):
+    head = embed_head.ParallelLMHead.__new__(embed_head.ParallelLMHead)
+    torch.nn.Module.__init__(head)
+    head.tp_size = tp_size
+    head.num_embeddings = num_embeddings
+    head.weight = torch.nn.Parameter(torch.empty(1), requires_grad=False)
+    head.bias = None
+    return head
+
+
+# --------------------------------------------------------------------------- #
+# Gate verdict table
+# --------------------------------------------------------------------------- #
+_PRESENT = object()  # a non-None dp_metadata stand-in (a DP-reduced step)
+
+
+def _install_gate_env(
+    monkeypatch,
+    *,
+    flag=True,
+    plugin=False,
+    world_size=2,
+    dp_metadata=_PRESENT,
+    context=None,
+):
+    monkeypatch.setattr(embed_head.envs, "ATOM_DP_DRAFT_ARGMAX", flag)
+    monkeypatch.setattr(embed_head.envs, "ATOM_DP_DRAFT_ARGMAX_MAX_ROWS", 256)
+    monkeypatch.setattr(embed_head, "is_plugin_mode", lambda: plugin)
+    monkeypatch.setattr(
+        embed_head, "get_dp_group", lambda: _Group(world_size=world_size)
+    )
+    monkeypatch.setattr(
+        embed_head,
+        "get_forward_context",
+        lambda: _FwdCtx(dp_metadata=dp_metadata, context=context),
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs, ctx_kwargs, head_kwargs, expected",
+    [
+        # everything aligned -> engage
+        ({}, {}, {}, True),
+        # env off
+        ({"flag": False}, {}, {}, False),
+        # plugin mode: caller decides collective counts -> never engage
+        ({"plugin": True}, {}, {}, False),
+        # hybrid TP present -> not pure DP
+        ({}, {}, {"tp_size": 2}, False),
+        # SGLang dp-attention / single-GPU: running_tokens was never reduced
+        ({"dp_metadata": None}, {}, {}, False),
+        # not a draft step
+        ({}, {"is_draft": False}, {}, False),
+        # ragged (variable-length) draft
+        ({}, {"unified": False}, {}, False),
+        # past the weight-read-bound crossover
+        ({}, {"running_tokens": 257}, {}, False),
+        # no DP (world_size == 1)
+        ({"world_size": 1}, {}, {}, False),
+        # vocab not evenly shardable
+        ({"world_size": 3}, {}, {"num_embeddings": 8}, False),
+    ],
+)
+def test_gate_verdict_table(monkeypatch, kwargs, ctx_kwargs, head_kwargs, expected):
+    ctx = _Ctx(**ctx_kwargs)
+    _install_gate_env(monkeypatch, context=ctx, **kwargs)
+    head = _head(**head_kwargs)
+    assert head._can_use_dp_sharded_argmax(ctx) is expected
+
+
+def test_gate_is_total_when_dp_group_absent(monkeypatch):
+    """dp_metadata is None must short-circuit BEFORE get_dp_group(), which raises
+    when the DP group was never built (single-GPU / unit test / plugin)."""
+
+    def _raises():
+        raise AssertionError("data parallel group is not initialized")
+
+    monkeypatch.setattr(embed_head.envs, "ATOM_DP_DRAFT_ARGMAX", True)
+    monkeypatch.setattr(embed_head, "is_plugin_mode", lambda: False)
+    monkeypatch.setattr(embed_head, "get_dp_group", _raises)
+    monkeypatch.setattr(
+        embed_head,
+        "get_forward_context",
+        lambda: _FwdCtx(dp_metadata=None, context=_Ctx()),
+    )
+    # Returns False rather than propagating the AssertionError.
+    assert (
+        embed_head.ParallelLMHead._can_use_dp_sharded_argmax(_head(), _Ctx()) is False
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Offset arithmetic in the argmax exchange
+# --------------------------------------------------------------------------- #
+def test_argmax_exchange_slices_each_rank_own_rows(monkeypatch):
+    """Every rank runs the sampler over EVERY rank's rows, then must return only
+    its own `local_rows` block at `dp_rank * max_rows`. Drive `_dp_sharded_logits`
+    for both ranks of a dp=2 step and check each gets the right ids."""
+    dp_size, max_rows, local_rows, vshard = 2, 3, 2, 4
+    V = dp_size * vshard
+
+    # Reference: a full-vocab logits per row for the Σ = dp_size * max_rows rows.
+    torch.manual_seed(0)
+    full_logits = torch.randn(dp_size * max_rows, V)
+    ref_ids = full_logits.argmax(dim=-1)  # [Σrows] the replicated answer
+
+    # Each shard sees the same rows but only its V/dp columns; pack (max, gidx).
+    def _shard_pack(shard):
+        cols = slice(shard * vshard, (shard + 1) * vshard)
+        val, loc = full_logits[:, cols].max(dim=-1)
+        return torch.stack([val, (loc + shard * vshard).float()], dim=-1)
+
+    packs = [_shard_pack(s) for s in range(dp_size)]  # each [Σrows, 2]
+
+    monkeypatch.setattr(embed_head.envs, "ATOM_USE_CUSTOM_ALL_GATHER", False)
+    # tgemm.mm / lm_head_argmax_pack are the GPU steps; on CPU we feed this rank's
+    # own pack straight through, so only the exchange + offset code runs for real.
+    monkeypatch.setattr(embed_head.tgemm, "mm", lambda *_a, **_k: None)
+
+    for rank in range(dp_size):
+        monkeypatch.setattr(
+            embed_head, "lm_head_argmax_pack", lambda *_a, _r=rank, **_k: packs[_r]
+        )
+
+        def _all_gather(x, dim, _r=rank):
+            if dim == 0 and x is packs[_r]:  # the pack gather
+                return torch.cat(packs, dim=0)
+            return x  # the hidden gather is unused (tgemm.mm is stubbed)
+
+        monkeypatch.setattr(
+            embed_head,
+            "get_dp_group",
+            lambda _r=rank: _Group(
+                world_size=dp_size, rank_in_group=_r, all_gather=_all_gather
+            ),
+        )
+        monkeypatch.setattr(
+            embed_head,
+            "get_forward_context",
+            lambda: _FwdCtx(
+                dp_metadata=object(), context=_Ctx(running_tokens=max_rows)
+            ),
+        )
+        head = _head(num_embeddings=V)
+        x = torch.empty(local_rows, 4)  # [local_rows, dim]; contents unused
+        got = head._dp_sharded_logits(x, "argmax")
+
+        start = rank * max_rows
+        assert got.tolist() == ref_ids[start : start + local_rows].tolist()

--- a/tests/test_lm_head_argmax_out.py
+++ b/tests/test_lm_head_argmax_out.py
@@ -14,9 +14,6 @@ def _tp1_head(logits: torch.Tensor, monkeypatch) -> embed_head.ParallelLMHead:
     head.tp_size = 1
     head.weight = torch.nn.Parameter(torch.empty(1), requires_grad=False)
     head.bias = None
-    # Exercise the replicated argmax path; the DP-sharded draft path needs an
-    # initialized DP group, which this unit test does not stand up.
-    monkeypatch.setattr(embed_head.envs, "ATOM_DP_DRAFT_ARGMAX", False)
     monkeypatch.setattr(embed_head.tgemm, "mm", lambda *_args, **_kwargs: logits)
     return head
 

--- a/tests/test_lm_head_argmax_out.py
+++ b/tests/test_lm_head_argmax_out.py
@@ -14,6 +14,9 @@ def _tp1_head(logits: torch.Tensor, monkeypatch) -> embed_head.ParallelLMHead:
     head.tp_size = 1
     head.weight = torch.nn.Parameter(torch.empty(1), requires_grad=False)
     head.bias = None
+    # Exercise the replicated argmax path; the DP-sharded draft path needs an
+    # initialized DP group, which this unit test does not stand up.
+    monkeypatch.setattr(embed_head.envs, "ATOM_DP_DRAFT_ARGMAX", False)
     monkeypatch.setattr(embed_head.tgemm, "mm", lambda *_args, **_kwargs: logits)
     return head
 


### PR DESCRIPTION
before in draft model DP:
<img width="607" height="304" alt="image" src="https://github.com/user-attachments/assets/6a569410-0830-41af-8931-ee70305d11b3" />


after sharded gemm:
<img width="822" height="384" alt="image" src="https://github.com/user-attachments/assets/cf4d7b05-c4f6-49e5-8e8c-bdf267d37f74" />


## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
