### PR TITLE
ci: drop the Meta-Llama-3-8B-Instruct accuracy test

### DIFF
--- a/.github/benchmark/models_accuracy.json
+++ b/.github/benchmark/models_accuracy.json
@@ -1,17 +1,5 @@
 [
   {
-    "model_name": "Meta-Llama-3-8B-Instruct",
-    "model_path": "meta-llama/Meta-Llama-3-8B-Instruct",
-    "extraArgs": "--kv_cache_dtype fp8 --gpu-memory-utilization 0.3",
-    "env_vars": "HSA_NO_SCRATCH_RECLAIM=1",
-    "runner": "linux-atom-mi35x-1",
-    "test_level": "pr",
-    "accuracy_threshold": 0.73,
-    "accuracy_baseline": 0.75,
-    "accuracy_baseline_model": "meta-llama/Meta-Llama-3-8B-Instruct",
-    "_baseline_note": "HF reports 0.796 but 8-shot CoT; CI uses 3-shot, not comparable"
-  },
-  {
     "model_name": "DeepSeek-R1-0528",
     "model_path": "deepseek-ai/DeepSeek-R1-0528",
     "extraArgs": "--kv_cache_dtype fp8 -tp 8",

--- a/.github/workflows/atom-test.yaml
+++ b/.github/workflows/atom-test.yaml
@@ -183,7 +183,10 @@ jobs:
     env:
       CONTAINER_NAME: atom_smoke_test
       SMOKE_MODEL: meta-llama/Meta-Llama-3-8B-Instruct
-      # Matches this model's entry in models_accuracy.json.
+      # These were this model's settings in models_accuracy.json before its
+      # accuracy entry was dropped. This job is not an accuracy test: it asserts
+      # the offline entrypoint completes, so it keeps the small model and its
+      # settings regardless of what the accuracy matrix tracks.
       SMOKE_EXTRA_ARGS: --kv_cache_dtype fp8 --gpu-memory-utilization 0.3
     steps:
       - name: Kill stale containers

--- a/.github/workflows/atomesh-accuracy-validation.yaml
+++ b/.github/workflows/atomesh-accuracy-validation.yaml
@@ -105,8 +105,12 @@ jobs:
           current = level_map.get(event, "pr")
           allowed = {"pr": {"pr"}, "main": {"pr", "main"}, "nightly": {"pr", "main", "nightly"}}[current]
           models = json.load(open(".github/benchmark/models_accuracy.json", encoding="utf-8"))
+          # NOTE: Meta-Llama-3-8B-Instruct was this whitelist's only "pr" entry
+          # and has been removed from models_accuracy.json, so atomesh
+          # standalone currently validates nothing on a pull request. Promoting
+          # a replacement changes what every atomesh PR pays for, so it is left
+          # to the job owner rather than decided here.
           atomesh_levels = {
-              "Meta-Llama-3-8B-Instruct": "pr",
               "DeepSeek-R1-0528": "main",
               "DeepSeek-V4-Pro MTP": "nightly",
               "gpt-oss-120b": "nightly",


### PR DESCRIPTION
## Summary

Removes the `Meta-Llama-3-8B-Instruct` entry from `.github/benchmark/models_accuracy.json`. The model is no longer part of what ATOM needs to track, and its accuracy job has been failing on `main` on every recent run.

The pull-request accuracy set goes from 14 models to 13. Nightly goes from 41 to 40.

## Why now

Every `ATOM Test` run on `main` in recent history is red, and `Meta-Llama-3-8B-Instruct` is a failing job in each one:

- `412f5bfe5` — 19/21 accuracy jobs pass; failures are `Meta-Llama-3-8B-Instruct` and `gpt-oss-120b (2 GPUs)`
- `f95ef3ec3` — same two
- `e4e473f8c` — 16/21; `Meta-Llama-3-8B-Instruct` among the failures

Dropping this test does not by itself turn `main` green. `gpt-oss-120b (2 GPUs)` is failing independently and is not touched here.

## Knock-on changes

**`atomesh-accuracy-validation.yaml`.** Its local `atomesh_levels` whitelist listed `Meta-Llama-3-8B-Instruct` as its only `"pr"` model, and it filters against `models_accuracy.json`. With the entry gone the key would match nothing while still reading as intentional, so it is removed and the effect is written into the file:

**atomesh standalone now validates zero models on a pull request.** Simulated against the new config:

    atomesh  event=pull_request  level=pr       -> 0 models
    atomesh  event=push          level=main     -> 1 model
    atomesh  event=schedule      level=nightly  -> 3 models

Promoting a replacement to `"pr"` changes what every atomesh PR pays for in runner time, which is a resourcing call for the job owner, not something to decide inside this change. Flagging it here rather than papering over it.

## Deliberately not changed

**The offline inference smoke test** in `atom-test.yaml` keeps using this model. It is not an accuracy test. It asserts that the offline entrypoint completes, and it guards the path the nightly Docker release smoke-tests after building the image. Its existing comment records a bug that killed the offline output thread, reached `main`, and surfaced a day later as a 60-minute nightly timeout. One small model exercises that path as well as thirteen do. Only its `SMOKE_EXTRA_ARGS` comment is updated, because it pointed at the accuracy entry that this PR removes.

**`docker-release.yaml`'s golden-output check** also still uses this model, for the same reason.

If the intent is to remove this model from ATOM automation entirely, those two need a replacement smoke model chosen first. Say the word and I will follow up separately.

## Verification

- `models_accuracy.json` parses; 41 entries to 40; no `Meta-Llama-3-8B` entry remains.
- Both edited workflow files parse as YAML.
- Model selection simulated against the real filter logic for all three event types:

      atom-test  event=pull_request  level=pr       -> 13/40 models
      atom-test  event=push          level=main     -> 20/40 models
      atom-test  event=schedule      level=nightly  -> 40/40 models

- The JSON edit is textual, so the diff is 12 deleted lines and nothing else. Re-serialising the file would have silently rewritten `0.90` to `0.9` in three unrelated entries.
