### PR TITLE
kv_transfer/offload: add PAGE-only m3 layout for MiniMax-M3

### DIFF
--- a/atom/kv_transfer/offload/config.py
+++ b/atom/kv_transfer/offload/config.py
@@ -32,6 +32,7 @@ _OFFLOAD_LAYOUT_ALIASES = {
     "hybrid": "hybrid",
     "dense": "dense",
     "kimi_k3": "kimi_k3",
+    "m3": "m3",
     # Compatibility with the names used while the layout split was developed.
     "terminal_unit": "hybrid",
     "page_slot": "hybrid",
@@ -63,10 +64,12 @@ _HF_INTEGER_GEOMETRY_FIELDS = frozenset(_HF_PAGE_FIELDS) - {
 # drops `qwen3_5`/`qwen3_5_moe` from that flatten, so if offload is ever wired
 # into plugin mode this guard must switch to the text config to stay in sync.
 # Unreachable today -- no plugin caller passes a `kv_transfer_config`.
-# MiniMax-M2/M3 are absent by design: M3 is sparse *paged* attention
+# MiniMax-M3 is not here either: it is sparse *paged* attention
 # (`MiniMaxM3SparseForCausalLM` -> `SparseMHAPagedAttentionImpl`), no recurrent
-# state, so the dense offload path handles it as ordinary paged KV -- it is NOT
-# a GDN/linear model despite some sibling comments once listing it as one.
+# state, so it is NOT a GDN/linear model. It does get its own PAGE-only `m3`
+# layout (see `_is_minimax_m3` and offload/hybrid/m3/): its NSA index_cache is
+# delivered only through transfer_tensors.block_regions, so the dense codec --
+# which builds from per-layer KVCacheTensor K/V -- would silently drop it.
 _GDN_LINEAR_MODEL_TYPES = frozenset(
     {"qwen3_next", "qwen3_next_mtp", "qwen3_5_text", "qwen3_5_moe_text"}
 )
@@ -93,6 +96,25 @@ def _strict_integer(name: str, value: object, *, minimum: int = 0) -> int:
         relation = "positive" if minimum == 1 else f">= {minimum}"
         raise ValueError(f"{name} must be {relation}")
     return normalized
+
+
+def _is_minimax_m3(hf_config) -> bool:
+    """MiniMax-M3: PAGE-only NSA sparse attention, no SLOT/compression.
+
+    Detected by architecture / model_type name so the offload layout
+    resolves identically in the scheduler and worker processes
+    (config-only selection, matching select_offload_layout's contract).
+    """
+
+    if hf_config is None:
+        return False
+    architectures = getattr(hf_config, "architectures", None) or ()
+    for arch in architectures:
+        name = str(arch).lower()
+        if "minimaxm3" in name or "minimax_m3" in name:
+            return True
+    model_type = str(getattr(hf_config, "model_type", "") or "").lower()
+    return "minimax_m3" in model_type or "minimaxm3" in model_type
 
 
 def select_offload_layout(config) -> str:
@@ -146,6 +168,14 @@ def _layout_from_model(config) -> str:
     hf_config = getattr(config, "hf_config", None)
     if hf_config is None:
         return "dense"
+    # MiniMax-M3 (NSA sparse *paged* attention, no recurrent state) gets a
+    # PAGE-only layout whose codec is sourced from transfer_tensors.block_regions
+    # -- the NSA index_cache rides there, never as a KVCacheTensor the dense codec
+    # inspects, so `dense` would offload K/V and silently drop the index cache,
+    # corrupting restored prefixes. Checked before the text-config family probe
+    # below because M3 is identified by architecture name, not model_type family.
+    if _is_minimax_m3(hf_config):
+        return "m3"
     # Resolve the family off the *text* config, exactly as the model-side
     # predicates this mirrors do (`ModelRunner.is_qwen_next`/`is_kimi_linear`
     # read `self.hf_text_config`). Two names in `_GDN_LINEAR_MODEL_TYPES` --
@@ -261,11 +291,10 @@ def build_page_namespace(
         "schema": "atom-page-namespace",
         "layout_version": layout_version,
         "model": base_model_name,
-        "page_mode": (
-            "dsv4-page-regions"
-            if select_offload_layout(config) == "hybrid"
-            else "dense-opaque-block"
-        ),
+        "page_mode": {
+            "hybrid": "dsv4-page-regions",
+            "m3": "m3-page-regions",
+        }.get(select_offload_layout(config), "dense-opaque-block"),
         "kv_cache_dtype": str(getattr(config, "kv_cache_dtype", "auto")),
         "index_cache_dtype": str(getattr(config, "index_cache_dtype", "auto")),
         "block_size": _strict_integer(

--- a/atom/kv_transfer/offload/connector.py
+++ b/atom/kv_transfer/offload/connector.py
@@ -8,7 +8,8 @@ both the scheduler and worker from configuration alone:
 
 * ``dense`` stores ordinary token-indexed KV chunks;
 * ``hybrid`` stores DSV4 compressed PAGE chunks plus complete SLOT sidecars;
-* ``kimi_k3`` stores dense MLA KV plus a KDA per-request state tier.
+* ``kimi_k3`` stores dense MLA KV plus a KDA per-request state tier;
+* ``m3`` stores MiniMax-M3 PAGE-only KV including the NSA index cache.
 
 Keeping selection config-only is important because the scheduler process does
 not have access to the worker's transfer tensors.
@@ -51,6 +52,13 @@ def _build_worker(config):
 
         return KimiK3OffloadConnector(config)
 
+    if variant == "m3":
+        from atom.kv_transfer.offload.hybrid.m3.connector import (
+            M3OffloadConnector,
+        )
+
+        return M3OffloadConnector(config)
+
     from atom.kv_transfer.offload.dense.connector import DenseOffloadConnector
 
     return DenseOffloadConnector(config)
@@ -72,6 +80,13 @@ def _build_scheduler(config):
         )
 
         return KimiK3OffloadScheduler(config)
+
+    if variant == "m3":
+        from atom.kv_transfer.offload.hybrid.m3.connector import (
+            M3OffloadScheduler,
+        )
+
+        return M3OffloadScheduler(config)
 
     from atom.kv_transfer.offload.dense.connector import DenseOffloadScheduler
 

--- a/atom/kv_transfer/offload/hybrid/m3/__init__.py
+++ b/atom/kv_transfer/offload/hybrid/m3/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""PAGE-only (multi-region, no SLOT) LMCache offload for MiniMax-M3 NSA."""
+
+from atom.kv_transfer.offload.hybrid.m3.connector import (
+    M3OffloadConnector,
+    M3OffloadScheduler,
+)
+
+__all__ = ["M3OffloadConnector", "M3OffloadScheduler"]

--- a/atom/kv_transfer/offload/hybrid/m3/connector.py
+++ b/atom/kv_transfer/offload/hybrid/m3/connector.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""PAGE-only multi-region LMCache offload for MiniMax-M3 (NSA sparse attention).
+
+MiniMax-M3 is a pure-attention model: dense full attention on layers 0-2 and
+NSA "lightning-indexer" sparse attention on layers 3-59. It has no recurrent /
+SSM / linear-attention layers, hence no per-request state and no SLOT sidecar
+(``transfer_tensors.slot_regions`` is always empty).
+
+Why a dedicated variant instead of ``dense``:
+
+* The dense connector builds its byte codec from the per-layer ``KVCacheTensor``
+  objects in ``kv_caches`` (K / V / scales). For M3 the NSA per-sparse-layer
+  ``index_cache`` is delivered ONLY through ``transfer_tensors.block_regions``;
+  it is not an attribute of any ``KVCacheTensor``. Routing M3 through ``dense``
+  would silently offload K / V but drop the index cache, corrupting restored
+  prefixes on load.
+
+Why not ``hybrid`` (dsv4):
+
+* The dsv4 connector requires ``kv_caches`` to be empty and drives a compressed
+  PAGE + stateful SLOT geometry via ``build_dsv4_profile``. M3 delivers a
+  non-empty ``kv_caches`` and has no SLOT state, so dsv4 rejects it.
+
+This variant reuses the model-agnostic dense scheduler / worker lifecycle
+unchanged and swaps only the byte codec: it builds a ``DSV4PageSlotCodec`` from
+``transfer_tensors.block_regions`` (the complete, ordered K / V / scale / index
+region list) with ``slot_regions=()`` / ``num_slots=0`` -- i.e. pure PAGE. The
+DSV4 codec's PAGE path is byte-exact and exposes the same ``BlockByteCodec``
+contract (``bytes_per_block``, ``has_fused_chunk_major_staging``,
+``gpu_to_chunk_major_device_buffer``, ``chunk_major_device_buffer_to_gpu``) that
+:class:`BlockGPUConnector` requires. The model NEVER changes -- the model runner
+already emits complete transfer_tensors; this is a serving-layer wiring only.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from atom.kv_transfer.offload import config as offcfg
+from atom.kv_transfer.offload._block_gpu_connector import BlockGPUConnector
+from atom.kv_transfer.offload._offload_common import (
+    build_offload_engine,
+    pp_aware_rank_and_world,
+)
+from atom.kv_transfer.offload.dense.connector import (
+    DenseOffloadConnector,
+    DenseOffloadScheduler,
+)
+from atom.kv_transfer.offload.hybrid.dsv4.codec import DSV4PageSlotCodec
+
+logger = logging.getLogger("atom")
+
+
+class M3OffloadConnector(DenseOffloadConnector):
+    """PAGE-only, multi-region offload worker for MiniMax-M3.
+
+    Identical lifecycle to :class:`DenseOffloadConnector`; only
+    ``register_kv_caches`` differs -- it sources the byte codec from
+    ``transfer_tensors.block_regions`` (which include the NSA index cache)
+    instead of the per-layer ``KVCacheTensor`` K / V.
+    """
+
+    def register_kv_caches(
+        self, kv_caches: dict, transfer_tensors=None, num_blocks: int | None = None
+    ) -> None:
+        from aiter.dist.parallel_state import get_tp_group
+
+        tp = get_tp_group()
+        rank, world = pp_aware_rank_and_world(self._config, tp)
+        self._rank = rank
+
+        block_regions = getattr(transfer_tensors, "block_regions", None)
+        if not block_regions:
+            raise ValueError(
+                "M3 offload requires transfer_tensors.block_regions "
+                "(K/V/scale + NSA index_cache regions); got none. The M3 model "
+                "runner must emit get_kv_transfer_tensors() block_regions."
+            )
+        slot_regions = getattr(transfer_tensors, "slot_regions", ()) or ()
+        if slot_regions:
+            # M3 has no per-request state; a non-empty SLOT list means the model
+            # or config selected the wrong offload variant.
+            raise ValueError(
+                "M3 offload is PAGE-only but transfer_tensors carries "
+                f"{len(slot_regions)} SLOT region(s); expected none"
+            )
+
+        page_num_blocks = (
+            num_blocks
+            if num_blocks is not None
+            else getattr(transfer_tensors, "num_blocks", None)
+        )
+        if page_num_blocks is None:
+            raise ValueError("M3 offload PAGE regions require a num_blocks value")
+
+        # Build the codec from the ordered region list (NOT from kv_caches), so
+        # the NSA index_cache regions are included. slot_regions empty ->
+        # DSV4PageSlotCodec runs pure-PAGE (num_slots=0).
+        self._codec = DSV4PageSlotCodec(
+            page_regions=block_regions,
+            slot_regions=(),
+            num_blocks=int(page_num_blocks),
+            num_slots=0,
+            device=torch.device("cuda", torch.cuda.current_device()),
+        )
+        if not self._codec.has_fused_chunk_major_staging:
+            raise RuntimeError(
+                "M3 offload requires the Triton fused chunk-major PAGE staging "
+                "kernels (DSV4PageSlotCodec reported them unavailable)"
+            )
+
+        self._engine, cfg, meta = build_offload_engine(
+            self._config,
+            engine_id=f"{offcfg.lmcache_engine_id(self._config)}-{rank}",
+            block_size=self.virtual_block_size,
+            bytes_per_block=self._codec.bytes_per_block,
+            gpu_connector_factory=lambda cfg, meta: BlockGPUConnector(
+                self._codec,
+                self.block_size,
+                chunk_size=int(cfg.chunk_size),
+                virtual_block_size=self.virtual_block_size,
+            ),
+            world=world,
+            rank=rank,
+        )
+        self.chunk_size = int(cfg.chunk_size)
+
+        try:
+            from lmcache.v1.lookup_client.factory import LookupClientFactory
+
+            self._lookup_server = LookupClientFactory.create_lookup_server(
+                self._engine, meta
+            )
+        except Exception as e:  # noqa: BLE001  # optional save-only dependency
+            logger.warning("LMCache offload: lookup server not started: %s", e)
+
+        gpu_connector = self._engine.gpu_connector
+        logger.info(
+            "LMCache M3 PAGE offload worker rank=%d: page_regions=%d "
+            "bytes_per_block=%d chunk=%d gpu_staging_chunk_bytes=%d "
+            "gpu_staging_buffer_chunks=%d gpu_staging_buffer_bytes=%d "
+            "release_gpu_staging=%s save=%s load=%s",
+            rank,
+            len(block_regions),
+            self._codec.bytes_per_block,
+            self.chunk_size,
+            gpu_connector.gpu_staging_chunk_bytes,
+            gpu_connector.gpu_staging_buffer_chunks,
+            gpu_connector.gpu_staging_buffer_bytes,
+            gpu_connector.release_gpu_staging_after_transfer,
+            self._do_save,
+            self._do_load,
+        )
+
+
+class M3OffloadScheduler(DenseOffloadScheduler):
+    """M3 reuses the model-agnostic dense offload scheduler unchanged.
+
+    The scheduler operates purely on token counts, block tables, and LMCache
+    hit lookups -- no model-specific geometry -- so PAGE-only M3 needs no
+    scheduler changes.
+    """

--- a/recipes/MiniMax-M3-Agentic-Offload.md
+++ b/recipes/MiniMax-M3-Agentic-Offload.md
@@ -1,0 +1,265 @@
+# MiniMax-M3 — Agentic serving recipe (KV offload + DP2 by concurrency)
+
+Serving-layer only — model code (`atom/model_ops/minimax_m3/*`) is untouched; every knob below
+is a server flag or an environment variable.
+
+MiniMax-M3's KV is **uncompressed** (2,961,408 bytes / 128-token block = **22.6 KB/token/rank**,
+vs DeepSeek-V4's MLA which compresses ~10–20×). HBM holds only ~4.66M tokens/rank, so the
+prefix cache that agentic multi-turn replay lives on evicts fast as concurrency climbs. That
+single fact drives the whole ladder: **how much of the reusable prefix survives in HBM, and
+where the rest has to live.**
+
+---
+
+## TL;DR — pick by offered concurrency
+
+| Concurrency | Config | Offload | GPUs | Ranks | Why |
+|:-----------:|:-------|:-------:|:----:|:-----:|:----|
+| **1 – 16c** | TP4 + EAGLE3 | off | 4 | 4 | Working set fits HBM; the HBM prefix cache alone hits ~100%. Offload only adds lookup + CPU-staging overhead for zero recovered tokens. |
+| **32 – 48c** | TP4 + EAGLE3 | on | 4 | 4 | HBM prefix cache starts evicting reusable prefixes; the CPU (L2) + NVMe (L3) offload tier restores what HBM dropped. Total cache-read stays ~96%. 256 GB/rank pool (1 TB total) holds through 48c. |
+| **≥ 64c** | DP2 × TP4 | on | 8 | 8 | A single TP4's offload pool saturates at 64c (per-rank working set × concurrency > pool → alloc-fail thrash, run stalls). DP2 = two independent TP4 replicas: each sees ~conc/2, **total CPU pool doubles (8 ranks), restore bandwidth doubles** → back in the unsaturated regime. |
+
+Rule of thumb for the in-between points (24c, etc.): offload earns its keep the moment HBM
+prefix hit starts dropping below ~100%; add DP2 the moment a single-TP4 offload pool starts
+logging LMCache alloc-fails. Don't run DP2 below ~64c — splitting the batch halves each
+replica's spec-decode/batch efficiency for no cache benefit while HBM is still coping.
+
+Notes on the commands below:
+- `--port` is the internal engine port; `--server-port` is the HTTP listener (8890). Passing
+  only `--port` leaves nothing listening on 8890.
+- `--max-num-seqs` is sized at **2 × offered concurrency** (32 for 16c, 96 for 48c, 192 for
+  96c). A cap below the offered load silently becomes the bottleneck.
+- `--model` points at the local checkpoint; adjust the path to your mount.
+
+---
+
+## A. Low concurrency (1–16c) — TP4 + EAGLE3, no offload
+
+Server:
+```bash
+env \
+  AITER_QUICK_REDUCE_QUANTIZATION=INT4 \
+  AITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0 \
+  ATOM_FORCE_ATTN_TRITON=1 \
+  AITER_LOG_LEVEL=WARNING \
+  ATOM_GC_THRESHOLD=20000,50,50 \
+  python3 -u -m atom.entrypoints.openai_server \
+    --model /mnt/m2m_nobackup/models/MiniMax-M3-MXFP8 \
+    --served-model-name /mnt/m2m_nobackup/models/MiniMax-M3-MXFP8 \
+    --host 0.0.0.0 --port 8896 --server-port 8890 \
+    --tensor-parallel-size 4 \
+    --trust-remote-code \
+    --kv_cache_dtype fp8 \
+    --gpu-memory-utilization 0.9 \
+    --block-size 128 \
+    --max-num-batched-tokens 16384 \
+    --attn-prefill-chunk-size 16384 \
+    --state-checkpoint-interval-tokens 32768 \
+    --max-num-seqs 32 \
+    --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+    --enable-prefix-caching \
+    --method eagle3 \
+    --draft-model /shared_nfs/huggingface_models/Inferact/MiniMax-M3-EAGLE3 \
+    --num-speculative-tokens 3 \
+    --spec-decode-acceptance-rate 0.7336
+```
+No `--kv-transfer-config` and no LMCache env: single TP4, EAGLE3 spec-decode, HBM prefix cache
+only. Then run the client (§ Client) with `--concurrency 16`.
+
+---
+
+## B. Mid concurrency (32–48c) — TP4 + EAGLE3 + offload
+
+Same as A plus the LMCache env and `--kv-transfer-config`:
+```bash
+mkdir -p /mnt/m2m_nobackup/lmcache_disk   # NVMe (L3) tier dir
+
+env \
+  PYTHONHASHSEED=0 \
+  LMCACHE_LOCAL_CPU=True \
+  LMCACHE_MAX_LOCAL_CPU_SIZE=256 \
+  LMCACHE_CHUNK_SIZE=256 \
+  LMCACHE_LOCAL_DISK=file:///mnt/m2m_nobackup/lmcache_disk \
+  LMCACHE_MAX_LOCAL_DISK_SIZE=500 \
+  AITER_QUICK_REDUCE_QUANTIZATION=INT4 \
+  AITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0 \
+  ATOM_FORCE_ATTN_TRITON=1 \
+  AITER_LOG_LEVEL=WARNING \
+  ATOM_GC_THRESHOLD=20000,50,50 \
+  python3 -u -m atom.entrypoints.openai_server \
+    --model /mnt/m2m_nobackup/models/MiniMax-M3-MXFP8 \
+    --served-model-name /mnt/m2m_nobackup/models/MiniMax-M3-MXFP8 \
+    --host 0.0.0.0 --port 8896 --server-port 8890 \
+    --tensor-parallel-size 4 \
+    --trust-remote-code \
+    --kv_cache_dtype fp8 \
+    --gpu-memory-utilization 0.9 \
+    --block-size 128 \
+    --max-num-batched-tokens 16384 \
+    --attn-prefill-chunk-size 16384 \
+    --state-checkpoint-interval-tokens 32768 \
+    --max-num-seqs 96 \
+    --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+    --enable-prefix-caching \
+    --kv-transfer-config '{"kv_connector":"lmcache_offload","kv_role":"offload"}' \
+    --method eagle3 \
+    --draft-model /shared_nfs/huggingface_models/Inferact/MiniMax-M3-EAGLE3 \
+    --num-speculative-tokens 3 \
+    --spec-decode-acceptance-rate 0.7336
+```
+`LMCACHE_MAX_LOCAL_CPU_SIZE` (GB) and `LMCACHE_MAX_LOCAL_DISK_SIZE` (GB) are the CPU (L2) and
+NVMe (L3) tier sizes, **per rank**. 256 GB/rank × 4 ranks = **1 TB** CPU pool, which carries
+48c. `PYTHONHASHSEED=0` is mandatory — without it each TP rank keys the same prompt differently
+and the offload hit ratio collapses to 0. Then run the client with `--concurrency 48`.
+
+---
+
+## C. High concurrency (≥64c) — DP2 × TP4 + offload
+
+`--data-parallel-size 2` (two independent TP4 replicas across all 8 GPUs), no EAGLE3, session
+affinity on:
+```bash
+mkdir -p /mnt/m2m_nobackup/lmcache_disk   # NVMe (L3) tier dir
+
+env \
+  ATOM_DP_SESSION_AFFINITY=1 \
+  PYTHONHASHSEED=0 \
+  LMCACHE_LOCAL_CPU=True \
+  LMCACHE_MAX_LOCAL_CPU_SIZE=256 \
+  LMCACHE_CHUNK_SIZE=256 \
+  LMCACHE_LOCAL_DISK=file:///mnt/m2m_nobackup/lmcache_disk \
+  LMCACHE_MAX_LOCAL_DISK_SIZE=500 \
+  AITER_QUICK_REDUCE_QUANTIZATION=INT4 \
+  AITER_QUICK_REDUCE_CAST_BF16_TO_FP16=0 \
+  ATOM_FORCE_ATTN_TRITON=1 \
+  AITER_LOG_LEVEL=WARNING \
+  ATOM_GC_THRESHOLD=20000,50,50 \
+  python3 -u -m atom.entrypoints.openai_server \
+    --model /mnt/m2m_nobackup/models/MiniMax-M3-MXFP8 \
+    --served-model-name /mnt/m2m_nobackup/models/MiniMax-M3-MXFP8 \
+    --host 0.0.0.0 --port 8896 --server-port 8890 \
+    --tensor-parallel-size 4 --data-parallel-size 2 --dp-load-balance least_requests \
+    --trust-remote-code \
+    --kv_cache_dtype fp8 \
+    --gpu-memory-utilization 0.9 \
+    --block-size 128 \
+    --max-num-batched-tokens 16384 \
+    --attn-prefill-chunk-size 16384 \
+    --state-checkpoint-interval-tokens 32768 \
+    --max-num-seqs 192 \
+    --online_quant_config '{"global_quant_config": "ptpc_fp8", "exclude_layer": ["lm_head", "model.embed_tokens", "vision_tower", "multi_modal_projector", "patch_merge_mlp", "*block_sparse_moe"]}' \
+    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+    --enable-prefix-caching \
+    --kv-transfer-config '{"kv_connector":"lmcache_offload","kv_role":"offload"}' \
+    --index-cache-dtype fp8
+```
+`LMCACHE_MAX_LOCAL_CPU_SIZE` is **per rank** and DP2 has **8 ranks** (2 dp × 4 tp), so the host
+CPU total is size × 8. 256 → **2 TB** (fits a 2.5 TB node); drop to 192 (→ 1.5 TB) on a tighter
+box. `ATOM_DP_SESSION_AFFINITY=1` is mandatory — it pins each multi-turn session to the replica
+whose local prefix cache owns it, so a later turn is a warm hit rather than a cold prefill on a
+rank that never saw the prefix. The DP2 configuration runs without spec-decode (no draft model).
+Then run the client with `--concurrency 96`.
+
+---
+
+## Client (aiperf agentic replay)
+
+Identical across all three bands — **only `--concurrency` changes** to match the server's
+`--max-num-seqs / 2`. Start it after the server logs `READY http=200`:
+```bash
+ART=./results_FP8/c96_$(date +%m%d_%H%M)   # set concurrency in the name to taste
+mkdir -p "$ART"
+
+export AIPERF_HTTP_TCP_USER_TIMEOUT=900000
+export AIPERF_DATASET_CONFIGURATION_TIMEOUT=1800
+export AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT=1800
+export AIPERF_TIMING_CANCEL_DRAIN_TIMEOUT=300
+export AIPERF_DATASET_WEKA_LIVE_ASSISTANT_RESPONSES=0
+export AIPERF_UI_REALTIME_METRICS_ENABLED=true
+export AIPERF_FAILED_REQUEST_THRESHOLD=0.10
+export AIPERF_LIVE_FAILED_REQUEST_THRESHOLD=0.10
+export AIPERF_WARMUP_REQUESTS_PER_LANE=10
+export AIPERF_BENCHMARK_GRACE_PERIOD=30
+export AIPERF_SERVER_METRICS_URLS="http://localhost:8890/metrics"
+export AIPERF_REQUIRED_SERVER_METRIC_PREFIX="atom:"
+
+aiperf profile --scenario inferencex-agentx-mvp \
+  --url http://localhost:8890 --endpoint /v1/chat/completions \
+  --endpoint-type chat --streaming \
+  --model /mnt/m2m_nobackup/models/MiniMax-M3-MXFP8 \
+  --tokenizer /mnt/m2m_nobackup/models/MiniMax-M3-MXFP8 \
+  --tokenizer-trust-remote-code \
+  --concurrency 96 --benchmark-duration 3600 --stats-interval 30 \
+  --random-seed 42 --failed-request-threshold 0.10 \
+  --trajectory-start-min-ratio 0.25 --trajectory-start-max-ratio 0.75 \
+  --warmup-requests-per-lane 10 --trace-idle-gap-cap-seconds 300 \
+  --agentic-warmup-grace-period 1800 \
+  --use-server-token-count --no-gpu-telemetry \
+  --num-dataset-entries 393 --slice-duration 1.0 \
+  --server-metrics http://localhost:8890/metrics \
+  --public-dataset semianalysis_cc_traces_weka_062126 \
+  --output-artifact-dir "$ART"
+```
+`--tokenizer` / `--model` must match the server's `--served-model-name` exactly or every request
+404s. `--benchmark-duration` must be ≥ 900 (the scenario floor); anything shorter needs
+`--unsafe-override`, which stamps `submission_valid=false` (smoke test only). The DP2 server in
+§C is plain data parallelism (not DP-attention), so the client needs no session-id headers —
+affinity is keyed server-side.
+
+---
+
+## Why these thresholds (the mechanism)
+
+- **≤16c — HBM suffices.** Concurrency × per-session KV stays well under 4.66M tokens/rank,
+  so evicted-then-reused prefixes are rare. The offload connector would spend lookups and
+  CPU→HBM restores to recover tokens HBM never lost. Net negative. Keep it off.
+
+- **32–48c — HBM leaks, offload catches.** The working set crosses HBM's ceiling and the
+  prefix cache begins evicting reusable multi-turn prefixes. The **two tiers are disjoint**
+  (HBM prefix cache checked first; the PAGE offload connector restores only what HBM missed),
+  so as HBM hit falls the offload tier picks up the exact shift and the *total* holds. Measured:
+
+  | Concurrency | Offload hit (LMCache) | Prefix hit (HBM) | Total cache-read |
+  |:-----------:|:---------------------:|:----------------:|:----------------:|
+  | 32c | 44.1% | 52.6% | **96.7%** |
+  | 48c | 82.5% | 13.1% | **95.5%** |
+
+  (% of prompt tokens, server Prometheus counters. Cross-checked vs aiperf Overall Prompt
+  Cache Read %: 32c=94.87%, 48c=95.76% — within ~0.3%.) HBM collapses 52.6%→13.1% while
+  offload rises 44.1%→82.5%; true prefill stays ~3–5%. **Without offload that HBM collapse
+  falls straight through to recompute.**
+
+- **≥64c — single pool saturates, split it.** At 64c the per-rank working set × concurrency
+  exceeds a 4-rank / 1 TB CPU pool; LMCache logs mass allocation failures (≈778k observed at
+  c64 single-TP4) and the run stalls. DP2 fixes it three ways at once: **(1)** each replica
+  serves ~conc/2, halving per-rank working set; **(2)** 8 ranks instead of 4 double the total
+  CPU pool; **(3)** 8 ranks double the CPU→HBM restore parallelism. The same 256 GB/rank that
+  thrashes at c64-on-4-ranks runs clean at c64-on-8-ranks.
+
+---
+
+## Mandatory env (do not drop)
+
+- `ATOM_FORCE_ATTN_TRITON=1` — always. Without it decode routes to the ASM paged-attention
+  kernel whose `qlen*gqa ≤ 16` constraint M3 violates (gqa=16, qlen=4 → 64); server dies at
+  startup.
+- `PYTHONHASHSEED=0` — whenever offload is on. Without a fixed hash seed each TP rank derives a
+  different cache key for the same prompt and the offload hit ratio collapses to 0.
+- `ATOM_DP_SESSION_AFFINITY=1` — for the DP2 configuration. Without it a session's turns scatter
+  across replicas and every turn is a cold prefill.
+- Offload requires the **HIP source build of LMCache** (`/opt/LMCache`, `backend: lmcache.c_ops`).
+  The PyPI wheel is CUDA-linked and silently falls back to a slow python path that negates the win.
+
+## Notes / non-knobs on M3
+
+- `--state-checkpoint-interval-tokens` (V4's 32768) is **inert on M3**: the runtime reports
+  zero state slots ("state 0/0", "Checkpoint Fates kept: 0"). Set for flag-parity only; it
+  changes nothing.
+- `--max-model-len` — leave uncapped (model-native 1,048,576). AgentX warmup primers replay each
+  trace's full accumulated context (up to ~996k tokens); any cap below ~1M makes the server 400
+  those primers and the run aborts before profiling. A cap also can't grow the KV pool, so it
+  can't help hit rate anyway.
+- `--enable-prefix-caching` is on here, a deliberate deviation from CI's `--no-enable_prefix_caching`
+  — CI's random ISL/OSL workloads don't reuse prefixes; agentic replay is built on prefix reuse.

--- a/tests/test_lmcache_offload_config.py
+++ b/tests/test_lmcache_offload_config.py
@@ -204,14 +204,37 @@ def test_offload_layout_override_still_allows_dense_hybrid_choice():
     assert offcfg.select_offload_layout(config) == "dense"
 
 
-def test_minimax_and_dense_model_types_still_route_to_dense():
+def test_minimax_m2_and_dense_model_types_still_route_to_dense():
     # The refusal must be narrow: a non-GDN model with no compress_ratios is
-    # ordinary dense, including MiniMax (sparse/standard attention, no state).
-    for model_type in ("minimax_m2", "minimax_m3", "llama", None):
+    # ordinary dense. MiniMax-M2 (standard attention, no NSA index cache) is
+    # plain dense; only M3, whose NSA index cache needs its own tier, is carved
+    # out to the PAGE-only "m3" layout (see the two tests below).
+    for model_type in ("minimax_m2", "llama", None):
         config = _config()
         config.hf_config.compress_ratios = None
         config.hf_config.model_type = model_type
         assert offcfg.select_offload_layout(config) == "dense"
+
+
+def test_minimax_m3_model_type_routes_to_m3():
+    # M3's NSA index cache rides in transfer_tensors.block_regions, which only
+    # the PAGE-only "m3" layout sources; `dense` would offload K/V and silently
+    # drop the index cache, corrupting restored prefixes.
+    config = _config()
+    config.hf_config.compress_ratios = None
+    config.hf_config.model_type = "minimax_m3"
+    assert offcfg.select_offload_layout(config) == "m3"
+
+
+def test_minimax_m3_is_detected_by_architecture_name():
+    # M3 is identified by architecture name, not a model_type family, so the
+    # arch-name path must route to "m3" from the architectures list even when
+    # the model_type string does not name M3.
+    config = _config()
+    config.hf_config.compress_ratios = None
+    config.hf_config.model_type = "minimax_text_01"
+    config.hf_config.architectures = ["MiniMaxM3ForCausalLM"]
+    assert offcfg.select_offload_layout(config) == "m3"
 
 
 @pytest.mark.parametrize("invalid", [True, 256.0, "256"])


### PR DESCRIPTION
MiniMax-M3 is a 60-layer MoE + NSA sparse-attention model: PAGE-only KV, no per-request SLOT/compression state. With no offload layout of its own it fell through to "dense", whose byte codec is built from the per-layer KVCacheTensor K/V and never sees the NSA index_cache -- that region is delivered only via transfer_tensors.block_regions. So dense would offload
K/V and silently drop the index cache, corrupting restored prefixes; in practice evicted-prefix KV was dropped and every request re-prefilled in high CONC.


### Cache-hit breakdown (MiniMax-M3, TP4 + PAGE offload, agentic replay)

Cache-read as % of prompt tokens (server Prometheus counters; the two tiers are
disjoint — the HBM prefix cache is checked first, the PAGE offload connector
restores whatever HBM missed):

| Concurrency | Offload hit (LMCache) | Prefix cache hit (HBM) | Total cache-read |
|:-----------:|:---------------------:|:----------------------:|:----------------:|
| 32c         | 44.1%                 | 52.6%                  | 96.7%            |
| 48c         | 82.5%                 | 13.1%                  | 95.5%            |

Total cache-read holds at ~96% as concurrency rises: as the HBM prefix cache
comes under eviction pressure (52.6% → 13.1%), the PAGE offload tier absorbs the
shift (44.1% → 82.5%), keeping true prefill at only ~3–5%. Without offload that
HBM collapse would fall straight through to recompute.



### Cache-hit breakdown (MiniMax-M3, TP4 * DP2 + PAGE offload)

| Concurrency | Offload hit (LMCache) | Prefix cache hit (HBM) | Total cache-read |
|:-----------:|:---------------------:|:----------------------:|:----------------:|
| 64c         | 57.2%                | 37.8%                  | 95.1%            |
| 96c         | 81.4%                | 10.3%                  | 91.7%            |


