### PR TITLE
 [MTP] Fix negative pad-row KV length in draft decode metadata

### DIFF
--- a/atom/model_ops/attentions/aiter_mla.py
+++ b/atom/model_ops/attentions/aiter_mla.py
@@ -965,6 +965,21 @@ class AiterMLAMetadataBuilder(CommonAttentionBuilder):
             var["context_lens"].gpu[:running_bs] if update_context_lens else None
         )
 
+        # A padded row's `kv_indptr` entry is a range from whatever batch last
+        # occupied it, and `_enter_decode_metadata` rebases only the real rows,
+        # so the tail no longer continues them. Once the real rows total more
+        # tokens than that stale value the array runs BACKWARDS and the pad row
+        # comes out with a NEGATIVE length -- which the kernel below turns into
+        # a negative sparse count, and sparse decode into a wild kv_start/kv_end
+        # that faults. A long request landing on a bucket a shorter batch left
+        # behind is enough. Close the tail the way a draft PREFILL's widened
+        # rows already are (`_pad_prefill_mla_draft_tail`) -- repeat the last
+        # real end. This has to precede the kernel, which reads the diffs; the
+        # `+= cu_seqlens_q` it applies then leaves each pad row holding the same
+        # single token it leaves every real one.
+        if running_bs > bs:
+            kv_indptr[bs + 1 : running_bs + 1] = kv_indptr[bs]
+
         mtp_prepare_decode_mla_kernel[(1,)](
             kv_indptr,
             cu_seqlens_q,

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -485,10 +485,11 @@ class EagleProposer(Drafter):
         cu_seqlens_q[: running_bs + 1] = builder.row_ids[: running_bs + 1]
         if target_uses_mla and has_flat_kv:
             # MLA: block_size=1, kv_indptr tracks tokens
-            # Per REAL request: `num_reject_tokens` is scheduled_bs-long, a pad row
-            # rejected nothing. Their `kv_indptr` keeps what the target left,
-            # which is one of its own valid ranges, so their reads stay in
-            # bounds; their WRITES are what has to be neutralized, below.
+            # Per REAL request: `num_reject_tokens` is scheduled_bs-long, a pad
+            # row rejected nothing. That leaves the tail holding whatever batch
+            # last occupied those rows, which no longer continues the rows just
+            # rebased here -- `prepare_mtp_decode` closes it, per backend.
+            # Their WRITES are neutralized below.
             kv_indptr[1 : scheduled_bs + 1] -= torch.cumsum(num_reject_tokens, dim=0)
         if positions.ndim == 1:
             positions = torch.index_select(positions, 0, last_token_indices)


### PR DESCRIPTION
## Problem

`_enter_decode_metadata` rebases `kv_indptr` for the scheduled rows only:

```python
kv_indptr[1 : scheduled_bs + 1] -= torch.cumsum(num_reject_tokens, dim=0)
```

A padded row therefore keeps the range whatever batch last occupied that row left behind. The comment above this line assumed those stale entries are harmless because they are "one of its own valid ranges, so their reads stay in bounds" — they are not. Once the real rows total more tokens than the stale value, the tail of the indptr runs **backwards**, so the pad row's length comes out negative. `mtp_prepare_decode_mla_kernel` turns that into a negative sparse count, and sparse decode derives `kv_start`/`kv_end` from the negative extent and faults on an address unrelated to any live allocation:

```
Memory access fault by GPU node-6 ... on address 0x783dda000000. Reason: Unknown.
```

Per-row KV lengths from the batch that faulted (`bs=5`, padded to `running_bs=8`):

```
kvcnt=[3477, 3493, 3596, 3725, 3201, -11147, 980, 1058]
spcnt=[2048, 2048, 2048, 2048, 2048, -11147, 980, 1058]
```

The five real rows are correct (`spcnt` = `min(ctx, index_topk)`); the first pad row is negative.

Reaching it needs all three of:

1. a padded draft batch — so cudagraph mode, since `positions` is only staged up to `running_bs` when `self.step is not None`;
2. `num_speculative_tokens >= 2` — a draft step past 0 must exist to rebuild the decode metadata;
3. a long request landing on a size bucket a shorter batch left behind — otherwise the stale value still exceeds the real total and the tail stays monotonic.

That combination is why it shows up as an intermittent crash under mixed long/short traffic rather than in any single-length run.

## Fix

Close the tail in the backend's own `prepare_mtp_decode`, which is where the base contract already puts this:

> Backends that distinguish the two mark the padded tail so downstream kernels skip it; those that do not simply never read `bs`.

It receives `bs` as the scheduled count and reads `running_bs` off the row buffer, so both are already in hand — this is the same place and the same `if running_bs > bs:` shape DeepSeek-V4 uses to mark its own padded tail.

The value is the last real end repeated, matching what a draft PREFILL's widened rows already get from `_pad_prefill_mla_draft_tail`. It has to precede the fused kernel, which reads the diffs; the `+= cu_seqlens_q` that kernel applies right after then leaves each pad row holding the same single token it leaves every real one, so no kernel sees an empty range. The row's output stays discarded exactly as before, and its writes remain neutralized by the existing `-1` slot path.

`TritonMLAMetadataBuilder` inherits this through its `super().prepare_mtp_decode(...)` call. MHA and GDN never take the rebase that strands the tail, and DeepSeek-V4 rebuilds its indptr over the full `running_bs`.

## Validation

DeepSeek-V3.2 + MTP-3, TP8 on MI355X, `cudagraph_mode=FULL` (draft graph enabled), full GSM8K at 64 concurrency. 5-shot and 20-shot were driven against one server simultaneously, which is the mixed long/short scenario that reproduces the fault.

| | before | after |
|---|---|---|
| memory access fault | 8/8 ranks, < 1 min in | none |
| GSM8K 5-shot (n=1319) | crash | 0.9538 ± 0.0058 |
| GSM8K 20-shot (n=1319) | crash | 0.9522 ± 0.0059 |
| MTP acceptance | — | 68.86%, 3.07 toks/fwd |
| per-position acceptance | — | 21.6% / 31.9% / 40.5% |

Without the fix the same workload faulted on every rank within a minute; `--num-speculative-tokens 1` or an eager draft avoided it, matching the conditions above.

Localized by bisecting with per-kernel `torch.cuda.synchronize()` markers, which pinned the fault inside the draft decode replay, then by dumping per-row KV and sparse counts at the faulting batch.
