### PR TITLE
[atom-vllm]: enable DSpark speculative decoding for DeepSeek-V4-Flash-0731

### DIFF
--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2024-2025, Advanced Micro Devices, Inc. All rights reserved.
 
 import torch
-import torch.nn.functional as F
 import triton
 import triton.language as tl
 from aiter.dist.communication_op import tensor_model_parallel_all_gather
@@ -174,7 +173,10 @@ class VocabParallelEmbedding(nn.Module):
             )
             y = get_tp_group().all_reduce(y, ca_fp8_quant=False)
         else:
-            y = F.embedding(x, self.weight)
+            # Not F.embedding: async scheduling can pass the -1 spec
+            # placeholder, which reads below the table and GPU-faults.
+            # replicated_embedding returns zeros out of range.
+            y = replicated_embedding(x, self.weight)
         return y
         # if self.tp_size > 1:
         #     mask = torch.logical_and(x >= self.vocab_start_idx, x < self.vocab_end_idx)
@@ -222,6 +224,23 @@ class ReplicatedEmbedding(nn.Module):
         return replicated_embedding(x, self.weight)
 
 
+class _UnquantizedHeadMethod:
+    """``QuantizeMethodBase``-shaped shim so vLLM's ``LogitsProcessor`` can drive
+    an ATOM head (EAGLE3/DSpark share the target's ``lm_head`` with the draft).
+
+    ``apply`` is the LOCAL shard GEMM only: vLLM's ``_apply_head`` does its own
+    TP gather, and ``ParallelLMHead.forward`` would double-gather.
+    """
+
+    @staticmethod
+    def apply(
+        layer: nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return tgemm.mm(x, layer.weight, layer.bias if bias is None else bias)
+
+
 class ParallelLMHead(VocabParallelEmbedding):
 
     def __init__(
@@ -232,6 +251,8 @@ class ParallelLMHead(VocabParallelEmbedding):
         **kwargs,
     ):
         super().__init__(num_embeddings, embedding_dim)
+        # Plain object, so nn.Module keeps it in __dict__, not as a submodule.
+        self.quant_method = _UnquantizedHeadMethod()
         if bias:
             self.bias = atom_parameter(
                 torch.empty(self.num_embeddings_per_partition),

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -126,6 +126,12 @@ from atom.utils.forward_context import AttnState, get_forward_context
 
 logger = logging.getLogger(__name__)
 
+# COMPILE BOUNDARY: `DeepseekV4Model.forward` is the only traced entry point.
+# `aux_hidden_state_layers` is read inside it, so Dynamo bakes in the branch and
+# the ids; from `--level 2` up the custom dispatcher replays code object 0
+# without evaluating guards, so mutating it after the first forward is silently
+# ignored. Set it at load time (`set_aux_hidden_state_layers`) and never after.
+
 # ---------------------------------------------------------------------------
 # Classical KV cache scatter / gather helpers (PR3-pre2c-B).
 #
@@ -4554,6 +4560,10 @@ class DeepseekV4Model(nn.Module):
         self.hc_head_base = atom_parameter(torch.empty(hc_mult, dtype=torch.float32))
         self.hc_head_scale = atom_parameter(torch.empty(1, dtype=torch.float32))
 
+        # 1-based layer ids whose residual is also returned, for EAGLE3 /
+        # DSpark / DFlash drafts. Set via `set_aux_hidden_state_layers`.
+        self.aux_hidden_state_layers: tuple[int, ...] = ()
+
     def forward(
         self,
         input_ids: torch.Tensor,  # [num_tokens] int  flat ragged-batch token ids
@@ -4561,10 +4571,17 @@ class DeepseekV4Model(nn.Module):
     ) -> torch.Tensor:  # [num_tokens, hc, dim]  pre-hc_head residual stream
         """Forward over `num_tokens` flat ragged-batch tokens.
 
+        TRACED ENTRY POINT — see the COMPILE BOUNDARY note at the top of the file.
+
         Returns the mHC residual stack `[num_tokens, hc, dim]` BEFORE hc_head
         reduction — `hc_head + RMSNorm + LM head` are all deferred to
         `compute_logits`. Returning the hc-shaped residual lets the (future)
         MTP draft consume it without re-expanding from a dim-reduced state.
+
+        With `aux_hidden_state_layers` set, returns `(h, aux_hidden_states)`
+        instead; each aux entry is that layer's residual averaged over hc
+        (`[num_tokens, dim]`), matching vLLM's DSv4 target, which is what the
+        DSpark drafter was trained against.
         """
         assert input_ids.dim() == 1, f"input_ids must be 1D, got {input_ids.shape}"
         # PCP note: under PCP, `input_ids`/`positions` arrive already round-robin-
@@ -4578,12 +4595,38 @@ class DeepseekV4Model(nn.Module):
         h = h.unsqueeze(-2).repeat(1, self.hc_mult, 1)
         hc_state = HCState(residual=h, post_mix=None, comb_mix=None, x_prev=None)
 
-        for layer in self.layers:
+        aux_layers = self.aux_hidden_state_layers
+        if not aux_layers:
+            for layer in self.layers:
+                hc_state = layer(hc_state, positions)
+            h = self.layers[-1].hc_post(
+                hc_state.x_prev, hc_state.residual, hc_state.post_mix, hc_state.comb_mix
+            )
+            return h
+
+        # Aux path. `hc_post` is the deferred mHC reconstruction: it turns the
+        # layer's `x_prev` + residual + mixing tensors into that layer's
+        # post-layer `[num_tokens, hc, dim]` residual, which is what aux wants.
+        aux_hidden_states: list[torch.Tensor] = []
+        final_aux_recon: torch.Tensor | None = None
+        for idx, layer in enumerate(self.layers):
             hc_state = layer(hc_state, positions)
-        h = self.layers[-1].hc_post(
-            hc_state.x_prev, hc_state.residual, hc_state.post_mix, hc_state.comb_mix
-        )
-        return h
+            if (idx + 1) in aux_layers:
+                final_aux_recon = layer.hc_post(
+                    hc_state.x_prev,
+                    hc_state.residual,
+                    hc_state.post_mix,
+                    hc_state.comb_mix,
+                )
+                aux_hidden_states.append(final_aux_recon.mean(dim=1))
+        if final_aux_recon is not None and len(self.layers) in aux_layers:
+            # Last layer was an aux layer; reuse its reconstruction.
+            h = final_aux_recon
+        else:
+            h = self.layers[-1].hc_post(
+                hc_state.x_prev, hc_state.residual, hc_state.post_mix, hc_state.comb_mix
+            )
+        return h, aux_hidden_states
 
 
 class DeepseekV4ForCausalLM(nn.Module):
@@ -4782,6 +4825,11 @@ class DeepseekV4ForCausalLM(nn.Module):
         else:
             ctx.context.input_ids = input_ids
         h = self.model(input_ids, positions)
+        # Aux layers make the inner model return `(h, aux_list)`. Unpack so the
+        # PCP fixups below keep operating on a single tensor; re-attach at exit.
+        aux_hidden_states = None
+        if isinstance(h, tuple):
+            h, aux_hidden_states = h
 
         # ----- PCP: all-gather shards, restore original order, drop pad -----
         if use_pcp:
@@ -4794,7 +4842,35 @@ class DeepseekV4ForCausalLM(nn.Module):
                 h = pcp_allgather_rerange(h, pcp_size)
                 if pad > 0:
                     h = h[:n_global]
+                if aux_hidden_states is not None:
+                    aux_hidden_states = [
+                        (
+                            pcp_allgather_rerange(a, pcp_size)[:n_global]
+                            if pad > 0
+                            else pcp_allgather_rerange(a, pcp_size)
+                        )
+                        for a in aux_hidden_states
+                    ]
+        if aux_hidden_states is not None:
+            return h, aux_hidden_states
         return h
+
+    # ----- EAGLE3 / DSpark / DFlash auxiliary hidden states -----
+    # ATOM's server-mode convention. The plugin's
+    # `_enable_eagle3_target_interface` bridges it onto vLLM's `SupportsEagle3`.
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        """`layers` are 1-based: id `i` means "after `self.layers[i-1]`"."""
+        self.model.aux_hidden_state_layers = tuple(int(i) for i in layers)
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        # Checkpoint ids are 0-based; +1 converts to the 1-based convention.
+        for attr in ("dspark_target_layer_ids", "target_layer_ids"):
+            ids = getattr(self.hf_config, attr, None)
+            if ids:
+                return tuple(int(i) + 1 for i in ids)
+        num_layers = len(self.model.layers)
+        return (2, num_layers // 2, num_layers - 3)
 
     def compute_logits(
         self,

--- a/atom/plugin/vllm/deepseek_v4_bridge.py
+++ b/atom/plugin/vllm/deepseek_v4_bridge.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Hashable
 from contextlib import contextmanager
+from functools import cache
 from types import SimpleNamespace
 
 import numpy as np
@@ -29,8 +31,13 @@ logger = logging.getLogger(__name__)
 # gfx950 / gfx1250. Mirror native's guard (deepseek_v4_attn.py): a request for an
 # fp8 KV cache on any other arch degrades to a bf16 cache instead of hard-failing.
 _V4_FP8_SUPPORTED_GFX = ("gfx950", "gfx1250")
-_V4_FP8_DOWNGRADE_WARNED = False
 _V4_SWA_DEST_RATIOS = (0, 4, 128)
+
+
+@cache
+def _warn_once(msg: str, *args: Hashable) -> None:
+    """Log once per distinct message+args; callers fire from per-step paths."""
+    logger.warning(msg, *args)
 
 
 def _v4_kv_fp8(vllm_config) -> bool:
@@ -43,7 +50,6 @@ def _v4_kv_fp8(vllm_config) -> bool:
     ``get_kv_cache_spec``), the view slicing, and the per-module bind all key off
     it, so pool geometry and the runtime dispatch never disagree.
     """
-    global _V4_FP8_DOWNGRADE_WARNED
     cache_config = getattr(vllm_config, "cache_config", None)
     cache_dtype = getattr(cache_config, "cache_dtype", None) if cache_config else None
     if not (isinstance(cache_dtype, str) and cache_dtype.startswith("fp8")):
@@ -55,15 +61,13 @@ def _v4_kv_fp8(vllm_config) -> bool:
     except Exception:
         gfx = None
     if gfx not in _V4_FP8_SUPPORTED_GFX:
-        if not _V4_FP8_DOWNGRADE_WARNED:
-            logger.warning(
-                "DeepSeek-V4 --kv-cache-dtype %r (2buff fp8) is only supported on "
-                "%s (aiter op4/op5); got gfx=%r. Falling back to a bf16 KV cache.",
-                cache_dtype,
-                "/".join(_V4_FP8_SUPPORTED_GFX),
-                gfx,
-            )
-            _V4_FP8_DOWNGRADE_WARNED = True
+        _warn_once(
+            "DeepSeek-V4 --kv-cache-dtype %r (2buff fp8) is only supported on "
+            "%s (aiter op4/op5); got gfx=%r. Falling back to a bf16 KV cache.",
+            cache_dtype,
+            "/".join(_V4_FP8_SUPPORTED_GFX),
+            gfx,
+        )
         return False
     return True
 
@@ -197,6 +201,19 @@ def _proxy_region_byte_sizes(
     return regions
 
 
+def _v4_proxy_min_blocks(vllm_config) -> int:
+    """Block count ``_proxy_page_bytes`` amortizes the fixed per-slot regions
+    over. Anything less and the page is short. See
+    ``apply_vllm_v4_profiling_min_blocks_patch``.
+    """
+    max_model_len = int(vllm_config.model_config.max_model_len)
+    return max(
+        1,
+        (max_model_len + ATOM_DEEPSEEK_V4_BLOCK_SIZE - 1)
+        // ATOM_DEEPSEEK_V4_BLOCK_SIZE,
+    )
+
+
 def _proxy_page_bytes(vllm_config) -> int:
     from atom.model_ops.attentions.v4_pool_geometry import UnifiedPoolGeometry
 
@@ -209,12 +226,7 @@ def _proxy_page_bytes(vllm_config) -> int:
     _arena_planes, arena_rows, _row_widths = _v4_state_layout(vllm_config, kv_fp8)
     win = _v4_win_with_spec(vllm_config, int(getattr(hf, "sliding_window", 128)))
     max_num_seqs = int(getattr(vllm_config.scheduler_config, "max_num_seqs", 1))
-    max_model_len = int(vllm_config.model_config.max_model_len)
-    min_blocks = max(
-        1,
-        (max_model_len + ATOM_DEEPSEEK_V4_BLOCK_SIZE - 1)
-        // ATOM_DEEPSEEK_V4_BLOCK_SIZE,
-    )
+    min_blocks = _v4_proxy_min_blocks(vllm_config)
     geometry = UnifiedPoolGeometry(
         ratios,
         num_blocks=min_blocks,
@@ -419,6 +431,80 @@ def slice_deepseek_v4_proxy_cache_views(
     }
 
 
+def _is_runtime_dummy_decode(common_attn_metadata, req_ids, num_spec_tokens) -> bool:
+    """Whether this build is a dummy decode batch that reached the ordinary path.
+
+    An idle DP rank steps via ``execute_dummy_batch()``, whose batch is the same
+    degenerate ``InputBatch.make_dummy`` a capture uses but arrives with
+    ``capturing`` False -- so a capture-only repair skips it and the rank faults.
+
+    Gated on ``req_ids == []`` ("no real requests") plus a decode shape, so
+    prefill-shaped profiling dummies, whose context is coherent, are left alone.
+    """
+    if req_ids is None or len(req_ids) != 0:
+        return False
+    max_q = int(getattr(common_attn_metadata, "max_query_len", 0) or 0)
+    return 0 < max_q <= 1 + int(num_spec_tokens)
+
+
+def _synthesize_v4_decode_context(common_attn_metadata, meta_params) -> None:
+    """Give a dummy decode batch a realistic decode context.
+
+    ``InputBatch.make_dummy`` uses ``seq_len == query_len`` and zeroed
+    ``positions``, i.e. decoding at ``start_pos == 0``. V4 decode is undefined
+    there -- the SWA gather, the committed counts and the sparse top-k all
+    derive from ``seq_len - query_len``, so the paged gather addresses outside
+    the pool. Mirrors native's ``build_for_cudagraph_capture``.
+
+    In-place value rewrite only: replays refill ``seq_lens``/``positions`` from
+    the real batch and shapes stay as vLLM chose them.
+    """
+    if meta_params is None:
+        return
+    num_reqs = int(common_attn_metadata.num_reqs)
+    q_cpu = getattr(common_attn_metadata, "query_start_loc_cpu", None)
+    if num_reqs <= 0 or q_cpu is None:
+        return
+    q_np = q_cpu[: num_reqs + 1].numpy().astype(np.int32)
+    lens = np.diff(q_np).astype(np.int32)
+    total = int(lens.sum())
+    # A prefill capture already carries a coherent context.
+    if total <= 0 or lens.max() <= 0:
+        return
+    start_pos = int(meta_params.window_size)
+
+    # context_len = start_pos + query_len, matching native's synthetic batch.
+    # Zero-query CG-padding rows keep seq_len 0 so they stay inactive.
+    seq_np = np.where(lens > 0, lens + start_pos, 0).astype(np.int32)
+    seq_lens = common_attn_metadata.seq_lens
+    seq_lens[:num_reqs].copy_(
+        torch.from_numpy(seq_np).to(seq_lens.dtype), non_blocking=True
+    )
+    # Keep every host mirror in sync with the device tensor, or the metadata
+    # describes a different batch than the kernels see.
+    seq_cpu = torch.from_numpy(seq_np).to(torch.int32)
+    ub = getattr(common_attn_metadata, "seq_lens_cpu_upper_bound", None)
+    if ub is not None:
+        ub[:num_reqs].copy_(seq_cpu.to(ub.dtype))
+    if getattr(common_attn_metadata, "_seq_lens_cpu", None) is not None:
+        common_attn_metadata._seq_lens_cpu[:num_reqs].copy_(
+            seq_cpu.to(common_attn_metadata._seq_lens_cpu.dtype)
+        )
+    else:
+        common_attn_metadata._seq_lens_cpu = seq_cpu
+    common_attn_metadata.max_seq_len = int(seq_np.max())
+
+    # positions = start_pos + within-sequence offset.
+    positions = getattr(common_attn_metadata, "positions", None)
+    if positions is not None and positions.numel() >= total:
+        batch_np = np.repeat(np.arange(num_reqs, dtype=np.int32), lens)
+        within = np.arange(total, dtype=np.int32) - q_np[batch_np]
+        pos_np = (within + start_pos).astype(np.int64)
+        positions[:total].copy_(
+            torch.from_numpy(pos_np).to(positions.dtype), non_blocking=True
+        )
+
+
 class AtomDeepseekV4ProxyMetadataBuilder(AttentionMetadataBuilder):
     # Decode is full-graph safe for uniform query batches, including speculative
     # decode where each request contributes 1 + num_speculative_tokens queries.
@@ -510,11 +596,19 @@ class AtomDeepseekV4ProxyMetadataBuilder(AttentionMetadataBuilder):
             # Pre-bind (profiling / first warmup forward, before the proxy cache is
             # bound): leave common untouched. The forward detects the missing
             # atom_v4_md and falls back to an inline eager build (force_dummy).
+            _warn_once(
+                "ATOM V4: metadata builder ran unbound (layer=%r, proxy=%s, "
+                "proxy_kv_numel=%s, profiling_cache=%s, model=%s, "
+                "meta_params=%s, capturing=%s)",
+                proxy_layer_name,
+                type(proxy).__name__ if proxy is not None else None,
+                getattr(getattr(proxy, "kv_cache", None), "numel", lambda: None)(),
+                getattr(proxy, "_atom_v4_profiling_kv_cache", None),
+                model is not None,
+                meta_params is not None,
+                capturing,
+            )
             return common_attn_metadata
-        slot_allocator = (
-            None if capturing else getattr(model, "_atom_v4_slot_allocator", None)
-        )
-        decode_bufs = getattr(model, "_atom_v4_decode_bufs", None)
         # Batch-ordered req_ids exposed by the ATOM vLLM patch for this step;
         # used as the host-resident state-slot key (no block-table D2H). None
         # when the patch isn't applied (standalone/tests) -> build falls back.
@@ -526,8 +620,16 @@ class AtomDeepseekV4ProxyMetadataBuilder(AttentionMetadataBuilder):
                 )
 
                 req_ids = get_current_req_ids()
-            except Exception:
+            except Exception:  # noqa: BLE001 - passthrough patch is optional
                 req_ids = None
+        if capturing or _is_runtime_dummy_decode(
+            common_attn_metadata, req_ids, self._num_spec_tokens
+        ):
+            _synthesize_v4_decode_context(common_attn_metadata, meta_params)
+        slot_allocator = (
+            None if capturing else getattr(model, "_atom_v4_slot_allocator", None)
+        )
+        decode_bufs = getattr(model, "_atom_v4_decode_bufs", None)
         md = build_atom_v4_attention_metadata(
             common_attn_metadata,
             meta_params=meta_params,
@@ -627,7 +729,7 @@ def register_deepseek_v4_proxy_layer(
     vllm_config,
     layer_name: str = ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME,
 ) -> AtomDeepseekV4ProxyAttention:
-    from atom.plugin.vllm.deepseek_v4_prefix_patch import (
+    from atom.plugin.vllm.deepseek_v4_profiling_patch import (
         apply_vllm_v4_profile_cache_patch,
     )
 
@@ -843,6 +945,9 @@ class _V4DecodeMetaBuffers:
         # (padded decode batch); max_q_len == 1 + max_spec_steps.
         self.decode_running_bs = S
         self.decode_q_len = max(1, T // S)
+        # Completion of the previous build's staging H2Ds; see
+        # `gate_staging_reuse`.
+        self._h2d_done = torch.cuda.Event()
         self.plan_buffers: dict[int, dict] = {}
         for ratio, is_overlap in ratios_overlap:
             ratio = int(ratio)
@@ -852,6 +957,28 @@ class _V4DecodeMetaBuffers:
                 "compress": i32(cap, 4),
                 "write": i32(max(1, T), 4),
             }
+
+    def gate_staging_reuse(self):
+        """Block until the previous build's staging H2Ds have executed.
+
+        ``stage`` copies non-blocking out of one pinned host buffer per name.
+        Stream ordering protects the GPU side, not the host side, so the next
+        build's ``buf.np[:n] = arr`` races the previous DMA. Async scheduling
+        removes the sampled-token sync that used to drain it, and a torn
+        ``kv_indptr`` faults the decode kernel.
+
+        Depth-1, as in native's ``model_runner._gate_staging_reuse``: one host
+        buffer admits one build of lead. Skipped while capturing -- events are
+        illegal in a capture region and there is no CPU run-ahead to guard.
+        """
+        if not torch.cuda.is_current_stream_capturing():
+            self._h2d_done.synchronize()
+
+    def mark_h2d_enqueued(self):
+        """Close the window ``gate_staging_reuse`` waits on. Called once per
+        build, after the last staging copy, so one event covers them all."""
+        if not torch.cuda.is_current_stream_capturing():
+            self._h2d_done.record()
 
     def stage(self, buf, arr_np):
         """Copy ``arr_np`` into the head of CpuGpuBuffer ``buf`` and return the
@@ -1455,6 +1582,8 @@ def build_atom_v4_attention_metadata(
 
     if decode_persistent:
         bufs = decode_bufs
+        # Make the pinned host buffers safe to overwrite before staging below.
+        bufs.gate_staging_reuse()
         md.state_slot_out_cpu = physical_slot_arr
         md.state_slot_out = bufs.stage(bufs.state_slot_out, physical_slot_arr)
         md.state_slot_in = bufs.stage(bufs.state_slot_in, physical_slot_arr)
@@ -1541,6 +1670,8 @@ def build_atom_v4_attention_metadata(
             md.qo_indptr = bufs.qo_indptr.copy_to_gpu(T_pad + 1)
             bufs.kv_last_page_lens.np[:T_pad] = 1
             md.kv_last_page_lens = bufs.kv_last_page_lens.copy_to_gpu(T_pad)
+        # Last staging copy of this build is enqueued.
+        bufs.mark_h2d_enqueued()
         return md
 
     # ---- eager path: prefill, or decode without persistent buffers ----
@@ -2038,8 +2169,37 @@ def _is_vllm_decode_graph_phase(attn_metadata, atom_config) -> bool:
         if not (is_uniform_decode_bucket or is_single_query_decode):
             return False
         return bool(getattr(vllm_monitor, "cudagraph_capturing_enabled", False))
-    except Exception:
+    except Exception:  # noqa: BLE001 - vLLM capture state is best-effort
         return False
+
+
+def _warn_inline_v4_build(common_attn_metadata, proxy_layer_name) -> None:
+    """Diagnose a bound forward that still had to build metadata inline.
+
+    Once the proxy cache is bound the builder should attach ``atom_v4_md`` and
+    the forward should take the fast path, the only graph-safe one. Reaching the
+    inline fallback with a live allocator means the builder never ran, or ran
+    for a different object. Log it rather than degrade silently.
+    """
+    from vllm.forward_context import get_forward_context, is_forward_context_available
+
+    keys = None
+    if is_forward_context_available():
+        meta = get_forward_context().attn_metadata
+        if isinstance(meta, dict):
+            keys = tuple(sorted(meta))
+        elif isinstance(meta, list) and meta and isinstance(meta[0], dict):
+            keys = tuple(sorted(meta[0]))
+        else:
+            keys = f"<{type(meta).__name__}>"
+    _warn_once(
+        "ATOM V4: inline attention-metadata build on a bound forward "
+        "(proxy_layer=%r, common_attn_metadata=%s, forward-context attn keys=%s). "
+        "The prebuilt fast path was missed; decode graph capture is unsafe here.",
+        proxy_layer_name,
+        type(common_attn_metadata).__name__ if common_attn_metadata else None,
+        keys,
+    )
 
 
 @contextmanager
@@ -2086,6 +2246,8 @@ def atom_deepseek_v4_forward_context(
     if attn_metadata is None:
         # Fallback (profiling / dummy / standalone, before the proxy cache is
         # bound): build inline with fresh tensors. Never captured.
+        if slot_allocator is not None:
+            _warn_inline_v4_build(common_attn_metadata, proxy_layer_name)
         if common_attn_metadata is not None:
             common_attn_metadata.positions = positions
         _spec_cfg = getattr(atom_config, "speculative_config", None)
@@ -2094,6 +2256,18 @@ def atom_deepseek_v4_forward_context(
             if _spec_cfg is not None
             else 0
         )
+        # With a live allocator this fallback is a *real* build (the first bound
+        # forward lands here), so it needs the same host-resident slot key the
+        # fast path uses. Without it the allocator's fail-fast contract trips,
+        # or it silently uses throwaway arange slots and scribbles over live
+        # per-request state.
+        _req_ids = None
+        try:
+            from atom.plugin.vllm.req_id_passthrough_patch import get_current_req_ids
+
+            _req_ids = get_current_req_ids()
+        except Exception:  # noqa: BLE001 - passthrough patch is optional
+            _req_ids = None
         attn_metadata = build_atom_v4_attention_metadata(
             common_attn_metadata,
             meta_params=meta_params,
@@ -2103,6 +2277,7 @@ def atom_deepseek_v4_forward_context(
                 if state_model is not None
                 else None
             ),
+            req_ids=_req_ids,
             num_spec_tokens=_num_spec,
         )
         # Selective per-slot reset: clear only the slots the allocator just

--- a/atom/plugin/vllm/deepseek_v4_prefix_patch.py
+++ b/atom/plugin/vllm/deepseek_v4_prefix_patch.py
@@ -1,29 +1,19 @@
-"""ATOM DeepSeek-V4 vLLM prefix-cache SWA-recompute patch.
+"""ATOM DeepSeek-V4 vLLM prefix-cache tail-recompute patch.
 
-V4's sliding-window (SWA) state is a per-request ring stored in a fixed
-per-slot region of the ATOM proxy arena -- it is NOT keyed by a vLLM block, so
-vLLM's block-level prefix cache never carries it. CSA/HCA compressed history,
-by contrast, lives in the 128-token proxy pages and is reused for free on a
-prefix-cache hit.
+V4's sliding-window state is a per-request ring in the ATOM proxy arena, not
+keyed by a vLLM block, so vLLM's block-level prefix cache never carries it. On a
+cross-request hit the new request gets an empty ring, and a tail token whose
+window reaches into the cached region reads stale data.
 
-On a cross-request prefix hit the new request gets a fresh per-request state
-slot whose SWA ring is empty; a non-block-aligned tail token whose SWA window
-reaches back into the cached (not-re-forwarded) region would then read stale
-ring data.
+Fix (mirrors native ATOM scheduler "fix B'"): roll every hit back by
+``max(win_with_spec, index_topk)`` tokens so that tail is re-forwarded,
+repopulating the ring. Compressed-KV reuse is unaffected -- ``n_committed =
+context_len // ratio`` is invariant under the shift.
 
-Fix (mirrors native ATOM scheduler "fix B'"): on a hit, drop the last
-``ceil(win_with_spec / block_size)`` cached blocks so those tail tokens are
-re-forwarded, repopulating the ring. The re-forwarded region is >= the ring
-stride, so by the last prompt token ``prefix_swa_count`` collapses to 0 and its
-whole window is served from the freshly computed extend KV. Compressed-KV reuse
-is unaffected: ``n_committed = context_len // ratio`` and
-``context_len = cached + scheduled`` is invariant under the shift.
-
-In plugin mode vLLM owns the scheduler / KVCacheManager, so the block drop is
-applied by wrapping ``KVCacheManager.get_computed_blocks`` -- the single point
-where vLLM computes the local prefix-cache hit length. It is only called when
-``request.num_computed_tokens == 0`` (a genuine cross-request hit), never on a
-chunked-prefill resume, whose SWA ring is already populated by prior chunks.
+KNOWN ISSUE: the ``index_topk`` term is empirical (512 on V4-Flash vs a
+128-token window) and the same floor appears with prefix caching off, so the
+underlying defect is in the sparse indexer whenever fewer than ``index_topk``
+rows are forwarded into a request's own state. This rollback is a workaround.
 """
 
 import functools
@@ -31,12 +21,6 @@ import logging
 import math
 
 logger = logging.getLogger("atom")
-
-
-def _mark_v4_proxy_cache_mode(static_forward_context, is_profiling: bool) -> None:
-    for layer in static_forward_context.values():
-        if getattr(layer, "_atom_v4_proxy_layer", False):
-            layer._atom_v4_profiling_kv_cache = is_profiling
 
 
 _V4_PROXY_LAYER_MARKERS = (
@@ -126,84 +110,77 @@ def apply_vllm_v4_block_reuse_patch() -> None:
     logger.info("ATOM DeepSeek-V4: installed packed-proxy block reuse patch")
 
 
-def apply_vllm_v4_profile_cache_patch() -> None:
-    """Mark vLLM 0.26's temporary CUDA-graph profiling KV cache.
-
-    The temporary cache intentionally contains only one block per captured
-    request and cannot hold V4's fixed per-request SWA arena. The V4 forward
-    must therefore stay on its existing dummy-attention path until vLLM
-    installs the real cache.
-    """
-    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
-
-    original = GPUModelRunner.initialize_kv_cache
-    if getattr(original, "_atom_v4_profile_cache_patched", False):
-        return
-
-    @functools.wraps(original)
-    def wrapped_initialize_kv_cache(
-        self,
-        kv_cache_config,
-        is_profiling: bool = False,
-    ):
-        result = original(
-            self,
-            kv_cache_config,
-            is_profiling=is_profiling,
-        )
-        _mark_v4_proxy_cache_mode(
-            self.compilation_config.static_forward_context,
-            is_profiling,
-        )
-        return result
-
-    wrapped_initialize_kv_cache._atom_v4_profile_cache_patched = True
-    GPUModelRunner.initialize_kv_cache = wrapped_initialize_kv_cache
-
-
 def _v4_sliding_window(vllm_config) -> int:
     hf = vllm_config.model_config.hf_config
     return int(getattr(hf, "sliding_window", 128) or 128)
 
 
-def _drop_swa_warmup_blocks(
+def _group_block_sizes(manager):
+    """Real block size per KV cache group, in ``KVCacheBlocks.blocks`` order.
+
+    Returns [] on an unexpected manager shape; the caller then falls back to the
+    proxy block size.
+    """
+    try:
+        return [m.block_size for m in manager.coordinator.single_type_managers]
+    except AttributeError:
+        return []
+
+
+def _roll_back_prefix_hit(
     manager,
     computed_blocks,
     num_computed_tokens: int,
     shared_prefix_boundary: int,
     *,
-    warmup_blocks: int,
-    block_size: int,
+    rollback_tokens: int,
 ):
-    if num_computed_tokens <= 0:
+    """Shorten a prefix hit by ``rollback_tokens`` so the tail is re-forwarded,
+    repopulating the SWA ring and the sparse indexer's rows. Deep-prefix blocks
+    are still reused.
+
+    The rollback is expressed in **tokens**, not blocks, and converted per group
+    using that group's own block size: DSpark adds a second group at block 64
+    alongside the proxy's 128, and a shared block count would leave one group
+    holding blocks past its declared ``num_computed_tokens``.
+    """
+    # Local import: deepseek_v4_bridge imports back into this package.
+    from atom.plugin.vllm.deepseek_v4_bridge import ATOM_DEEPSEEK_V4_BLOCK_SIZE
+
+    if num_computed_tokens <= 0 or rollback_tokens <= 0:
         return computed_blocks, num_computed_tokens, shared_prefix_boundary
 
-    # Drop the trailing warmup blocks from every KV cache group (V4 runs a
-    # single proxy group). vLLM allocates fresh blocks for the dropped tail and
-    # re-forwards those tokens, repopulating the SWA ring; the deep-prefix blocks
-    # are still reused.
-    dropped = 0
+    # rollback_tokens is a multiple of every group's block size and
+    # num_computed_tokens is block-aligned, so the difference stays aligned.
+    new_num_computed_tokens = max(0, num_computed_tokens - rollback_tokens)
+
+    block_sizes = _group_block_sizes(manager)
+    groups = list(computed_blocks.blocks)
     new_groups = []
-    for group in computed_blocks.blocks:
+    dropped_any = False
+    for idx, group in enumerate(groups):
         block_list = list(group)
-        keep = max(0, len(block_list) - warmup_blocks)
-        dropped = max(dropped, len(block_list) - keep)
+        block_size = (
+            block_sizes[idx] if idx < len(block_sizes) else ATOM_DEEPSEEK_V4_BLOCK_SIZE
+        )
+        keep = min(len(block_list), new_num_computed_tokens // block_size)
+        if keep != len(block_list):
+            dropped_any = True
         new_groups.append(block_list[:keep])
-    if dropped == 0:
+    if not dropped_any:
         return computed_blocks, num_computed_tokens, shared_prefix_boundary
 
-    new_num_computed_tokens = max(0, num_computed_tokens - dropped * block_size)
     new_blocks = manager.create_kv_cache_blocks(tuple(new_groups))
     return new_blocks, new_num_computed_tokens, shared_prefix_boundary
 
 
-def apply_vllm_v4_prefix_swa_patch(vllm_config) -> None:
-    """Enable DeepSeek-V4 prefix caching by dropping the SWA warmup blocks.
+def apply_vllm_v4_prefix_recompute_patch(vllm_config) -> None:
+    """Enable DeepSeek-V4 prefix caching by recomputing the tail of every hit.
 
     Call only for a DeepSeek-V4 deployment with prefix caching enabled. The
-    number of blocks to drop is derived once from ``vllm_config`` and captured
-    in the wrapper closure, so non-V4 deployments (which never install this
-    patch) are unaffected.
+    rollback length is derived once from ``vllm_config`` and captured in the
+    wrapper closure, so non-V4 deployments (which never install this patch) are
+    unaffected.
     """
     from vllm.v1.core.kv_cache_manager import KVCacheManager
 
@@ -217,12 +194,23 @@ def apply_vllm_v4_prefix_swa_patch(vllm_config) -> None:
     # (MTP draft tokens get their own ring slots). Rolling back ceil(stride /
     # block_size) whole blocks guarantees the re-forwarded region covers the full
     # ring, so the last prompt token reads its entire window from extend KV.
-    warmup_blocks = math.ceil(win_with_spec / ATOM_DEEPSEEK_V4_BLOCK_SIZE)
-    if warmup_blocks <= 0:
+    # The ring is not the only state a hit fails to carry: leaving fewer than
+    # `index_topk` freshly-forwarded tokens makes the sparse indexer emit another
+    # request's content. Empirical on V4-Flash-0731 (TP4, greedy, long shared
+    # prefix): 128/256/384 -> 1/6 correct, 512 -> 6/6, and 512 holds at 2K/6K/17K
+    # prefixes, so it is a constant. Keep both terms.
+    index_topk = int(getattr(vllm_config.model_config.hf_config, "index_topk", 0) or 0)
+    rollback_tokens = max(win_with_spec, index_topk)
+    # Round up to a whole proxy block: the rollback must be a multiple of every
+    # group's block size, and the proxy's 128 is the coarsest in play (and a
+    # multiple of the DSpark draft group's 64).
+    rollback_blocks = math.ceil(rollback_tokens / ATOM_DEEPSEEK_V4_BLOCK_SIZE)
+    if rollback_blocks <= 0:
         return
+    rollback_tokens = rollback_blocks * ATOM_DEEPSEEK_V4_BLOCK_SIZE
 
     original = KVCacheManager.get_computed_blocks
-    if getattr(original, "_atom_v4_prefix_swa_patched", False):
+    if getattr(original, "_atom_v4_prefix_recompute_patched", False):
         return
 
     @functools.wraps(original)
@@ -230,21 +218,22 @@ def apply_vllm_v4_prefix_swa_patch(vllm_config) -> None:
         computed_blocks, num_computed_tokens, shared_prefix_boundary = original(
             self, request
         )
-        return _drop_swa_warmup_blocks(
+        return _roll_back_prefix_hit(
             self,
             computed_blocks,
             num_computed_tokens,
             shared_prefix_boundary,
-            warmup_blocks=warmup_blocks,
-            block_size=ATOM_DEEPSEEK_V4_BLOCK_SIZE,
+            rollback_tokens=rollback_tokens,
         )
 
-    wrapped_get_computed_blocks._atom_v4_prefix_swa_patched = True
+    wrapped_get_computed_blocks._atom_v4_prefix_recompute_patched = True
     KVCacheManager.get_computed_blocks = wrapped_get_computed_blocks
     logger.info(
         "ATOM DeepSeek-V4: prefix caching enabled with SWA recompute "
-        "(drop last %d cached block(s) per hit, win_with_spec=%d, block_size=%d).",
-        warmup_blocks,
+        "(roll back last %d token(s) per hit = %d proxy block(s), "
+        "win_with_spec=%d, index_topk=%d).",
+        rollback_tokens,
+        rollback_blocks,
         win_with_spec,
-        ATOM_DEEPSEEK_V4_BLOCK_SIZE,
+        index_topk,
     )

--- a/atom/plugin/vllm/deepseek_v4_profiling_patch.py
+++ b/atom/plugin/vllm/deepseek_v4_profiling_patch.py
@@ -1,0 +1,125 @@
+"""ATOM DeepSeek-V4 patches for vLLM's throwaway cudagraph-profiling KV cache.
+
+vLLM sizes it at one block per sequence, which is short for the V4 proxy page.
+Both patches below no-op for non-V4 models. Nothing here concerns prefix
+caching; see ``deepseek_v4_prefix_patch`` for that.
+"""
+
+import functools
+import logging
+
+logger = logging.getLogger("atom")
+
+
+def _mark_v4_proxy_cache_mode(static_forward_context, is_profiling: bool) -> None:
+    for layer in static_forward_context.values():
+        if getattr(layer, "_atom_v4_proxy_layer", False):
+            layer._atom_v4_profiling_kv_cache = is_profiling
+
+
+def apply_vllm_v4_profile_cache_patch() -> None:
+    """Mark vLLM 0.26's temporary CUDA-graph profiling KV cache.
+
+    The temporary cache intentionally contains only one block per captured
+    request and cannot hold V4's fixed per-request SWA arena. The V4 forward
+    must therefore stay on its existing dummy-attention path until vLLM
+    installs the real cache.
+    """
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    original = GPUModelRunner.initialize_kv_cache
+    if getattr(original, "_atom_v4_profile_cache_patched", False):
+        return
+
+    @functools.wraps(original)
+    def wrapped_initialize_kv_cache(
+        self,
+        kv_cache_config,
+        is_profiling: bool = False,
+    ):
+        result = original(
+            self,
+            kv_cache_config,
+            is_profiling=is_profiling,
+        )
+        _mark_v4_proxy_cache_mode(
+            self.compilation_config.static_forward_context,
+            is_profiling,
+        )
+        return result
+
+    wrapped_initialize_kv_cache._atom_v4_profile_cache_patched = True
+    GPUModelRunner.initialize_kv_cache = wrapped_initialize_kv_cache
+
+
+def apply_vllm_v4_profiling_min_blocks_patch(vllm_config=None) -> None:
+    """Make vLLM's cudagraph-profiling KV cache big enough for the V4 proxy.
+
+    ``_init_minimal_kv_cache_for_profiling`` allocates one block per sequence,
+    which only works for a backend whose per-page bytes are self-contained. The
+    V4 proxy page is not -- ``_proxy_page_bytes`` amortizes the SWA ring across
+    ``ceil(max_model_len / 128)`` pages -- so less raises "proxy cache too
+    small". Raise the floor to that count; the blocks are transient.
+
+    ``vllm_config`` only seeds the log line; the floor is re-derived at call
+    time so this stays installable from ``register_model()``.
+    """
+    from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+    from atom.plugin.vllm.deepseek_v4_bridge import _v4_proxy_min_blocks
+
+    original = getattr(GPUModelRunner, "_init_minimal_kv_cache_for_profiling", None)
+    if original is None or getattr(original, "_atom_v4_min_blocks_patched", False):
+        return
+
+    def _proxy_min_blocks_for(config) -> int:
+        mc = getattr(config, "model_config", None)
+        if mc is None or not any(
+            "DeepseekV4" in str(a) for a in (getattr(mc, "architectures", None) or [])
+        ):
+            return 0
+        return _v4_proxy_min_blocks(config)
+
+    # The count is computed inside the original and the inputs that would steer
+    # it also size the metadata builders it constructs, so intercept the one
+    # thing carrying the count: the KVCacheConfig it builds.
+    from vllm.v1.core import kv_cache_utils
+
+    @functools.wraps(original)
+    def wrapped_init_minimal_kv_cache_for_profiling(self):
+        floor = _proxy_min_blocks_for(getattr(self, "vllm_config", None))
+        if floor <= 0:
+            return original(self)
+
+        inner = kv_cache_utils.get_kv_cache_config_from_groups
+
+        @functools.wraps(inner)
+        def floored(*args, **kwargs):
+            config = inner(*args, **kwargs)
+            old = int(config.num_blocks)
+            if old <= 0 or old >= floor:
+                return config
+            for tensor in config.kv_cache_tensors:
+                tensor.size = (tensor.size // old) * floor
+            config.num_blocks = floor
+            return config
+
+        kv_cache_utils.get_kv_cache_config_from_groups = floored
+        try:
+            return original(self)
+        finally:
+            kv_cache_utils.get_kv_cache_config_from_groups = inner
+
+    wrapped_init_minimal_kv_cache_for_profiling._atom_v4_min_blocks_patched = True
+    GPUModelRunner._init_minimal_kv_cache_for_profiling = (
+        wrapped_init_minimal_kv_cache_for_profiling
+    )
+    logger.info(
+        "ATOM DeepSeek-V4: cudagraph-profiling KV cache floor installed "
+        "(%s; the proxy page amortizes the SWA ring over exactly that many).",
+        (
+            f"{_proxy_min_blocks_for(vllm_config)} blocks"
+            if vllm_config is not None
+            else "resolved per model runner"
+        ),
+    )

--- a/atom/plugin/vllm/dspark_draft_kv_patch.py
+++ b/atom/plugin/vllm/dspark_draft_kv_patch.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Keep the DSpark draft's sliding-window KV group out of the prefix cache.
+
+Under ``--speculative-config '{"method":"dspark"}'`` there are two KV groups:
+ATOM's V4 proxy (``FullAttentionSpec``, block 128) and the draft's three MLA
+layers (``SlidingWindowMLASpec``, block 64, window 128).
+``find_longest_cache_hit`` reconciles groups to the minimum and
+``remove_skipped_blocks`` frees draft blocks while the previous request is still
+decoding, so the draft caps the whole request's hit at whatever stale run
+survived eviction (17.4% observed, against 84.9% for ATOM native).
+
+Skipping the lookup is safe: ``_roll_back_prefix_hit`` re-forwards the last
+512 tokens of every hit and the draft reads only the last 128.
+
+Registered through vLLM's ``@register_kv_cache_spec`` seam rather than a
+coordinator monkeypatch, so page size, memory accounting and allocation are
+inherited unchanged. The hit-rate recovery is not yet measured on hardware.
+"""
+
+import dataclasses
+import logging
+
+logger = logging.getLogger("atom")
+
+_spec_cls = None
+_registered = False
+# Cached so a rebuild cannot hand out a second, unequal type that pickle would
+# then resolve inconsistently.
+_built = None
+
+
+def _build_spec_and_manager():
+    """Define the spec/manager pair lazily: importing
+    ``vllm.v1.core.single_type_kv_cache_manager`` at module import time drags in
+    vLLM's scheduler core before the plugin has registered models.
+    """
+    global _built
+    if _built is not None:
+        return _built
+
+    from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+    from vllm.v1.kv_cache_interface import SlidingWindowMLASpec
+
+    @dataclasses.dataclass(frozen=True, kw_only=True)
+    class DSparkDraftSWAMLASpec(SlidingWindowMLASpec):
+        """No added fields, so sizing is identical to ``SlidingWindowMLASpec``.
+        Exists only so the registry can route it to a different manager."""
+
+    class DSparkDraftSWAManager(SlidingWindowManager):
+        """Sliding-window manager that abstains from the prefix cache. Only the
+        two prefix-cache entry points are overridden; allocation and
+        ``remove_skipped_blocks`` recycling stay on the inherited path."""
+
+        @classmethod
+        def find_longest_cache_hit(
+            cls,
+            block_hashes,
+            max_length: int,
+            kv_cache_group_ids,
+            block_pool,
+            kv_cache_spec,
+            drop_eagle_block: bool,
+            alignment_tokens: int,
+            dcp_world_size: int = 1,
+            pcp_world_size: int = 1,
+        ):
+            """Return the candidate hit unchanged, backed by null blocks.
+
+            The reconciled hit is the minimum over groups, so returning the
+            candidate drops this group out of it. ``null_block`` declares the
+            tokens computed without claiming storage, and a leading null run is
+            the normal sliding-window shape. ``drop_eagle_block`` must still be
+            honoured: the coordinator passes ``candidate + block_size`` for it.
+            """
+            block_size = kv_cache_spec.block_size
+            hit_length = max_length
+            if drop_eagle_block:
+                hit_length = max(0, hit_length - block_size)
+            # The coordinator only accepts alignment-aligned hit lengths.
+            if alignment_tokens:
+                hit_length -= hit_length % alignment_tokens
+            hit_length -= hit_length % block_size
+            num_blocks = hit_length // block_size
+            computed_blocks = tuple(
+                [block_pool.null_block] * num_blocks for _ in kv_cache_group_ids
+            )
+            return computed_blocks, hit_length
+
+        def cache_blocks(self, request, num_tokens, retention_interval=None) -> None:
+            """Publish nothing: the lookup above never consults the hash map."""
+            return
+
+    # The KVCacheConfig holding these specs is pickled to every worker, and
+    # pickle resolves a class by __module__ + __qualname__ -- a `<locals>`
+    # qualname resolves nowhere. Rewrite both onto this module; `__getattr__`
+    # below rebuilds the pair for workers that never registered.
+    for cls in (DSparkDraftSWAMLASpec, DSparkDraftSWAManager):
+        cls.__module__ = __name__
+        cls.__qualname__ = cls.__name__
+
+    _built = (DSparkDraftSWAMLASpec, DSparkDraftSWAManager)
+    return _built
+
+
+def __getattr__(name):
+    """Resolve the lazily-built classes by name, for pickle (PEP 562)."""
+    if name in ("DSparkDraftSWAMLASpec", "DSparkDraftSWAManager"):
+        spec_cls, manager_cls = _built or _build_spec_and_manager()
+        return {
+            "DSparkDraftSWAMLASpec": spec_cls,
+            "DSparkDraftSWAManager": manager_cls,
+        }[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def ensure_registered():
+    """Register the draft spec/manager pair, once, after vLLM's built-ins.
+
+    ``_ensure_registered`` populates the built-ins only ``if not
+    _REGISTRY_KVCACHESPEC_LIST``, so registering into an empty registry would
+    short-circuit that pass and leave every built-in unregistered.
+
+    Not hung off ``ATOMPlatform.register_custom_kv_cache_specs`` because
+    ATOMPlatform is often not the live platform -- see
+    ``platform.install_platform_config_hook``.
+    """
+    global _spec_cls, _registered
+    if _registered:
+        return _spec_cls
+
+    from vllm.v1.kv_cache_interface import SlidingWindowMLASpec
+    from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+    KVCacheSpecRegistry._ensure_registered()
+
+    spec_cls, manager_cls = _build_spec_and_manager()
+    KVCacheSpecRegistry.register(
+        kvcache_spec_cls=spec_cls,
+        manager_class=manager_cls,
+        # Stay grouping-compatible so `is_uniform_type` still accepts the three
+        # draft layers as one group.
+        uniform_type_base_spec=SlidingWindowMLASpec,
+    )
+    _spec_cls = spec_cls
+    _registered = True
+    return spec_cls
+
+
+def convert_draft_specs(draft_specs):
+    """Retype the draft's sliding-window specs, leaving field values intact.
+
+    Returns the input unchanged for a non-DSpark draft, or if the conversion
+    fails -- a prefix-cache optimisation must never stop a server starting.
+    """
+    from vllm.v1.kv_cache_interface import SlidingWindowMLASpec
+
+    if not draft_specs:
+        return draft_specs
+    if not all(type(spec) is SlidingWindowMLASpec for spec in draft_specs.values()):
+        return draft_specs
+    try:
+        spec_cls = ensure_registered()
+        converted = {}
+        for name, spec in draft_specs.items():
+            # Init fields only: `__post_init__` recomputes `page_size_padded`,
+            # so the round-trip is idempotent.
+            kwargs = {
+                f.name: getattr(spec, f.name)
+                for f in dataclasses.fields(spec)
+                if f.init
+            }
+            converted[name] = spec_cls(**kwargs)
+    except Exception:
+        logger.warning(
+            "ATOM DeepSeek-V4: could not retype the DSpark draft SWA specs; "
+            "falling back to vLLM's stock sliding-window manager. The draft "
+            "group will cap the target's prefix-cache hit.",
+            exc_info=True,
+        )
+        return draft_specs
+
+    logger.info(
+        "ATOM DeepSeek-V4: DSpark draft SWA group (%d layers) excluded from "
+        "prefix-cache hit reconciliation; its window is rebuilt by the SWA "
+        "recompute.",
+        len(converted),
+    )
+    return converted

--- a/atom/plugin/vllm/model_wrapper.py
+++ b/atom/plugin/vllm/model_wrapper.py
@@ -531,7 +531,7 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
             self._enable_eagle3_target_interface()
         if self.is_mtp:
             self.get_mtp_target_hidden_states = self._get_mtp_target_hidden_states
-        if self.is_mtp or self.is_eagle3:
+        if self.is_mtp or self.is_eagle3 or self.is_dspark:
             # Mirror nested attributes required by vLLM speculative decoding.
             self._expose_spec_decode_attrs()
 
@@ -643,6 +643,12 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
         if inner is not None:
             if not hasattr(model, "embedding") and hasattr(inner, "embed"):
                 put(model, "embedding", inner.embed)
+            # DSpark's draft loader aliases the target embedding under
+            # `embed_tokens` only. Without this name the alias silently no-ops
+            # and the draft runs off its own all-zero table
+            # (`has_own_embed_tokens = False`, so the checkpoint never fills it).
+            if not hasattr(model, "embed_tokens") and hasattr(inner, "embed"):
+                put(model, "embed_tokens", inner.embed)
             if not hasattr(model, "lm_head") and hasattr(inner, "head"):
                 put(model, "lm_head", inner.head)
 
@@ -996,7 +1002,12 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
                     )
                 else:
                     hidden_states = self.model(input_ids=input_ids, positions=positions)
-                    self._mtp_target_hidden_states = hidden_states
+                    if isinstance(hidden_states, tuple):
+                        # EAGLE3/DSpark/DFlash return `(hidden, aux_list)`; vLLM
+                        # unpacks it itself, but the MTP cache wants only hidden.
+                        self._mtp_target_hidden_states = hidden_states[0]
+                    else:
+                        self._mtp_target_hidden_states = hidden_states
         else:
             if (
                 self.model_arch in {"Qwen3NextMTP", "DeepSeekMTPModel"}

--- a/atom/plugin/vllm/models/deepseek_v4.py
+++ b/atom/plugin/vllm/models/deepseek_v4.py
@@ -91,6 +91,22 @@ class IndexerVllm(IndexerBase):
                 q_quant, weights, block_tables, indexer_meta, topk
             )  # [total_tokens, topk] int32
 
+        if num_decode_tokens >= q_quant.size(0):
+            # All rows are decode rows, so the prefill slice is empty and
+            # `_score_topk_prefill` would chunk by a zero step. Reachable when a
+            # step is prefill-classified but carries only decode rows.
+            return self._score_topk_decode(
+                q_quant,
+                weights,
+                block_tables,
+                indexer_meta,
+                topk,
+                next_n=int(indexer_meta["decode_next_n"]),
+                n_committed_per_seq=indexer_meta["n_committed_per_seq_gpu"][
+                    : int(indexer_meta["num_decodes"])
+                ],
+            )
+
         num_decodes = int(indexer_meta["num_decodes"])
         n_committed_per_seq = indexer_meta["n_committed_per_seq_gpu"]
         # Decode rows: paged fixed-shape logits (bounded per-seq, no batch-sum).
@@ -376,11 +392,15 @@ class DeepseekV4ModelVllm(DeepseekV4ModelBase):
         )
 
     def forward(self, input_ids: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
-        h = super().forward(input_ids, positions)
+        out = super().forward(input_ids, positions)
+        # `(h, aux)` when an EAGLE3/DSpark draft configured aux layers.
+        h, aux_hidden_states = out if isinstance(out, tuple) else (out, None)
         # In-graph copy_: captured into the CUDAGraph so it refreshes the buffer
         # on every replay, keeping the MTP draft's input hidden states current.
         num_tokens = h.shape[0]
         self._mtp_hidden_buffer[:num_tokens].copy_(h.flatten(1))
+        if aux_hidden_states is not None:
+            return h, aux_hidden_states
         return h
 
 

--- a/atom/plugin/vllm/platform.py
+++ b/atom/plugin/vllm/platform.py
@@ -32,15 +32,61 @@ def _chunked_prefill_on(scheduler_config) -> bool:
     )
 
 
+def _demote_piecewise_cudagraph(vllm_config) -> None:
+    """Drop the piecewise cudagraph component when there is nothing to split on.
+
+    ``set_splitting_ops_for_v1`` already demotes ``PIECEWISE -> NONE`` and
+    ``FULL_AND_PIECEWISE -> FULL`` on empty ``splitting_ops``, but it
+    early-returns unless ``mode == VLLM_COMPILE`` -- so on a plugin path, where
+    ATOM owns the model and vLLM compiles nothing, the demotion never runs.
+
+    A "piecewise" graph with no splitting ops is the whole model, which vLLM
+    dispatches with ``num_reqs=None``, i.e. any batch under the captured token
+    count is replayable. V4 attention bakes its grids from the captured batch,
+    so replaying an 8-token decode graph for a 6+1 batch faults the GPU.
+
+    ``FULL_DECODE_ONLY`` rather than ``FULL``: V4 prefill is eager, so a full
+    graph over mixed batches is not capturable either.
+    """
+    cc = getattr(vllm_config, "compilation_config", None)
+    if cc is None:
+        return
+    from vllm.config import CompilationMode, CUDAGraphMode
+
+    if getattr(cc, "mode", None) == CompilationMode.VLLM_COMPILE:
+        return  # vLLM compiles the model itself; its own demotion applies.
+    if getattr(cc, "splitting_ops", None):
+        return
+    mode = getattr(cc, "cudagraph_mode", None)
+    if mode is None or not mode.has_piecewise_cudagraphs():
+        return
+    demoted = (
+        CUDAGraphMode.FULL_DECODE_ONLY
+        if mode.has_full_cudagraphs()
+        else CUDAGraphMode.NONE
+    )
+    cc.cudagraph_mode = demoted
+    logger.warning(
+        "ATOM DeepSeek-V4: cudagraph_mode %s requests piecewise cudagraphs, but "
+        "the model is ATOM-owned so vLLM compiles nothing and splitting_ops is "
+        "empty -- a 'piecewise' graph would be the whole model, replayed for "
+        "batches whose query-length structure differs from capture. Demoting to "
+        "%s; pass `-O.cudagraph_mode=%s` to select it explicitly.",
+        mode.name,
+        demoted.name,
+        demoted.name,
+    )
+
+
 def _enforce_deepseek_v4_constraints(vllm_config) -> None:
     """Apply V4-specific plugin constraints.
 
-    1. Enable prefix caching via SWA recompute: V4's per-request SWA
+    1. Enable prefix caching via tail recompute: V4's per-request SWA
        sliding-window ring is not carried by vLLM's block-level prefix cache
        (only the CSA/HCA compressed pages are). Rather than disable caching, we
-       install a KVCacheManager patch that, on a prefix hit, drops the last
-       ``ceil(win_with_spec / block_size)`` cached blocks so the SWA tail is
-       re-forwarded and the ring is repopulated (mirrors native ATOM "fix B'").
+       install a KVCacheManager patch that rolls every prefix hit back by
+       ``max(win_with_spec, index_topk)`` tokens so the tail is re-forwarded and
+       the ring is repopulated (mirrors native ATOM "fix B'").
        See ``deepseek_v4_prefix_patch``.
 
     2. Guard the non-chunked oversized forward: with chunked prefill off, vLLM
@@ -49,20 +95,33 @@ def _enforce_deepseek_v4_constraints(vllm_config) -> None:
        offsets in per-token kernels. Fail fast with an actionable error instead
        of crashing with "illegal memory access". Enable chunked prefill for long
        context.
+
+    3. Demote piecewise cudagraph modes, a demotion vLLM skips on a plugin path.
+       See ``_demote_piecewise_cudagraph``.
     """
     mc = getattr(vllm_config, "model_config", None)
     if mc is None or not _is_deepseek_v4(mc):
         return
+
+    _demote_piecewise_cudagraph(vllm_config)
 
     cache_config = getattr(vllm_config, "cache_config", None)
     if cache_config is not None and getattr(
         cache_config, "enable_prefix_caching", False
     ):
         from atom.plugin.vllm.deepseek_v4_prefix_patch import (
-            apply_vllm_v4_prefix_swa_patch,
+            apply_vllm_v4_prefix_recompute_patch,
         )
 
-        apply_vllm_v4_prefix_swa_patch(vllm_config)
+        apply_vllm_v4_prefix_recompute_patch(vllm_config)
+
+    # Unconditional: vLLM's cudagraph memory profiling allocates one block per
+    # sequence, fewer than the V4 proxy page amortizes over.
+    from atom.plugin.vllm.deepseek_v4_profiling_patch import (
+        apply_vllm_v4_profiling_min_blocks_patch,
+    )
+
+    apply_vllm_v4_profiling_min_blocks_patch(vllm_config)
 
     sc = getattr(vllm_config, "scheduler_config", None)
     if sc is None or _chunked_prefill_on(sc):
@@ -113,3 +172,45 @@ if not disable_vllm_plugin:
 
 else:
     ATOMPlatform = None
+
+
+def install_platform_config_hook() -> None:
+    """Run ATOMPlatform's config hook even when the platform plugin lost the race.
+
+    vLLM memoizes `current_platform` on first read. On 0.25.x that read happens
+    during `import vllm` itself (`env_override` -> `utils.torch_utils`, whose
+    module body runs `is_pin_memory_available()`), while `vllm.model_executor`
+    is half-imported: `register_platform()` dies on a circular ImportError,
+    vLLM swallows it and caches the builtin platform. Later resolutions log
+    "Platform plugin atom is activated" but nothing re-reads
+    `_current_platform`, so `check_and_update_config` never runs.
+
+    For DeepSeek-V4 the casualty is `_enforce_deepseek_v4_constraints`: without
+    the prefix-cache SWA-recompute patch a cross-request hit reads an empty SWA
+    ring and the model emits another request's content. That hook is
+    ATOMPlatform's only override, so re-attach just it to whichever platform
+    went live. Called from `register_model()`, which runs inside
+    `create_engine_config()` before the platform hook. Idempotent.
+    """
+    if disable_vllm_plugin:
+        return
+    from vllm.platforms import current_platform
+
+    live_cls = type(current_platform)
+    if ATOMPlatform is not None and issubclass(live_cls, ATOMPlatform):
+        return  # plugin won the race; the hook is already in the MRO
+    original = live_cls.check_and_update_config
+    if getattr(original, "_atom_config_hook_installed", False):
+        return
+
+    def patched(cls, vllm_config) -> None:
+        original(vllm_config)
+        _enforce_deepseek_v4_constraints(vllm_config)
+
+    patched._atom_config_hook_installed = True
+    live_cls.check_and_update_config = classmethod(patched)
+    logger.info(
+        "ATOM plugin: re-attached check_and_update_config to the live platform "
+        "%s (the platform plugin lost vLLM's memoized current_platform race).",
+        live_cls.__name__,
+    )

--- a/atom/plugin/vllm/register.py
+++ b/atom/plugin/vllm/register.py
@@ -266,6 +266,18 @@ def register_model() -> None:
 
     apply_vllm_v4_block_reuse_patch()
 
+    # If vLLM memoized `current_platform` before our plugin resolved,
+    # ATOMPlatform is not live and its config hook never runs. Re-attach it here
+    # -- this runs from `create_engine_config()`, before vLLM calls the hook.
+    from atom.plugin.vllm.platform import install_platform_config_hook
+
+    install_platform_config_hook()
+
+    # Late-run the registrations `register_platform()` may have aborted on:
+    # `vllm.model_executor` can still be half-imported at that point.
+    _register_hf_configs()
+    _register_mxfp8_quantization_config()
+
     from atom.plugin.vllm.gdn_backend import register_gdn_attention_backend
 
     register_gdn_attention_backend()
@@ -352,3 +364,13 @@ def register_model() -> None:
     )
 
     apply_vllm_req_id_passthrough_patch()
+
+    # DeepSeek-V4 cudagraph-profiling KV-cache floor. Also installed here
+    # because mp workers only run the platform hook when a VllmConfig is
+    # (re)constructed in their process; without it an unpatched worker dies in
+    # profile_cudagraph_memory. No-ops for non-V4 models.
+    from atom.plugin.vllm.deepseek_v4_profiling_patch import (
+        apply_vllm_v4_profiling_min_blocks_patch,
+    )
+
+    apply_vllm_v4_profiling_min_blocks_patch()

--- a/atom/plugin/vllm/req_id_passthrough_patch.py
+++ b/atom/plugin/vllm/req_id_passthrough_patch.py
@@ -1,34 +1,14 @@
 """Expose the current step's request ids (CPU, batch-ordered) to ATOM builders.
 
-The DeepSeek-V4 proxy metadata build needs a stable per-request key to assign a
-state slot (its SWA ring + compressor state). Previously it derived that key
-from ``block_table_tensor[:, 0]`` with a ``.cpu()`` copy, which forces a host<->
-device sync and leaves a large bubble on the decode stream even though the copy
-itself is tiny.
+The V4 proxy metadata build needs a per-request key for its state slot. Deriving
+one from ``block_table_tensor[:, 0]`` costs a ``.cpu()`` sync per step;
+``input_batch.req_ids`` is the same key, already host-resident and already
+reordered with every per-request tensor row (``InputBatch.swap_states``).
 
-vLLM already has the canonical, host-resident key: ``input_batch.req_ids``. By
-the time attention metadata is built it has been reordered together with the
-block table / seq_lens rows (``InputBatch.swap_states``), so ``req_ids[i]``
-lines up with row ``i`` of every per-request tensor.
-
-This patch wraps two GPUModelRunner methods to snapshot ``req_ids`` into a
-thread-local for the duration of each call:
-
-* ``_build_attention_metadata`` -- constructs ``CommonAttentionMetadata`` *and*
-  drives the target ``builder.build()`` in one synchronous call.
-* ``propose_draft_token_ids`` -- drives the MTP/Eagle drafter, which (in current
-  vLLM) builds its *own* attention metadata via
-  ``SpecDecodeBaseProposer.build_per_group_and_layer_attn_metadata`` ->
-  ``build_for_drafting`` -> the ATOM V4 bridge, entirely outside
-  ``_build_attention_metadata``. Without this second wrap the thread-local is
-  unset during drafting and the V4 slot allocator's fail-fast contract trips.
-
-The drafter reuses the target step's ``input_batch`` ordering (pure decodes were
-already pulled to the front and the batch is not re-reordered before the draft
-forward), so ``req_ids[i]`` still aligns with row ``i`` of the draft metadata --
-the same invariant the target build relies on. ATOM's V4 metadata builder reads
-the snapshot via ``get_current_req_ids()`` and keys slot allocation on it, with
-no D2H. All of this lives in ATOM; no vLLM source is modified.
+Each wrapper below snapshots it into a thread-local for the duration of one
+call, read back via ``get_current_req_ids()``. Both of vLLM's two unrelated
+``GPUModelRunner`` classes need covering: ``use_v2_model_runner`` forces V2 for
+dspark, so a V1-only patch would be a silent no-op for every DSpark run.
 """
 
 from __future__ import annotations
@@ -45,11 +25,13 @@ _req_id_local = threading.local()
 def get_current_req_ids() -> list[str] | None:
     """Return the current step's batch-ordered request ids, or None.
 
-    Valid only while ``GPUModelRunner._build_attention_metadata`` (target) or
-    ``GPUModelRunner.propose_draft_token_ids`` (MTP/Eagle draft) is on the stack
-    -- i.e. inside an attention metadata builder's ``build()`` for either the
-    target or the draft. Returns None otherwise, or if the pass-through patch was
-    not applied -- callers must treat None as "fall back to the device-side key".
+    Valid only inside an attention metadata builder's ``build()`` for either the
+    target or the draft: on V1 that means ``_build_attention_metadata`` or
+    ``propose_draft_token_ids`` is on the stack; on V2, ``execute_model`` after
+    ``prepare_inputs`` has run, or ``sample_tokens``. Returns the empty list for
+    a batch with no real requests (V2 dummy runs and cudagraph capture), and None
+    outside any of those scopes or if the pass-through patch was not applied --
+    callers must treat None as "fall back to the device-side key".
     """
     return getattr(_req_id_local, "req_ids", None)
 
@@ -87,16 +69,141 @@ def _wrap_with_req_id_snapshot(cls, method_name: str) -> bool:
     return True
 
 
+def _wrap_runner_scope(cls, method_name: str) -> bool:
+    """Open a req_id scope for the duration of ``cls.method_name`` (V2 runner).
+
+    The batch order is not known at entry (``prepare_inputs`` computes it), so
+    this only *scopes* the thread-local, publishing ``[]`` in and restoring out;
+    ``_wrap_v2_prepare_inputs`` fills in the real order. That keeps dummy /
+    capture runs, which never call ``prepare_inputs``, from reading the previous
+    real step's ids.
+
+    ``[]`` not None: to the V4 builder None means "patch not installed" (a
+    fail-fast contract violation) while ``[]`` means "no real requests".
+    """
+    original = getattr(cls, method_name, None)
+    if original is None or getattr(original, "_atom_req_id_passthrough_patched", False):
+        return False
+
+    @functools.wraps(original)
+    def wrapped(self, *args, **kwargs):
+        prev = getattr(_req_id_local, "req_ids", None)
+        _req_id_local.req_ids = []
+        try:
+            return original(self, *args, **kwargs)
+        finally:
+            _req_id_local.req_ids = prev
+
+    wrapped._atom_req_id_passthrough_patched = True  # type: ignore[attr-defined]
+    setattr(cls, method_name, wrapped)
+    return True
+
+
+def _wrap_v2_prepare_inputs(cls) -> bool:
+    """Publish the batch order as soon as the V2 runner computes it.
+
+    The returned ``InputBatch.req_ids`` line up with row ``i`` of every
+    per-request tensor, as on V1. Every reader runs after this point inside the
+    same ``execute_model`` call, whose wrapper bounds the scope.
+    """
+    original = getattr(cls, "prepare_inputs", None)
+    if original is None or getattr(original, "_atom_req_id_passthrough_patched", False):
+        return False
+
+    @functools.wraps(original)
+    def wrapped(self, *args, **kwargs):
+        input_batch = original(self, *args, **kwargs)
+        try:
+            _req_id_local.req_ids = list(input_batch.req_ids)
+        except Exception:  # noqa: BLE001 - unknown order, fall back to None
+            _req_id_local.req_ids = None
+        return input_batch
+
+    wrapped._atom_req_id_passthrough_patched = True  # type: ignore[attr-defined]
+    cls.prepare_inputs = wrapped
+    return True
+
+
+def _wrap_v2_sample_tokens(cls) -> bool:
+    """Re-publish the batch order for the draft proposal (V2 runner).
+
+    ``sample_tokens`` is a separate call from ``execute_model``, so outside its
+    scope, and it drives ``speculator.propose()`` (V2's
+    ``propose_draft_token_ids``), which builds metadata through the V4 bridge.
+    """
+    original = getattr(cls, "sample_tokens", None)
+    if original is None or getattr(original, "_atom_req_id_passthrough_patched", False):
+        return False
+
+    @functools.wraps(original)
+    def wrapped(self, *args, **kwargs):
+        prev = getattr(_req_id_local, "req_ids", None)
+        try:
+            state = getattr(self, "execute_model_state", None)
+            _req_id_local.req_ids = (
+                list(state.input_batch.req_ids) if state is not None else []
+            )
+        except Exception:  # noqa: BLE001 - unknown order, fall back to None
+            _req_id_local.req_ids = None
+        try:
+            return original(self, *args, **kwargs)
+        finally:
+            _req_id_local.req_ids = prev
+
+    wrapped._atom_req_id_passthrough_patched = True  # type: ignore[attr-defined]
+    cls.sample_tokens = wrapped
+    return True
+
+
+def _apply_v2_patch() -> bool:
+    """Patch the V2 runner (``vllm.v1.worker.gpu.model_runner``), if present."""
+    try:
+        from vllm.v1.worker.gpu.model_runner import GPUModelRunner as GPUModelRunnerV2
+    except ImportError as e:  # pragma: no cover - vLLM version guard
+        logger.debug(
+            "ATOM vLLM req_id passthrough patch: V2 GPUModelRunner unavailable "
+            "(%s), skip",
+            e,
+        )
+        return False
+
+    # capture_model builds metadata from prepare_inputs_to_capture -- no
+    # execute_model, no prepare_inputs -- and for PIECEWISE through the plain
+    # `build()` (for_capture=False), so the builder cannot tell it is a capture
+    # from its arguments alone. Scope it.
+    scoped = _wrap_runner_scope(GPUModelRunnerV2, "execute_model")
+    scoped_capture = _wrap_runner_scope(GPUModelRunnerV2, "capture_model")
+    scoped_dummy = _wrap_runner_scope(GPUModelRunnerV2, "_dummy_run")
+    published = _wrap_v2_prepare_inputs(GPUModelRunnerV2)
+    drafted = _wrap_v2_sample_tokens(GPUModelRunnerV2)
+
+    patched = scoped or scoped_capture or scoped_dummy or published or drafted
+    if patched:
+        logger.info(
+            "ATOM plugin: patched vLLM V2 GPUModelRunner (execute_model=%s, "
+            "capture_model=%s, _dummy_run=%s, prepare_inputs=%s, sample_tokens=%s) "
+            "to expose batch-ordered req_ids to ATOM metadata builders",
+            scoped,
+            scoped_capture,
+            scoped_dummy,
+            published,
+            drafted,
+        )
+    return patched
+
+
 def apply_vllm_req_id_passthrough_patch() -> bool:
+    patched_v2 = _apply_v2_patch()
+
     try:
         from vllm.v1.worker.gpu_model_runner import GPUModelRunner
-    except Exception as e:  # pragma: no cover - import guard
+    except ImportError as e:  # pragma: no cover - vLLM version guard
         logger.debug(
             "ATOM vLLM req_id passthrough patch: GPUModelRunner unavailable (%s), "
             "skip",
             e,
         )
-        return False
+        return patched_v2
 
     # Target attention metadata build.
     patched_target = _wrap_with_req_id_snapshot(
@@ -107,15 +214,22 @@ def apply_vllm_req_id_passthrough_patch() -> bool:
     patched_draft = _wrap_with_req_id_snapshot(
         GPUModelRunner, "propose_draft_token_ids"
     )
+    # V1's cudagraph memory profiling reaches _dummy_run without builder
+    # metadata, so the bridge takes its inline fallback, reads None from
+    # get_current_req_ids() -- "patch not installed" -- and fails fast on a batch
+    # with no real requests. Scope it to [] as on V2. Hit by mtp and friends.
+    patched_dummy = _wrap_runner_scope(GPUModelRunner, "_dummy_run")
 
-    if patched_target or patched_draft:
+    if patched_target or patched_draft or patched_dummy:
         logger.info(
             "ATOM plugin: patched vLLM GPUModelRunner "
-            "(_build_attention_metadata=%s, propose_draft_token_ids=%s) to expose "
+            "(_build_attention_metadata=%s, propose_draft_token_ids=%s, "
+            "_dummy_run=%s) to expose "
             "batch-ordered req_ids to ATOM metadata builders (removes the "
             "block-table D2H in DeepSeek-V4 slot assignment; covers the MTP draft "
             "path)",
             patched_target,
             patched_draft,
+            patched_dummy,
         )
-    return patched_target or patched_draft
+    return patched_target or patched_draft or patched_dummy or patched_v2

--- a/atom/plugin/vllm/spec_decode_patch.py
+++ b/atom/plugin/vllm/spec_decode_patch.py
@@ -1,6 +1,8 @@
 import functools
 import logging
 
+import torch
+
 from atom.utils import envs
 
 logger = logging.getLogger("atom")
@@ -127,6 +129,43 @@ def _patch_dspark_fused_markov_sample() -> None:
     )
 
 
+def _patch_dspark_markov_embed_bounds() -> None:
+    """Bounds-check the DSpark Markov embedding gather.
+
+    ``markov_embed`` is an unguarded ``F.embedding``, and under async scheduling
+    the ids can carry the scheduler's ``-1`` spec placeholder, which reads off
+    the table and faults the GPU.
+
+    Clamped at the point of use, not at the seed: ``_sample_sequential``
+    reassigns ``prev`` on every one of the K steps. No accuracy cost -- the
+    target verifies every draft token, so a bad draft costs acceptance only.
+    """
+    try:
+        from vllm.models.deepseek_v4.amd.dspark import DSparkDeepseekV4ForCausalLM
+    except ImportError:
+        return
+
+    original_markov_embed = DSparkDeepseekV4ForCausalLM.markov_embed
+    if getattr(original_markov_embed, "_atom_markov_bounds_patched", False):
+        return
+
+    @functools.wraps(original_markov_embed)
+    def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
+        limit = getattr(self, "_atom_markov_num_rows", None)
+        if limit is None:
+            limit = self.model.markov_head.markov_w1.num_embeddings
+            self._atom_markov_num_rows = limit
+        # Out-of-place: `prev` is the caller's live loop variable.
+        return original_markov_embed(self, token_ids.clamp(0, limit - 1))
+
+    markov_embed._atom_markov_bounds_patched = True
+    DSparkDeepseekV4ForCausalLM.markov_embed = markov_embed
+    logger.info(
+        "ATOM plugin: bounds-checking the DSpark Markov embedding gather "
+        "(an out-of-range draft id would fault the GPU under async scheduling)."
+    )
+
+
 def _get_attn_backend_block_size(backend) -> int:
     supported = backend.get_supported_kernel_block_sizes()
     get_preferred = getattr(backend, "get_preferred_block_size", None)
@@ -163,6 +202,97 @@ def _spec_has_heterogeneous_mla_mha_backend(kv_cache_spec) -> bool:
         elif isinstance(spec, AttentionSpec):
             has_non_mla_attn = True
     return has_mla and has_non_mla_attn
+
+
+def _spec_is_v4_proxy_target_with_mla_draft(kv_cache_spec) -> bool:
+    """The DeepSeek-V4 topology, the mirror image of the EAGLE3 one above: the
+    *target* is ATOM's opaque proxy layer (a FullAttentionSpec of uint8 bytes,
+    with the real MLA + indexer caches behind it) and the *draft* is vLLM's
+    DSpark head, whose 3 `mtp.*` layers are genuine sliding-window MLA.
+
+    `_spec_has_heterogeneous_mla_mha_backend` also matches, but its splitter
+    would rewrite the proxy's block size to ATOM's MHA one and the draft's to
+    ATOM's MLA one -- both wrong, since neither layer belongs to the backend the
+    name suggests. Handle it separately and keep every spec's own block size.
+    """
+    try:
+        from vllm.v1.kv_cache_interface import MLAAttentionSpec, SlidingWindowMLASpec
+
+        from atom.plugin.vllm.deepseek_v4_bridge import (
+            ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME,
+        )
+    except ImportError:  # specs are optional across vLLM versions
+        return False
+
+    if ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME not in kv_cache_spec:
+        return False
+    draft = {
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if name != ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME
+    }
+    # NB: SlidingWindowMLASpec derives from SlidingWindowSpec, NOT from
+    # MLAAttentionSpec. DSpark's mtp layers produce the former.
+    return bool(draft) and all(
+        isinstance(spec, (MLAAttentionSpec, SlidingWindowMLASpec))
+        for spec in draft.values()
+    )
+
+
+def _groups_are_v4_proxy_plus_mla_draft(kv_cache_groups) -> bool:
+    """Recognise the pair built by `_build_v4_proxy_draft_kv_cache_groups` so the
+    shared-num_blocks allocator below covers it too. Keyed on the proxy layer
+    name, not spec classes: SlidingWindowMLASpec does not subclass
+    MLAAttentionSpec, so `_groups_are_heterogeneous_mla_mha` misses it.
+    """
+    try:
+        from atom.plugin.vllm.deepseek_v4_bridge import (
+            ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME,
+        )
+    except ImportError:
+        return False
+
+    if len(kv_cache_groups) != 2:
+        return False
+    return kv_cache_groups[0].layer_names == [ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME]
+
+
+def _build_v4_proxy_draft_kv_cache_groups(kv_cache_spec):
+    """Two pools, each keeping the block size its own backend asked for: ATOM's
+    proxy at ATOM_DEEPSEEK_V4_BLOCK_SIZE, the DSpark draft at whatever vLLM's MLA
+    backend picked. Unifying them would rewrite the proxy's block size, which its
+    page -- a byte blob sized for ATOM's internal caches -- cannot survive.
+    """
+    from vllm.v1.kv_cache_interface import KVCacheGroupSpec, UniformTypeKVCacheSpecs
+
+    from atom.plugin.vllm.deepseek_v4_bridge import ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME
+    from atom.plugin.vllm.dspark_draft_kv_patch import convert_draft_specs
+
+    proxy_name = ATOM_DEEPSEEK_V4_PROXY_LAYER_NAME
+    draft_specs = {
+        name: spec for name, spec in kv_cache_spec.items() if name != proxy_name
+    }
+    # Route the draft's specs to a manager that abstains from the prefix cache;
+    # otherwise the draft group caps the target's hit. See dspark_draft_kv_patch.
+    # No-op for non-DSpark drafts.
+    draft_specs = convert_draft_specs(draft_specs)
+
+    proxy_group = KVCacheGroupSpec(
+        layer_names=[proxy_name],
+        kv_cache_spec=kv_cache_spec[proxy_name],
+    )
+    draft_uniform = UniformTypeKVCacheSpecs.from_specs(draft_specs)
+    assert draft_uniform is not None, (
+        "DSpark draft KV specs are not of a uniform type: "
+        f"{ {n: type(s).__name__ for n, s in draft_specs.items()} }"
+    )
+    draft_group = KVCacheGroupSpec(
+        layer_names=list(draft_specs.keys()),
+        kv_cache_spec=draft_uniform,
+    )
+    # proxy (non-MLA) first, draft (MLA) second; the shared allocator below
+    # accepts either order.
+    return [proxy_group, draft_group]
 
 
 def _split_mla_and_mha_layers(kv_cache_spec):
@@ -356,6 +486,16 @@ def _patch_heterogeneous_eagle3_kv_cache() -> None:
 
     @functools.wraps(orig_get_groups)
     def patched_get_kv_cache_groups(vllm_config, kv_cache_spec):
+        logger.info(
+            "ATOM plugin: KV cache specs %s",
+            {name: type(spec).__name__ for name, spec in kv_cache_spec.items()},
+        )
+        if _spec_is_v4_proxy_target_with_mla_draft(kv_cache_spec):
+            logger.info(
+                "ATOM plugin: using heterogeneous KV cache layout - ATOM V4 proxy "
+                "target and vLLM MLA draft - with separate per-group pools."
+            )
+            return _build_v4_proxy_draft_kv_cache_groups(kv_cache_spec)
         if getattr(
             vllm_config.model_config, "use_mla", False
         ) and _spec_has_heterogeneous_mla_mha_backend(kv_cache_spec):
@@ -370,7 +510,9 @@ def _patch_heterogeneous_eagle3_kv_cache() -> None:
     def patched_get_kv_cache_config_from_groups(
         vllm_config, kv_cache_groups, available_memory
     ):
-        if _groups_are_heterogeneous_mla_mha(kv_cache_groups):
+        if _groups_are_heterogeneous_mla_mha(
+            kv_cache_groups
+        ) or _groups_are_v4_proxy_plus_mla_draft(kv_cache_groups):
             return _build_heterogeneous_kv_cache_config_from_groups(
                 vllm_config, kv_cache_groups, available_memory
             )
@@ -378,7 +520,9 @@ def _patch_heterogeneous_eagle3_kv_cache() -> None:
 
     @functools.wraps(orig_max_mem)
     def patched_max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups):
-        if _groups_are_heterogeneous_mla_mha(kv_cache_groups):
+        if _groups_are_heterogeneous_mla_mha(
+            kv_cache_groups
+        ) or _groups_are_v4_proxy_plus_mla_draft(kv_cache_groups):
             return _heterogeneous_max_memory_usage_bytes(vllm_config, kv_cache_groups)
         return orig_max_mem(vllm_config, kv_cache_groups)
 
@@ -444,7 +588,7 @@ def _patch_vllm_llm_base_model_sharing() -> None:
                     "DeepSeek-V4 MTP draft attention type check."
                 )
 
-    setattr(wrapped_load_model, "_atom_share_with_target_patched", True)
+    wrapped_load_model._atom_share_with_target_patched = True
     SpecDecodeBaseProposer.load_model = wrapped_load_model
 
 
@@ -513,16 +657,8 @@ def _patch_vllm_draft_kv_group_validation() -> None:
             return
         return original_initialize(self, kv_cache_config, kernel_block_sizes)
 
-    setattr(
-        wrapped_validate_same_kv_cache_group,
-        "_atom_kv_group_validation_patched",
-        True,
-    )
-    setattr(
-        wrapped_initialize_attn_backend,
-        "_atom_kv_group_validation_patched",
-        True,
-    )
+    wrapped_validate_same_kv_cache_group._atom_kv_group_validation_patched = True
+    wrapped_initialize_attn_backend._atom_kv_group_validation_patched = True
     SpecDecodeBaseProposer.validate_same_kv_cache_group = (
         wrapped_validate_same_kv_cache_group
     )
@@ -568,9 +704,7 @@ def _patch_vllm_draft_positions_on_metadata() -> None:
             common_attn_metadata.positions = self._get_positions(num_tokens)
         return original_build(self, common_attn_metadata, draft_index)
 
-    setattr(
-        wrapped_build_per_group_and_layer_attn_metadata, "_atom_positions_patched", True
-    )
+    wrapped_build_per_group_and_layer_attn_metadata._atom_positions_patched = True
     SpecDecodeBaseProposer.build_per_group_and_layer_attn_metadata = (
         wrapped_build_per_group_and_layer_attn_metadata
     )
@@ -619,7 +753,7 @@ def _patch_vllm_deepseek_v4_mtp_first_pass_inputs() -> None:
             num_rejected_tokens_gpu,
         )
 
-    setattr(wrapped_set_inputs_first_pass, "_atom_v4_mtp_inputs_patched", True)
+    wrapped_set_inputs_first_pass._atom_v4_mtp_inputs_patched = True
     SpecDecodeBaseProposer.set_inputs_first_pass = wrapped_set_inputs_first_pass
 
 
@@ -635,6 +769,7 @@ def _patch_vllm_dspark_dcp_inputs() -> None:
 def apply_vllm_spec_decode_patch() -> None:
     """Patch vLLM speculative decoding for ATOM metadata compatibility."""
     _patch_dspark_fused_markov_sample()
+    _patch_dspark_markov_embed_bounds()
     _patch_vllm_dspark_dcp_inputs()
     _patch_vllm_llm_base_model_sharing()
     _patch_vllm_draft_kv_group_validation()
@@ -686,7 +821,7 @@ def apply_vllm_spec_decode_patch() -> None:
                 dict.fromkeys((*allowed, *atom_allowed_attn_types))
             )
 
-    setattr(wrapped_init, "_atom_allowed_attn_types_patched", True)
+    wrapped_init._atom_allowed_attn_types_patched = True
     SpecDecodeBaseProposer.__init__ = wrapped_init
 
     logger.info(

--- a/tests/plugin/test_vllm_026_compat.py
+++ b/tests/plugin/test_vllm_026_compat.py
@@ -1,18 +1,31 @@
 from types import SimpleNamespace
 
 from atom.plugin.vllm.deepseek_v4_prefix_patch import (
-    _drop_swa_warmup_blocks,
     _kv_cache_config_has_v4_proxy,
     _kv_cache_config_needs_non_immediate_reuse,
-    _mark_v4_proxy_cache_mode,
+    _roll_back_prefix_hit,
 )
+from atom.plugin.vllm.deepseek_v4_profiling_patch import _mark_v4_proxy_cache_mode
 from atom.plugin.vllm.spec_decode_patch import _make_atom_compatible_eagle3_type
 
 
 class _FakeKVCacheManager:
+    """A manager with no ``coordinator``, so every group takes the fallback."""
+
     @staticmethod
     def create_kv_cache_blocks(groups):
         return SimpleNamespace(blocks=groups)
+
+
+class _FakeTwoGroupKVCacheManager(_FakeKVCacheManager):
+    """Target at block 128 plus a DSpark draft group at block 64."""
+
+    coordinator = SimpleNamespace(
+        single_type_managers=(
+            SimpleNamespace(block_size=128),
+            SimpleNamespace(block_size=64),
+        )
+    )
 
 
 def test_v4_prefix_cache_drop_preserves_vllm_026_boundary():
@@ -24,31 +37,55 @@ def test_v4_prefix_cache_drop_preserves_vllm_026_boundary():
         )
     )
 
-    new_blocks, num_tokens, shared_prefix_boundary = _drop_swa_warmup_blocks(
+    new_blocks, num_tokens, shared_prefix_boundary = _roll_back_prefix_hit(
+        manager,
+        computed_blocks,
+        512,  # 4 blocks x 128
+        384,
+        rollback_tokens=256,
+    )
+
+    # No coordinator -> both groups convert with ATOM_DEEPSEEK_V4_BLOCK_SIZE.
+    # That fallback is the only reader of the constant, so this also pins the
+    # import that used to sit in the installer and raised NameError here.
+    assert new_blocks.blocks == ([0, 1], [4, 5])
+    assert num_tokens == 256
+    assert shared_prefix_boundary == 384
+
+
+def test_v4_prefix_cache_drop_converts_per_group_block_size():
+    manager = _FakeTwoGroupKVCacheManager()
+    computed_blocks = SimpleNamespace(
+        blocks=(
+            tuple(range(8)),  # 8 x 128 = 1024 tokens
+            tuple(range(100, 116)),  # 16 x 64 = 1024 tokens
+        )
+    )
+
+    new_blocks, num_tokens, _ = _roll_back_prefix_hit(
         manager,
         computed_blocks,
         1024,
         384,
-        warmup_blocks=2,
-        block_size=128,
+        rollback_tokens=256,
     )
 
-    assert new_blocks.blocks == ([0, 1], [4, 5])
+    # 768 tokens kept in both groups: 6 blocks at 128, 12 at 64. Dropping a
+    # fixed block *count* would have charged 512 tokens to the block-64 group.
+    assert new_blocks.blocks == (list(range(6)), list(range(100, 112)))
     assert num_tokens == 768
-    assert shared_prefix_boundary == 384
 
 
 def test_v4_prefix_cache_empty_hit_keeps_vllm_026_result():
     manager = _FakeKVCacheManager()
     computed_blocks = SimpleNamespace(blocks=((),))
 
-    result = _drop_swa_warmup_blocks(
+    result = _roll_back_prefix_hit(
         manager,
         computed_blocks,
         0,
         0,
-        warmup_blocks=2,
-        block_size=128,
+        rollback_tokens=256,
     )
 
     assert result == (computed_blocks, 0, 0)

--- a/tests/plugin/test_vllm_dspark_draft_kv_patch.py
+++ b/tests/plugin/test_vllm_dspark_draft_kv_patch.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""The DSpark draft's SWA group must abstain from the prefix cache.
+
+`HybridKVCacheCoordinator` reconciles every group's hit down to the minimum, so
+the draft group -- whose blocks are evicted by `remove_skipped_blocks` long
+before the next request looks them up -- caps the target's hit. These tests pin
+the abstention and, just as importantly, pin everything the retype must leave
+alone: field values, page size, grouping, and picklability.
+"""
+
+import dataclasses
+import pickle
+
+import pytest
+import torch
+
+from atom.plugin.vllm.dspark_draft_kv_patch import (
+    convert_draft_specs,
+    ensure_registered,
+)
+
+pytest.importorskip("vllm")
+
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    SlidingWindowMLASpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
+
+BLOCK = 64
+LAYERS = ("model.layers.43.attn.swa_cache", "model.layers.44.attn.swa_cache")
+
+
+class _FakeBlockPool:
+    null_block = "NULL"
+
+
+def _swa_spec():
+    # DSpark's draft geometry: block 64, window 128, MLA head.
+    return SlidingWindowMLASpec(
+        block_size=BLOCK,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+        sliding_window=128,
+    )
+
+
+def _draft_specs():
+    return {name: _swa_spec() for name in LAYERS}
+
+
+def _converted_spec():
+    return next(iter(convert_draft_specs(_draft_specs()).values()))
+
+
+def _hit(max_length, *, drop_eagle_block=False, alignment_tokens=0, groups=(0,)):
+    spec = _converted_spec()
+    manager = KVCacheSpecRegistry.get_manager_class(spec)
+    return manager.find_longest_cache_hit(
+        block_hashes=[],
+        max_length=max_length,
+        kv_cache_group_ids=groups,
+        block_pool=_FakeBlockPool(),
+        kv_cache_spec=spec,
+        drop_eagle_block=drop_eagle_block,
+        alignment_tokens=alignment_tokens,
+    )
+
+
+# --------------------------------------------------------------------------
+# The retype must change the type and nothing else.
+# --------------------------------------------------------------------------
+
+
+def test_retype_preserves_every_spec_field():
+    original = _swa_spec()
+    converted = _converted_spec()
+
+    assert type(converted) is not SlidingWindowMLASpec
+    assert isinstance(converted, SlidingWindowMLASpec)
+    for field in dataclasses.fields(original):
+        assert getattr(converted, field.name) == getattr(original, field.name)
+
+
+def test_retype_leaves_kv_pool_sizing_untouched():
+    # The subclass adds no fields, so `__post_init__` padding and the page size
+    # the memory profiler budgets against must be identical.
+    assert _converted_spec().page_size_bytes == _swa_spec().page_size_bytes
+
+
+def test_retyped_specs_still_group_as_one_uniform_type():
+    # The draft's three layers must stay a single KV cache group; splitting them
+    # would hand vLLM more groups than the proxy layout expects.
+    converted = convert_draft_specs(_draft_specs())
+
+    assert UniformTypeKVCacheSpecs.is_uniform_type(converted)
+    assert (
+        KVCacheSpecRegistry.get_uniform_type_base_spec(next(iter(converted.values())))
+        is SlidingWindowMLASpec
+    )
+
+
+def test_retyped_spec_survives_the_broadcast_to_workers():
+    # KVCacheConfig is pickled to every worker, and pickle resolves a class by
+    # __module__ + __qualname__. A class built inside a function keeps a
+    # `<locals>` qualname that resolves nowhere.
+    spec = _converted_spec()
+
+    assert type(pickle.loads(pickle.dumps(spec))) is type(spec)
+
+
+def test_registering_the_draft_spec_keeps_vllm_builtins_registered():
+    # `_ensure_registered` populates the built-ins only if the registry is
+    # empty, so registering into an empty registry would starve all of them.
+    ensure_registered()
+
+    assert KVCacheSpecRegistry.get_manager_class(_swa_spec()) is not None
+    assert KVCacheSpecRegistry.get_manager_class(_converted_spec()) is not None
+
+
+def test_ensure_registered_returns_the_same_class_every_time():
+    # Two unequal types would make pickle resolve to whichever was cached last.
+    assert ensure_registered() is ensure_registered()
+
+
+# --------------------------------------------------------------------------
+# The abstention itself.
+# --------------------------------------------------------------------------
+
+
+def test_draft_group_never_shortens_the_reconciled_hit():
+    _, hit = _hit(10 * BLOCK)
+
+    assert hit == 10 * BLOCK
+
+
+def test_hit_is_block_aligned_down():
+    # The coordinator rejects a hit length that is not a whole number of blocks.
+    _, hit = _hit(10 * BLOCK + 1)
+
+    assert hit == 10 * BLOCK
+
+
+def test_hit_honours_the_alignment_the_coordinator_asks_for():
+    _, hit = _hit(1000, alignment_tokens=256)
+
+    assert hit == 768
+
+
+def test_drop_eagle_block_gives_one_block_back():
+    # The coordinator hands us `candidate + block_size` when it is set and
+    # expects to get the candidate back.
+    _, hit = _hit(10 * BLOCK, drop_eagle_block=True)
+
+    assert hit == 9 * BLOCK
+
+
+def test_drop_eagle_block_cannot_drive_the_hit_negative():
+    _, hit = _hit(0, drop_eagle_block=True)
+
+    assert hit == 0
+
+
+def test_the_hit_claims_no_real_storage():
+    # Tokens are declared computed, but every block is the null block: nothing
+    # reads that region, and `_roll_back_prefix_hit` re-forwards the last 512
+    # tokens -- more than the 128-token window -- into fresh blocks.
+    blocks, hit = _hit(10 * BLOCK, groups=(0, 1))
+
+    assert len(blocks) == 2
+    for group in blocks:
+        assert len(group) == hit // BLOCK
+        assert set(group) == {_FakeBlockPool.null_block}
+
+
+def test_the_draft_publishes_nothing_to_the_prefix_cache():
+    spec = _converted_spec()
+    manager = KVCacheSpecRegistry.get_manager_class(spec)
+
+    # An entry here could only keep a draft block hash-resident for a hit the
+    # lookup above will never take. Called unbound -- the override touches no
+    # instance state, and a real manager needs a live block pool to construct.
+    assert manager.cache_blocks(None, request=object(), num_tokens=1024) is None
+
+
+# --------------------------------------------------------------------------
+# When the conversion must not happen.
+# --------------------------------------------------------------------------
+
+
+def test_non_sliding_window_drafts_keep_vllm_stock_behaviour():
+    # An MTP draft is full attention and does contribute real cache hits.
+    specs = {
+        "model.layers.61.attn": FullAttentionSpec(
+            block_size=128, num_kv_heads=1, head_size=576, dtype=torch.bfloat16
+        )
+    }
+
+    assert convert_draft_specs(specs) is specs
+
+
+def test_mixed_draft_specs_are_left_alone_wholesale():
+    specs = dict(_draft_specs())
+    specs["model.layers.61.attn"] = FullAttentionSpec(
+        block_size=128, num_kv_heads=1, head_size=576, dtype=torch.bfloat16
+    )
+
+    assert convert_draft_specs(specs) is specs
+
+
+def test_no_draft_specs_is_a_no_op():
+    assert convert_draft_specs({}) == {}
+
+
+def test_a_broken_conversion_never_blocks_startup(monkeypatch):
+    # A prefix-cache optimisation must not be the reason a server fails to boot.
+    monkeypatch.setattr(
+        "atom.plugin.vllm.dspark_draft_kv_patch.ensure_registered",
+        lambda: (_ for _ in ()).throw(RuntimeError("registry moved")),
+    )
+    specs = _draft_specs()
+
+    assert convert_draft_specs(specs) is specs

--- a/tests/plugin/test_vllm_kimi_k3.py
+++ b/tests/plugin/test_vllm_kimi_k3.py
@@ -382,7 +382,12 @@ def test_dense_mla_decode_pads_gathered_dcp_heads():
             dcp_world_size=8,
             kv_cache_dtype="fp8",
             is_sparse_mla=False,
-            dcp_persistent_supported=True,
+            # gfx942: no lse persistent decode kernel, so DCP decode runs
+            # non-persistent and the gathered width rounds up to a dispatchable
+            # one. That rounding IS the padding under test -- persistent takes
+            # the gathered 96 as-is and pads nothing. Matches the
+            # use_persistent_metadata=False decode metadata below.
+            dcp_persistent_supported=False,
             scale=1.0,
             _q_scale=None,
             _k_scale=None,

--- a/tests/plugin/test_vllm_v4_async_scheduling_guards.py
+++ b/tests/plugin/test_vllm_v4_async_scheduling_guards.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Guards that keep DeepSeek-V4 alive under `--async-scheduling` and DP > 1.
+
+Async scheduling drops vLLM's sync on the sampled token ids. That is what makes
+the CPU run ahead of the H2D copies, and what lets the scheduler's `-1` spec
+placeholder reach a gather before the worker overwrites it. Each test below
+pins one of the guards that removed a reproduced GPU fault.
+"""
+
+import ast
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from atom.plugin.vllm.deepseek_v4_bridge import (
+    _is_runtime_dummy_decode,
+    _V4DecodeMetaBuffers,
+)
+from atom.plugin.vllm.spec_decode_patch import _patch_dspark_markov_embed_bounds
+from atom.utils.forward_context import running_tokens_from_bs
+
+BRIDGE_PATH = Path(__file__).parents[2] / "atom/plugin/vllm/deepseek_v4_bridge.py"
+EMBED_HEAD_PATH = Path(__file__).parents[2] / "atom/model_ops/embed_head.py"
+
+# execute_dummy_batch() sends uniform_decode_query_len == 1 + num_spec_tokens.
+K = 5
+
+
+def _batch(max_query_len):
+    return SimpleNamespace(max_query_len=max_query_len)
+
+
+# --------------------------------------------------------------------------
+# 1. The runtime dummy decode batch an idle DP rank steps through.
+# --------------------------------------------------------------------------
+
+
+def test_idle_dp_rank_dummy_decode_is_repaired_like_a_capture_batch():
+    # req_ids == [] plus a decode-width query: exactly what execute_dummy_batch
+    # produces. Without the repair the rank faults on its first idle step.
+    assert _is_runtime_dummy_decode(_batch(1 + K), [], K)
+    assert _is_runtime_dummy_decode(_batch(1), [], 0)
+
+
+def test_real_decode_batch_is_never_repaired():
+    # A real step has requests, so its context is coherent and rewriting
+    # seq_lens/positions would corrupt it.
+    assert not _is_runtime_dummy_decode(_batch(1 + K), ["req-0"], K)
+
+
+def test_prefill_shaped_dummy_is_left_alone():
+    # Profiling dummies are prefill-shaped and already carry a coherent context.
+    assert not _is_runtime_dummy_decode(_batch(4096), [], K)
+    assert not _is_runtime_dummy_decode(_batch(2 + K), [], K)
+
+
+def test_missing_passthrough_patch_does_not_trigger_the_repair():
+    # None means "patch not installed" (standalone/tests), not "no requests".
+    assert not _is_runtime_dummy_decode(_batch(1 + K), None, K)
+
+
+def test_zero_width_batch_is_not_a_decode():
+    assert not _is_runtime_dummy_decode(_batch(0), [], K)
+
+
+# --------------------------------------------------------------------------
+# 2. The depth-1 gate on pinned staging-buffer reuse.
+# --------------------------------------------------------------------------
+
+
+class _RecordingEvent:
+    def __init__(self):
+        self.calls = []
+
+    def synchronize(self):
+        self.calls.append("synchronize")
+
+    def record(self):
+        self.calls.append("record")
+
+
+def _bufs_with(event):
+    bufs = object.__new__(_V4DecodeMetaBuffers)
+    bufs._h2d_done = event
+    return bufs
+
+
+def test_gate_and_mark_pair_up_outside_capture():
+    event = _RecordingEvent()
+    bufs = _bufs_with(event)
+
+    bufs.gate_staging_reuse()
+    bufs.mark_h2d_enqueued()
+
+    assert event.calls == ["synchronize", "record"]
+
+
+def test_gate_and_mark_are_skipped_inside_a_capture_region(monkeypatch):
+    # Event record/synchronize are illegal inside a capture region, and capture
+    # has no CPU run-ahead to guard.
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+    event = _RecordingEvent()
+    bufs = _bufs_with(event)
+
+    bufs.gate_staging_reuse()
+    bufs.mark_h2d_enqueued()
+
+    assert event.calls == []
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs a CUDA event")
+def test_gate_blocks_until_the_previous_h2d_has_executed():
+    bufs = _bufs_with(torch.cuda.Event())
+    pinned = torch.zeros(1 << 22, dtype=torch.int32, pin_memory=True)
+    gpu = torch.empty_like(pinned, device="cuda")
+
+    # A never-recorded event passes immediately, so the first build is free.
+    bufs.gate_staging_reuse()
+
+    gpu.copy_(pinned, non_blocking=True)
+    bufs.mark_h2d_enqueued()
+    bufs.gate_staging_reuse()
+
+    # Returning means the DMA out of `pinned` is done, so the next build may
+    # overwrite it. This is the invariant; the assert just proves we got here
+    # with the copy retired rather than merely enqueued.
+    assert bufs._h2d_done.query()
+
+
+def _persistent_decode_block():
+    tree = ast.parse(BRIDGE_PATH.read_text())
+    fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "build_atom_v4_attention_metadata"
+    )
+    return next(
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "decode_persistent"
+    )
+
+
+def test_every_staging_h2d_sits_between_the_gate_and_the_mark():
+    # One event covers a whole build, so an H2D added outside the pair would be
+    # silently unguarded -- the exact shape of the original bug.
+    gate, mark, staging = [], [], []
+    for node in ast.walk(_persistent_decode_block()):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        attr = node.func.attr
+        if attr == "gate_staging_reuse":
+            gate.append(node.lineno)
+        elif attr == "mark_h2d_enqueued":
+            mark.append(node.lineno)
+        elif attr in ("stage", "copy_to_gpu"):
+            staging.append(node.lineno)
+
+    assert len(gate) == 1, "the gate must be entered exactly once per build"
+    assert len(mark) == 1, "one event per build, recorded after the last copy"
+    assert staging, "no staging copies found -- did the persistent path move?"
+    assert gate[0] < min(staging)
+    assert mark[0] > max(staging)
+
+
+# --------------------------------------------------------------------------
+# 3. Embedding gathers that must survive the `-1` spec placeholder.
+# --------------------------------------------------------------------------
+
+
+def test_tp1_vocab_embedding_does_not_use_a_raw_gather():
+    # The tp_size > 1 branch masked; tp_size == 1 fell through to F.embedding,
+    # which reads the row before the table for the -1 placeholder. Both branches
+    # must now go through a masked kernel, which returns zeros out of range and
+    # is bit-identical for every valid token.
+    tree = ast.parse(EMBED_HEAD_PATH.read_text())
+    forward = next(
+        node
+        for cls in ast.walk(tree)
+        if isinstance(cls, ast.ClassDef) and cls.name == "VocabParallelEmbedding"
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == "forward"
+    )
+    called = {
+        node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+        for node in ast.walk(forward)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, (ast.Attribute, ast.Name))
+    }
+
+    assert "replicated_embedding" in called
+    assert "masked_embedding" in called
+    assert "embedding" not in called, "raw F.embedding is back in the tp1 branch"
+
+
+class _FakeDSpark:
+    """Stands in for DSparkDeepseekV4ForCausalLM's bare nn.Embedding lookup."""
+
+    num_rows = 8
+
+    def __init__(self):
+        self.model = SimpleNamespace(
+            markov_head=SimpleNamespace(
+                markov_w1=SimpleNamespace(num_embeddings=self.num_rows)
+            )
+        )
+        self.seen = None
+
+    def markov_embed(self, token_ids):
+        self.seen = token_ids
+        # A real F.embedding would fault here on a negative id.
+        assert int(token_ids.min()) >= 0
+        assert int(token_ids.max()) < self.num_rows
+        return token_ids
+
+
+@pytest.fixture
+def patched_dspark(monkeypatch):
+    module = ModuleType("vllm.models.deepseek_v4.amd.dspark")
+    module.DSparkDeepseekV4ForCausalLM = _FakeDSpark
+    for name in (
+        "vllm.models",
+        "vllm.models.deepseek_v4",
+        "vllm.models.deepseek_v4.amd",
+    ):
+        monkeypatch.setitem(sys.modules, name, sys.modules.get(name, ModuleType(name)))
+    monkeypatch.setitem(sys.modules, "vllm.models.deepseek_v4.amd.dspark", module)
+    original = _FakeDSpark.markov_embed
+    _patch_dspark_markov_embed_bounds()
+    yield _FakeDSpark
+    _FakeDSpark.markov_embed = original
+
+
+def test_markov_embed_clamps_the_spec_placeholder(patched_dspark):
+    model = patched_dspark()
+    ids = torch.tensor([-1, 0, 3, -1])
+
+    out = model.markov_embed(ids)
+
+    assert out.tolist() == [0, 0, 3, 0]
+    # Out-of-place: `prev` is the caller's live loop variable in
+    # _sample_sequential, reassigned on every one of the K steps.
+    assert ids.tolist() == [-1, 0, 3, -1]
+
+
+def test_markov_embed_clamps_ids_past_the_table(patched_dspark):
+    model = patched_dspark()
+
+    out = model.markov_embed(torch.tensor([7, 8, 99]))
+
+    assert out.tolist() == [7, 7, 7]
+
+
+def test_markov_embed_leaves_valid_ids_untouched(patched_dspark):
+    model = patched_dspark()
+    ids = torch.arange(patched_dspark.num_rows)
+
+    assert model.markov_embed(ids).tolist() == ids.tolist()
+
+
+def test_markov_embed_patch_is_idempotent(patched_dspark):
+    _patch_dspark_markov_embed_bounds()
+    _patch_dspark_markov_embed_bounds()
+
+    assert patched_dspark().markov_embed(torch.tensor([-1])).tolist() == [0]
+
+
+# --------------------------------------------------------------------------
+# 4. The profile stub has no attention geometry to answer with.
+# --------------------------------------------------------------------------
+
+
+def test_running_tokens_falls_back_to_the_request_count_without_metadata():
+    # force_dummy passes None because the profile stub cannot answer
+    # max_seqlen_q; is_prefill is pinned False there, which used to route the
+    # stub down the decode branch and kill the worker during profile_run.
+    assert running_tokens_from_bs(8, is_prefill=False, attn_metadata=None) == 8
+    assert running_tokens_from_bs(
+        8, is_prefill=False, attn_metadata=SimpleNamespace(max_seqlen_q=1 + K)
+    ) == 8 * (1 + K)
+
+
+def test_force_dummy_never_hands_the_profile_stub_to_running_tokens():
+    source = BRIDGE_PATH.read_text()
+    assert "attn_metadata=None if force_dummy else attn_metadata," in source


### PR DESCRIPTION
## Motivation

Closes https://github.com/ROCm/ATOM/issues/2136.

DeepSeek-V4-Flash-0731 runs with dspark in ATOM native mode but not through the vLLM plugin. This PR brings the plugin to parity: DSpark as a draft method via `--speculative-config '{"method":"dspark"}'`, plus four correctness fixes on the existing V4 plugin path that block the model regardless of spec decode.

## Technical Details

**Model.** `DeepseekV4Model.forward` optionally returns per-layer aux hidden states for EAGLE3/DSpark/DFlash drafts, averaged over the mHC dim; `DeepseekV4ForCausalLM` PCP-all-gathers them outside the compile boundary. The aux branch sits inside `@support_torch_compile`, so `aux_hidden_state_layers` is baked into the traced graph and must be set at load time: from `--level 2` up, the dispatcher replays code object 0 without evaluating guards, so later mutation is silently ignored. Noted in a COMPILE BOUNDARY comment in `atom/models/deepseek_v4.py`.

**KV cache.** The draft needs a second KV group (sliding-window MLA, block 64) beside the V4 proxy's block 128; `dspark_draft_kv_patch` registers it lazily and exposes it for pickle via PEP-562 `__getattr__`. V4's SWA ring is not keyed by a vLLM block, so a prefix-cache hit reads a stale window; every hit is rolled back by `max(win_with_spec, index_topk)` tokens and the tail re-forwarded, converted per group since the block sizes differ.

**KNOWN ISSUE:** the `index_topk` term is empirical (512 on V4-Flash vs a 128-token window), and the same floor reproduces with prefix caching off, so the real defect is in the sparse indexer. This rollback is a workaround; happy to track it separately.

**Correctness fixes** (independent of DSpark, latent on the existing V4 path):
- `VocabParallelEmbedding.forward` used a raw `F.embedding` on the `tp_size == 1` branch, which GPU-faults on the `-1` spec placeholder async scheduling can emit. Now `replicated_embedding`, which already masks it; its comment says VocabParallelEmbedding routes through the masked op, true only of the TP>1 branch.
- Async scheduling drops the sampled-token sync, so pinned staging buffers can tear; gated with a depth-1 `torch.cuda.Event`.
- Idle DP ranks reach `build()` via `execute_dummy_batch()` with `seq_len == query_len`; synthesized a decode context.
- Piecewise cudagraph modes are demoted on the plugin path, a demotion vLLM skips when it compiles nothing.

**Perf.** Request ids reach ATOM metadata builders through a thread-local instead of a per-step `block_table[:, 0]` D2H copy.

## Test Plan

New: `test_vllm_dspark_draft_kv_patch.py`, `test_vllm_v4_async_scheduling_guards.py`. Extended: `test_vllm_026_compat.py`, `test_vllm_kimi_k3.py`.

```
# 3 sglang files cannot be collected here (no sglang module), which aborts the whole dir
python -m pytest tests/plugin -q \
  --ignore=tests/plugin/test_sglang_gdn_target_verify.py \
  --ignore=tests/plugin/test_sglang_gdn_verify_batched_ssm.py \
  --ignore=tests/plugin/test_sglang_model_arch_metadata.py
black --check . && ruff check .
```

Run on this branch (`6fef3b9d`) and its base (`412f5bfe`) to separate regressions from pre-existing failures. Accuracy: DeepSeek-V4-Flash-0731, 8x MI355X (gfx950), TP8, GSM8K 5-shot, 200 questions, via `lm_eval` local-completions against a live server, with a spec-off control and a third arm at `temperature 1.0` to exercise the stochastic rejection path.

## Test Result

```
base 412f5bfe : 37 failed, 174 passed
this branch   : 36 failed, 209 passed
new failures  : none
```

All 36 are pre-existing and unrelated (27 sglang, 9 rtpllm), failing identically on base. `black --check .` clean; ruff on the touched files is 24 findings vs 33 at base.

GSM8K exact_match (strict):

| arm | value | stderr |
|---|---|---|
| DSpark off (control), greedy | 0.965 | +/- 0.013 |
| **DSpark on, greedy** | **0.960** | +/- 0.014 |
| DSpark on, temperature 1.0 | 0.925 | +/- 0.019 |

DSpark costs 0.005 against the control, inside one stderr, and both greedy arms clear the 0.94 bar the nightly `DeepSeek-V4-Pro TP8` case uses. The temperature arm differs from greedy on 197/200 questions, confirming the stochastic verifier is engaged: a draft that ignored the requested distribution would return the greedy text and score identically.

Prefix-cache sweep on V4-Flash-0731: rollback 128/256/384 -> 1/6 correct, 512 -> 6/6, and 512 holds at 2K/6K/17K prefixes.

Not run: throughput benchmarks. `.github/workflows/atom-vllm-test.yaml` is gated behind `ci:full` or an approving review, so it needs a maintainer to trigger. No CI case passes `--speculative-config` today, so none exercises dspark; glad to add one.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.