### PR TITLE
feat(v4): DeepSeek-V4-Flash-Vision support

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -2077,6 +2077,45 @@ class Config:
         # 16. Same reasoning and same mechanism as the V4 override above: the
         # BlockManager and slot_mapping assume one global block size, so it is
         # set here and the attention builder sizes the index cache from it.
+        # ----- DeepSeek-V4 vision: reject unverified feature combinations -----
+        # Collected here rather than as scattered asserts so a request never
+        # reaches a half-supported path. Each of these silently corrupts rather
+        # than failing on its own.
+        if int(getattr(self.hf_config, "vision_n_layers", 0) or 0) > 0:
+            if self.enable_prefix_caching:
+                # Turned off rather than rejected: it is on by default, so
+                # raising would make every vision checkpoint fail to start.
+                # The block hash covers token ids only, and an image block's
+                # sentinel run is byte-identical for any two images of the same
+                # grid -- one request could be served another's image KV. A hit
+                # also restarts the prompt mid-block, which the in-image
+                # visibility math cannot express.
+                logger.warning(
+                    "Disabling prefix caching: DeepSeek-V4 vision block hashes "
+                    "cover token ids only, and image placeholder runs collide "
+                    "across different images of the same grid."
+                )
+                self.enable_prefix_caching = False
+            unsupported = []
+            if self.enable_tbo or self.enable_tbo_decode:
+                unsupported.append("TBO")
+            if self.prefill_context_parallel_size > 1:
+                unsupported.append("PCP")
+            from atom.utils import envs as _envs
+
+            if _envs.is_set("ATOM_USE_TRITON_MOE") and _envs.ATOM_USE_TRITON_MOE:
+                # `FusedMoE`'s Triton path checks `custom_routing_function is
+                # not None` and then calls aiter's `routing()` -- it never
+                # invokes the callable. Image tokens would route with the text
+                # bias and the hash layers would lose `tid2eid` entirely, with
+                # fluent wrong output and no warning.
+                unsupported.append("ATOM_USE_TRITON_MOE=1")
+            if unsupported:
+                raise ValueError(
+                    "DeepSeek-V4 vision checkpoints do not support "
+                    f"{', '.join(unsupported)}."
+                )
+
         is_glm5_next = any("Glm5Next" in str(a) for a in arches)
         if is_glm5_next:
             unsupported_features = []

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -39,9 +39,9 @@ if TYPE_CHECKING:
 from atom import SamplingParams
 from atom.model_engine.arg_utils import EngineArgs
 from atom.model_engine.llm_engine import _load_tokenizer
-from atom.model_engine.multimodal import build_multimodal_inputs
 from atom.model_engine.request import RequestOutput
 from atom.model_engine.sequence import new_token_ids
+from atom.multimodal import build_multimodal_inputs
 from atom.utils.arg_parser import FlexibleArgumentParser
 from atom.utils.gc_utils import (
     freeze_gc_heap,

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -662,7 +662,25 @@ def _get_multimodal_processor():
     global processor, model_name
     if processor is None:
         logger.info(f"Loading multimodal processor from {model_name}...")
-        processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True)
+        try:
+            processor = AutoProcessor.from_pretrained(
+                model_name, trust_remote_code=True
+            )
+        except (OSError, ValueError, KeyError) as exc:
+            # Some checkpoints ship no `preprocessor_config.json` and do their
+            # own preprocessing inside the registered input builder
+            # (DeepSeek-V4-Flash-Vision is one). Without this the request 500s
+            # inside AutoProcessor before any model-specific handling runs, so
+            # the server could not serve an image the offline example can.
+            from transformers import AutoTokenizer
+
+            logger.info(
+                f"No HF processor for {model_name} ({exc}); "
+                "falling back to the tokenizer."
+            )
+            processor = AutoTokenizer.from_pretrained(
+                model_name, trust_remote_code=True
+            )
     return processor
 
 

--- a/atom/examples/multimodal_inference.py
+++ b/atom/examples/multimodal_inference.py
@@ -9,7 +9,7 @@ from transformers import AutoProcessor
 
 from atom import SamplingParams
 from atom.model_engine.arg_utils import EngineArgs
-from atom.model_engine.multimodal import build_multimodal_inputs
+from atom.multimodal import build_multimodal_inputs
 from atom.utils.arg_parser import FlexibleArgumentParser
 
 parser = FlexibleArgumentParser(
@@ -18,7 +18,7 @@ parser = FlexibleArgumentParser(
         "Generic image+text multimodal offline inference using the native ATOM engine.\n"
         "Validated with Qwen3.5 and Kimi-K3. The script relies on the model's\n"
         "Hugging Face processor and chat template, plus the architecture-specific\n"
-        "input builders in atom.model_engine.multimodal for processors that do not\n"
+        "input builders in atom.multimodal for processors that do not\n"
         "follow the Qwen convention."
     ),
 )
@@ -59,8 +59,15 @@ def main():
     # Force eager mode and single-batch cudagraph sizes for simplicity
     args.cudagraph_capture_sizes = "[1]"
 
-    # Load processor (handles media preprocessing and chat template)
-    processor = AutoProcessor.from_pretrained(args.model, trust_remote_code=True)
+    # Load processor (handles media preprocessing and chat template). Some
+    # checkpoints ship none and preprocess inside their input builder instead.
+    try:
+        processor = AutoProcessor.from_pretrained(args.model, trust_remote_code=True)
+    except (OSError, ValueError, KeyError) as exc:
+        from transformers import AutoTokenizer
+
+        print(f"No HF processor for {args.model} ({exc}); using the tokenizer.")
+        processor = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
 
     images = [Image.open(path).convert("RGB") for path in args.image]
 

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -13,8 +13,8 @@ from transformers import AutoTokenizer, PreTrainedTokenizerFast
 
 from atom.config import Config
 from atom.model_engine.engine_core_mgr import CoreManager, DisaggCoreManager
-from atom.model_engine.multimodal import get_mrope_input_positions
 from atom.model_engine.sequence import Sequence
+from atom.multimodal import get_mrope_input_positions
 from atom.sampling_params import SamplingParams
 from atom.utils import envs
 

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -426,6 +426,15 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         self.index_head_dim = getattr(hf, "index_head_dim", 128)
         self.window_size = getattr(hf, "sliding_window", 128)
         self.index_topk = getattr(hf, "index_topk", 1024)
+        # Vision checkpoints attend BIDIRECTIONALLY inside an image span, which
+        # widens the per-token sliding window. Zero on text-only V4, where every
+        # visibility term below collapses and the causal formulas are untouched.
+        self.vision_max_n_token = (
+            int(getattr(hf, "vision_max_n_token", 384))
+            if int(getattr(hf, "vision_n_layers", 0) or 0) > 0
+            else 0
+        )
+        self.vocab_size = int(getattr(hf, "vocab_size", 0))
         self.rope_head_dim = getattr(hf, "qk_rope_head_dim", 64)
         # MTP-portion of compress_ratios. `prepare_mtp_decode`'s direct-kernel
         # fast path only handles SWA (ratio=0) draft layers; non-zero ratios
@@ -2877,6 +2886,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             attn_metadata.state_slot_out_cpu,
             scheduled_bs,
             scheduled_tokens,
+            image_visibility=self._image_visibility(
+                batch, extend_lens_np, scheduled_tokens
+            ),
         )
 
         # ----- PCP: reindex per-query metadata to this rank's 1/W shard -----
@@ -3041,6 +3053,18 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         - Token-split TBO (default, §11): uses `ub_slice` / `running_bs`.
         """
         from atom.utils.tbo.ubatch_splitting import split_attn_metadata
+
+        if getattr(self, "_forward_has_images", False):
+            # An image block's tokens attend across the whole span, so the rows
+            # they name must all live in ONE forward's `kv`. A token-split TBO
+            # micro-batch cuts that span in half and the second half's rows
+            # simply are not there. Nothing downstream would notice: the indices
+            # stay in range and the model answers fluently off half a picture.
+            raise NotImplementedError(
+                "DeepSeek-V4 vision does not support TBO prefill micro-batching "
+                "(in-image attention spans the whole prompt). Start the server "
+                "without --enable-tbo."
+            )
 
         # PCP+TBO request-boundary split: each ubatch = one request group processed as an
         # independent non-TBO PCP mini-batch. Slice the FULL (un-reindexed)
@@ -3655,6 +3679,37 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             qo_buf.np[T + 1 : T_pad + 1] = T
             attn_metadata.qo_indptr = qo_buf.copy_to_gpu(T_pad + 1)
 
+    def _image_visibility(
+        self, batch, extend_lens_np: np.ndarray, total_tokens: int
+    ) -> "tuple[np.ndarray, np.ndarray] | None":
+        """Per-token left/right in-image visibility, or None for a text batch.
+
+        Returns None on text-only V4, and on any vision batch with no image
+        sentinels — which keeps every text forward on exactly the causal
+        arithmetic it used before, rather than a widened path that happens to
+        reduce to it.
+        """
+        self._forward_has_images = False
+        if self.vision_max_n_token == 0:
+            return None
+        tokens = getattr(batch, "scheduled_tokens", None)
+        if tokens is None or tokens.shape[0] < total_tokens:
+            return None
+        tokens = tokens[:total_tokens]
+        # Image sentinel ids are the only ones at or above the vocabulary.
+        if int(tokens.max(initial=0)) < self.vocab_size:
+            return None
+        self._forward_has_images = True
+
+        from atom.models.deepseek_v4_vl import image_visible_spans
+
+        return image_visible_spans(
+            tokens,
+            self.vocab_size,
+            self.vision_max_n_token,
+            seq_lens=extend_lens_np.tolist(),
+        )
+
     def _build_paged_prefill_meta(
         self,
         attn_metadata: AttentionMetaData_DSV4,
@@ -3669,6 +3724,7 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         positions_gpu: torch.Tensor | None = None,
         cu_q_per_seq_gpu: torch.Tensor | None = None,
         block_tables_gpu: torch.Tensor | None = None,
+        image_visibility: "tuple[np.ndarray, np.ndarray] | None" = None,
     ) -> None:
         """Build per-fwd index buffers consumed by sparse_attn_v4_paged_prefill.
 
@@ -3745,6 +3801,37 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
 
         extend_count_np = np.minimum(token_pos_in_chunk + 1, win).astype(np.int32)
         prefix_swa_count_np = np.maximum(chunk_start_pt - swa_low, 0).astype(np.int32)
+        # ----- in-image bidirectional visibility (vision checkpoints only) -----
+        # Widens each token's SWA span to cover its whole [IMAGE_START,
+        # IMAGE_END] block, in BOTH directions. Sound only because the prefill
+        # attention kernel is purely index-driven with no causal mask, and the
+        # scheduler forwards a multimodal prompt whole — so every future row
+        # named here is already materialized in this forward's `kv` tensor.
+        # `extend_start_np` is a global position; the kernel turns it into a row.
+        extend_start_np = None
+        if image_visibility is not None:
+            from atom.models.deepseek_v4_vl import (
+                image_aware_extend_window,
+                image_window_width,
+            )
+
+            img_left, img_right = image_visibility
+            if chunk_start_pt.any():
+                raise AssertionError(
+                    "a multimodal prefill reached the attention builder with "
+                    "chunk_start > 0, i.e. it was chunked. In-image attention "
+                    "reads rows across the whole image block, which a chunk "
+                    "boundary would cut in half."
+                )
+            extend_start_np, extend_count_np = image_aware_extend_window(
+                positions_arr,
+                img_left,
+                img_right,
+                win,
+                image_window_width(
+                    int(positions_arr.max()) + 1, win, self.vision_max_n_token
+                ),
+            )
         # These SIZE each slice while `_v4_paged_prefill_indices_kernel` FILLS
         # it, so both must stay the geometry's spelling or the tail is
         # uninitialized. Buffer size ↔ kernel-writes then match exactly and no
@@ -3842,6 +3929,18 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             win=win,
             geometry=self.pool_geometry,
             hca_rows_per_block=self.hca_rows_per_block,
+            # None on every text forward, which keeps the kernel deriving the
+            # causal window from `win` exactly as before.
+            extend_start=(
+                upload_numpy(extend_start_np, device)
+                if extend_start_np is not None
+                else None
+            ),
+            extend_count=(
+                upload_numpy(extend_count_np, device)
+                if extend_start_np is not None
+                else None
+            ),
         )
 
         # ----- skip_prefix_len_csa: per-token SWA prefix length -----

--- a/atom/model_ops/attentions/deepseek_v4_attn.py
+++ b/atom/model_ops/attentions/deepseek_v4_attn.py
@@ -3689,17 +3689,28 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
         arithmetic it used before, rather than a widened path that happens to
         reduce to it.
         """
-        self._forward_has_images = False
-        if self.vision_max_n_token == 0:
+        # `batch.multimodal_data` is the authoritative, stateless statement that
+        # this batch carries images (the scheduler fills it per request). Derive
+        # from it rather than sniffing token ids, so the fact does not depend on
+        # this method having run -- the ubatch-splitting guard reads the same
+        # flag and used to disarm whenever an early return skipped the write.
+        self._forward_has_images = bool(getattr(batch, "multimodal_data", None))
+        if self.vision_max_n_token == 0 or not self._forward_has_images:
             return None
         tokens = getattr(batch, "scheduled_tokens", None)
         if tokens is None or tokens.shape[0] < total_tokens:
-            return None
+            # Fail loudly: the batch says it has images, so returning None here
+            # would build plain causal windows for an image block and the model
+            # would answer fluently off a partly-visible picture.
+            raise AssertionError(
+                "batch carries multimodal_data but scheduled_tokens is "
+                f"{'missing' if tokens is None else 'too short'} "
+                f"(need {total_tokens}); cannot build in-image visibility."
+            )
         tokens = tokens[:total_tokens]
         # Image sentinel ids are the only ones at or above the vocabulary.
         if int(tokens.max(initial=0)) < self.vocab_size:
             return None
-        self._forward_has_images = True
 
         from atom.models.deepseek_v4_vl import image_visible_spans
 
@@ -3735,7 +3746,9 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
           - extend region (shared): in-chunk SWA tail from per-fwd `kv`
             tensor. One buffer.
 
-        Per-token length formulas:
+        Per-token length formulas (text, i.e. `image_visibility is None`; a
+        vision prefill widens the extend span in BOTH directions instead --
+        see `image_aware_extend_window`):
           extend_count[t]      = min(token_pos_in_chunk[t] + 1, win)
           prefix_swa_count[t]  = max(0, chunk_start[bid] - max(0, p_global - win + 1))
           prefix_swa_count[t] + extend_count[t] = min(p_global + 1, win)
@@ -3816,7 +3829,13 @@ class DeepseekV4AttentionMetadataBuilder(CommonAttentionBuilder):
             )
 
             img_left, img_right = image_visibility
-            if chunk_start_pt.any():
+            # Scope the check to tokens INSIDE an image span. `chunk_start_pt`
+            # spans every sequence in the batch, so a plain `.any()` also fired
+            # on a co-scheduled text prefill continuing its own chunk -- legal,
+            # and nothing to do with the image request it blamed. Spans are at
+            # least [START, END], so every in-span token has a nonzero side.
+            in_image = (img_left > 0) | (img_right > 0)
+            if chunk_start_pt[in_image].any():
                 raise AssertionError(
                     "a multimodal prefill reached the attention builder with "
                     "chunk_start > 0, i.e. it was chunked. In-image attention "

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1442,6 +1442,15 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         prefix: str = "",
     ) -> torch.Tensor:
         if self.use_triton_decode and not get_forward_context().context.is_prefill:
+            if custom_routing_function is not None:
+                # Same gap as the prefill Triton path below: `routing()` is
+                # called instead of the hook, so a model's custom routing is
+                # silently replaced by plain bias-corrected top-k.
+                raise NotImplementedError(
+                    "the Triton MoE decode path does not support "
+                    "custom_routing_function (it never calls it). Disable it "
+                    "with ATOM_USE_TRITON_MOE_DECODE=0 for this model."
+                )
             # Triton decode is GGUU-only; GUGU uses the FlyDSL path.
             from aiter.ops.triton.moe.moe_routing.routing import routing
 
@@ -1490,6 +1499,20 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 triton_kernel_fused_experts,
                 triton_kernel_moe_forward,
             )
+
+            if custom_routing_function is not None:
+                # This path calls aiter's `routing()` below and never invokes
+                # the callable, so a model that installed a routing hook would
+                # be silently routed by `e_score_correction_bias` alone --
+                # DeepSeek-V4 vision loses `bias_vl` on image tokens and
+                # `tid2eid` on the hash layers, with fluent wrong output. The
+                # Triton MoE path is on by default on gfx94x, so this cannot be
+                # left to an env-var check at startup.
+                raise NotImplementedError(
+                    "the Triton MoE path does not support "
+                    "custom_routing_function (it never calls it). Disable it "
+                    "with ATOM_USE_TRITON_MOE=0 for this model."
+                )
 
             # Check if the model needs custom routing that triton routing()
             # does not support (grouped topk, sigmoid scoring, bias correction).

--- a/atom/model_ops/topK.py
+++ b/atom/model_ops/topK.py
@@ -488,3 +488,46 @@ def rocm_aiter_grouped_topk(
             routed_scaling_factor,
             num_fused_shared_experts,
         )
+
+
+def mm_topk(
+    ids: torch.Tensor,
+    gating_output: torch.Tensor,
+    bias: torch.Tensor,
+    bias_alt: torch.Tensor,
+    hash_table: torch.Tensor | None,
+    vocab_size: int,
+    renormalize: bool,
+    scaling: float,
+    out_ids: torch.Tensor,
+    out_weights: torch.Tensor,
+) -> None:
+    """Top-k where each token picks one of two router correction biases.
+
+    Tokens with an id at or above ``vocab_size`` -- multimodal placeholders,
+    whose ids sit above the text vocabulary -- select experts with ``bias_alt``;
+    every other token uses ``bias``. aiter's topk takes a single ``[E]`` bias
+    and cannot express that per-token choice, so this routes to a Triton kernel
+    instead. Reached through `FusedMoE`'s ``custom_routing_function`` hook.
+
+    ``hash_table`` (``[vocab, topk]``) switches text tokens to table lookup
+    rather than top-k, which is what DeepSeek-V4's first three layers do.
+    Pass None on layers that route every text token through the gate.
+
+    Fills ``out_ids`` / ``out_weights`` in place; they may be ``[:, :topk]``
+    views of a wider buffer.
+    """
+    from atom.model_ops.triton_mm_topk import mm_topk_triton
+
+    mm_topk_triton(
+        ids,
+        gating_output,
+        bias,
+        bias_alt,
+        hash_table,
+        vocab_size,
+        renormalize,
+        scaling,
+        out_ids,
+        out_weights,
+    )

--- a/atom/model_ops/triton_mm_topk.py
+++ b/atom/model_ops/triton_mm_topk.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Fused Triton MoE routing for DeepSeek-V4 vision checkpoints.
+
+The vision checkpoint carries a SECOND router bias per layer, ``gate.bias_vl``,
+used in place of ``gate.bias`` for image tokens. Reference (`inference/model.py`
+``Gate.forward``)::
+
+    scores    = sqrt(softplus(gate_logits))       # weights come from here, unbiased
+    is_image  = input_ids >= vocab_size
+    # hash layers (the first `n_hash_layers`):
+    #   text  -> tid2eid[input_ids]
+    #   image -> topk(scores + bias_vl)
+    # every other layer:
+    #   topk(scores + where(is_image, bias_vl, bias))
+    weights   = scores.gather(indices) / sum      # renormalized, then * route_scale
+
+The bias steers *selection* only; the returned weights are always gathered from
+the unbiased scores. ``FusedMoE.select_experts`` takes a single ``[E]``
+correction bias and cannot express a per-token choice between two of them, so
+DeepSeek-V4 vision models route through here via the ``custom_routing_function``
+hook instead — the same hook the hash layers already use.
+
+Everything is branch-free on the per-token ``is_image`` predicate: both bias
+vectors are loaded and selected with ``tl.where``, and on hash layers both the
+table gather and the top-k are computed and selected. Only ``IS_HASH`` branches,
+and that is a compile-time constant.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _mm_topk_kernel(
+    ids_ptr,  # [N] token ids; >= vocab marks an image sentinel
+    gating_ptr,  # [N, n_routed] router logits
+    bias_ptr,  # [n_routed] fp32 text router bias
+    bias_alt_ptr,  # [n_routed] fp32 image router bias
+    tid2eid_ptr,  # [vocab, topk] int32 (hash layers only; else aliases bias)
+    out_ids_ptr,  # [N, topk] int32
+    out_w_ptr,  # [N, topk] fp32
+    stride_g_row,
+    stride_g_col,
+    stride_tid_row,
+    stride_oid_row,
+    stride_ow_row,
+    vocab,
+    n_routed,
+    scaling,
+    TOPK: tl.constexpr,
+    RENORM: tl.constexpr,
+    IS_HASH: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+):
+    t = tl.program_id(0)
+    tok = tl.load(ids_ptr + t).to(tl.int64)
+    # Image sentinels are the only ids at or above the vocabulary.
+    is_image = tok >= vocab
+
+    offs_k = tl.arange(0, BLOCK_TOPK)
+    k_mask = offs_k < TOPK
+    offs_e = tl.arange(0, BLOCK_E)
+    e_mask = offs_e < n_routed
+
+    # ---- scores over every routed expert: sqrt(softplus(logit)) ----
+    g = tl.load(
+        gating_ptr + t * stride_g_row + offs_e * stride_g_col, mask=e_mask, other=0.0
+    ).to(tl.float32)
+    # Numerically stable softplus: log1p(exp(x)) ~= x for large x.
+    sp = tl.where(g > 20.0, g, tl.log(1.0 + tl.exp(g)))
+    scores = tl.sqrt(sp)
+
+    # ---- selection bias: per-token choice between the two vectors ----
+    b_base = tl.load(bias_ptr + offs_e, mask=e_mask, other=0.0).to(tl.float32)
+    b_alt = tl.load(bias_alt_ptr + offs_e, mask=e_mask, other=0.0).to(tl.float32)
+    sel = scores + tl.where(is_image, b_alt, b_base)
+    sel = tl.where(e_mask, sel, float("-inf"))
+
+    # ---- top-k by repeated argmax (TOPK is ~6; a full sort would cost more) ----
+    top_ids = tl.zeros([BLOCK_TOPK], dtype=tl.int32)
+    top_w = tl.zeros([BLOCK_TOPK], dtype=tl.float32)
+    for k in tl.static_range(TOPK):
+        idx = tl.argmax(sel, axis=0)
+        # Weight comes from the UNBIASED score at the selected expert.
+        wk = tl.sum(tl.where(offs_e == idx, scores, 0.0), axis=0)
+        top_ids = tl.where(offs_k == k, idx.to(tl.int32), top_ids)
+        top_w = tl.where(offs_k == k, wk, top_w)
+        sel = tl.where(offs_e == idx, float("-inf"), sel)
+
+    if IS_HASH:
+        # Text tokens on a hash layer bypass the gate entirely: their experts
+        # come from the token-id table. Computed unconditionally and selected,
+        # so the kernel stays branch-free.
+        tokc = tl.minimum(tl.maximum(tok, 0), vocab - 1)
+        eid = tl.load(
+            tid2eid_ptr + tokc * stride_tid_row + offs_k, mask=k_mask, other=0
+        )
+        # A dummy-loaded or corrupt table would otherwise send the downstream
+        # expert-weight gather out of bounds and fault the GPU.
+        eid = tl.minimum(tl.maximum(eid, 0), n_routed - 1)
+        hg = tl.load(
+            gating_ptr + t * stride_g_row + eid.to(tl.int64) * stride_g_col,
+            mask=k_mask,
+            other=0.0,
+        ).to(tl.float32)
+        hsp = tl.where(hg > 20.0, hg, tl.log(1.0 + tl.exp(hg)))
+        hash_w = tl.where(k_mask, tl.sqrt(hsp), 0.0)
+        out_ids = tl.where(is_image, top_ids, eid.to(tl.int32))
+        out_w = tl.where(is_image, top_w, hash_w)
+    else:
+        out_ids = top_ids
+        out_w = top_w
+
+    out_w = tl.where(k_mask, out_w, 0.0)
+    if RENORM:
+        out_w = out_w / tl.maximum(tl.sum(out_w, axis=0), 1e-20)
+    out_w = out_w * scaling
+
+    tl.store(out_ids_ptr + t * stride_oid_row + offs_k, out_ids, mask=k_mask)
+    tl.store(out_w_ptr + t * stride_ow_row + offs_k, out_w, mask=k_mask)
+
+
+def mm_topk_triton(
+    ids: torch.Tensor,  # [N] token ids
+    gating_output: torch.Tensor,  # [N, n_routed]
+    bias: torch.Tensor,  # [n_routed] fp32
+    bias_alt: torch.Tensor,  # [n_routed] fp32
+    tid2eid: torch.Tensor | None,  # [vocab, topk] int32 on hash layers
+    vocab_size: int,
+    renormalize: bool,
+    scaling: float,
+    out_ids: torch.Tensor,  # [N, topk] int32 destination
+    out_weights: torch.Tensor,  # [N, topk] fp32 destination
+) -> None:
+    """Fill ``out_ids`` / ``out_weights`` in place with V4 vision routing.
+
+    Destinations may be standalone ``[N, topk]`` tensors or ``[:, :topk]`` views
+    of a wider preallocated buffer (row stride is read from the tensor; column
+    stride is assumed 1).
+    """
+    num_tokens, n_routed = gating_output.shape
+    if num_tokens == 0:
+        return
+    topk = out_ids.shape[1]
+    is_hash = tid2eid is not None
+    _mm_topk_kernel[(num_tokens,)](
+        ids,
+        gating_output,
+        bias,
+        bias_alt,
+        # The pointer is unused when IS_HASH is false, but Triton still needs a
+        # real tensor to take an address from.
+        tid2eid if is_hash else bias,
+        out_ids,
+        out_weights,
+        gating_output.stride(0),
+        gating_output.stride(1),
+        tid2eid.stride(0) if is_hash else 0,
+        out_ids.stride(0),
+        out_weights.stride(0),
+        vocab_size,
+        n_routed,
+        scaling,
+        TOPK=topk,
+        RENORM=renormalize,
+        IS_HASH=is_hash,
+        BLOCK_E=triton.next_power_of_2(n_routed),
+        BLOCK_TOPK=triton.next_power_of_2(topk),
+        num_warps=4,
+    )

--- a/atom/model_ops/v4_kernels/paged_prefill_indices.py
+++ b/atom/model_ops/v4_kernels/paged_prefill_indices.py
@@ -38,6 +38,13 @@ Per-token quantities (kernel-computed from inputs; mirror the formulas in
   extend_count[t]       = min(token_pos_in_chunk[t] + 1, win)
   prefix_swa_count[t]   = max(chunk_start[bid] - swa_low[t], 0)
 
+On a DeepSeek-V4 VISION prefill the caller instead passes per-token
+``extend_start`` / ``extend_count`` (``HAS_VISIBILITY``), widening each token's
+span to its whole ``[IMAGE_START, IMAGE_END]`` block in BOTH directions so
+in-image attention is bidirectional. Nothing here masks by position, so the
+non-causal span is expressed entirely by those indices. Text forwards pass
+neither and keep the causal formulas above, byte for byte.
+
 Per-token pool row for SWA prefix entries (the same formula `swa_write` and
 `_attach_v4_paged_decode_meta` use, from `pool_index.window_row`):
   row[t,k] = window.index(state_slot[bid], swa_low[t] + k)
@@ -85,7 +92,11 @@ def _v4_paged_prefill_indices_kernel(
     prefix_swa_indices_ptr,
     prefix_csa_indices_ptr,
     prefix_hca_indices_ptr,
+    # Per-token in-image visibility (vision prefill only; see HAS_VISIBILITY).
+    extend_start_ptr,  # [T] int — global position the extend span starts at
+    extend_count_ptr,  # [T] int — length of that span
     # Constants.
+    HAS_VISIBILITY: tl.constexpr,
     win: tl.constexpr,
     dense_ring_start,  # per-class window bases; the only terms the boundary moves
     csa_ring_start,
@@ -137,17 +148,31 @@ def _v4_paged_prefill_indices_kernel(
     # Per-token derived quantities (single-pass arithmetic).
     token_pos_in_chunk = pos - chunk_start
     swa_low = tl.maximum(pos - win + 1, 0)
-    extend_count = tl.minimum(token_pos_in_chunk + 1, win)
     prefix_swa_count = tl.maximum(chunk_start - swa_low, 0)
 
     i = tl.arange(0, BLOCK_N)
 
     # ---- Extend kv_indices: rows in per-fwd kv tensor ----
-    # row = cu_q + token_pos_in_chunk - extend_count + 1 + k, k in [0, extend_count)
     ext_base = tl.load(extend_indptr_ptr + t)
-    ext_mask = i < extend_count
-    ext_start_row = cu_q + token_pos_in_chunk - extend_count + 1
-    tl.store(extend_indices_ptr + ext_base + i, ext_start_row + i, mask=ext_mask)
+    if HAS_VISIBILITY:
+        # Vision prefill: the host widened this token's span to its whole image
+        # block, which can exceed BLOCK_N = next_pow2(win), so loop.
+        # `extend_start` is a GLOBAL position.
+        ext_start_row = cu_q + tl.load(extend_start_ptr + t) - chunk_start
+        vis_count = tl.load(extend_count_ptr + t)
+        for j in tl.range(0, vis_count, BLOCK_N):
+            k = j + i
+            tl.store(
+                extend_indices_ptr + ext_base + k,
+                ext_start_row + k,
+                mask=k < vis_count,
+            )
+    else:
+        # row = cu_q + token_pos_in_chunk - extend_count + 1 + k, k in [0, extend_count)
+        extend_count = tl.minimum(token_pos_in_chunk + 1, win)
+        ext_mask = i < extend_count
+        ext_start_row = cu_q + token_pos_in_chunk - extend_count + 1
+        tl.store(extend_indices_ptr + ext_base + i, ext_start_row + i, mask=ext_mask)
 
     # ---- SWA prefix rows: written to all three prefix buffers ----
     #   row = window.index(state_slot_per_seq[bid], gp) for that buffer's class,
@@ -255,6 +280,8 @@ def write_v4_paged_prefill_indices(
     T: int,
     win: int,
     geometry: UnifiedPoolGeometry,
+    extend_start: torch.Tensor | None = None,
+    extend_count: torch.Tensor | None = None,
     hca_ratio: int = 128,
     hca_rows_per_block: int = 1,
     prefix: str = "",
@@ -365,6 +392,10 @@ def write_v4_paged_prefill_indices(
         prefix_swa_indices,
         prefix_csa_indices,
         prefix_hca_indices,
+        # None on a text forward; the kernel then derives the window from `win`.
+        extend_start,
+        extend_count,
+        HAS_VISIBILITY=extend_start is not None,
         win=win,
         dense_ring_start=dense.ring_start,
         csa_ring_start=csa.ring_start,
@@ -399,6 +430,8 @@ def write_v4_paged_prefill_indices_reference(
     T: int,
     win: int,
     geometry: UnifiedPoolGeometry,
+    extend_start: torch.Tensor | None = None,
+    extend_count: torch.Tensor | None = None,
     hca_ratio: int = 128,
     hca_rows_per_block: int = 1,
 ) -> None:
@@ -426,6 +459,8 @@ def write_v4_paged_prefill_indices_reference(
     csa_indptr_cpu = prefix_csa_indptr.cpu().tolist()
     hca_indptr_cpu = prefix_hca_indptr.cpu().tolist()
     device = extend_indices.device
+    ext_start_cpu = extend_start.cpu().tolist() if extend_start is not None else None
+    ext_count_cpu = extend_count.cpu().tolist() if extend_count is not None else None
 
     for t in range(T):
         bid = bid_cpu[t]
@@ -438,12 +473,17 @@ def write_v4_paged_prefill_indices_reference(
 
         token_pos_in_chunk = pos - chunk_start
         swa_low = max(pos - win + 1, 0)
-        extend_count = min(token_pos_in_chunk + 1, win)
         prefix_swa_count = max(chunk_start - swa_low, 0)
 
         # Extend
         ext_base = ext_indptr_cpu[t]
-        ext_start_row = cu_q + token_pos_in_chunk - extend_count + 1
+        if extend_start is not None:
+            # Vision prefill: span widened on the host over the whole image block.
+            ext_start_row = cu_q + int(ext_start_cpu[t]) - chunk_start
+            extend_count = int(ext_count_cpu[t])
+        else:
+            extend_count = min(token_pos_in_chunk + 1, win)
+            ext_start_row = cu_q + token_pos_in_chunk - extend_count + 1
         ext_rows = torch.arange(
             ext_start_row,
             ext_start_row + extend_count,

--- a/atom/model_ops/v4_kernels/paged_prefill_indices.py
+++ b/atom/model_ops/v4_kernels/paged_prefill_indices.py
@@ -348,6 +348,23 @@ def write_v4_paged_prefill_indices(
     assert chunk_start_per_seq.dim() == 1
     assert cu_seqlens_q_per_seq.dim() == 1
     assert state_slot_per_seq.dim() == 1
+    # The kernel does unmasked `tl.load(extend_start_ptr + t)` for t in [0, T).
+    # An int64 array -- numpy's default, and `image_aware_extend_window` only
+    # casts on its final line -- would make every load read half of two adjacent
+    # elements; a short array reads past the allocation. Either way the row
+    # indices come out non-negative, pass `CHECK_NEG_ONE_SENTINEL`, and index
+    # arbitrary rows of the per-forward kv tensor: fluent wrong output, no fault.
+    if extend_start is not None:
+        assert extend_count is not None, "extend_start and extend_count are a pair"
+        for name, t in (("extend_start", extend_start), ("extend_count", extend_count)):
+            assert t.dim() == 1 and t.shape[0] >= T, (
+                f"{name} must be 1-D with at least T={T} elements, got "
+                f"shape {tuple(t.shape)}"
+            )
+            assert t.dtype == torch.int32, (
+                f"{name} must be int32 (the kernel loads 4-byte elements), "
+                f"got {t.dtype}"
+            )
     assert block_tables.dim() == 2
     for idp in (extend_indptr, prefix_swa_indptr, prefix_csa_indptr, prefix_hca_indptr):
         assert idp.dim() == 1 and idp.shape[0] >= T + 1

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -440,6 +440,13 @@ class DeepseekV4Args:
     route_scale: float = 2.5  # routed_scaling_factor
     swiglu_limit: float = 10.0
 
+    # Vision (0 on a text-only checkpoint). Only the two knobs the LANGUAGE side
+    # needs live here: whether there is a tower at all, and the per-image token
+    # budget that bounds in-image attention visibility. The tower's own geometry
+    # lives in `deepseek_v4_vl.DeepseekV4VisionConfig`.
+    vision_n_layers: int = 0
+    vision_max_n_token: int = 384
+
     # Hyper-Connections (mHC)
     hc_mult: int = 4
     hc_sinkhorn_iters: int = 20
@@ -502,6 +509,8 @@ class DeepseekV4Args:
             score_func=g("scoring_func", "sqrtsoftplus"),
             route_scale=g("routed_scaling_factor", 1.5),
             swiglu_limit=g("swiglu_limit", 10.0),
+            vision_n_layers=g("vision_n_layers", 0) or 0,
+            vision_max_n_token=g("vision_max_n_token", 384) or 384,
             hc_mult=g("hc_mult", 4),
             hc_sinkhorn_iters=g("hc_sinkhorn_iters", 20),
             hc_eps=g("hc_eps", 1e-6),
@@ -3505,15 +3514,24 @@ class MoE(nn.Module):
             quant_config=None,
             prefix=f"{prefix}.gate",
         )
+        # Vision checkpoints carry a per-layer `bias_vl` for image tokens, and
+        # ship `gate.bias` on the hash layers too.
+        self.is_vl = args.vision_n_layers > 0
+        self.vocab_size = args.vocab_size
+
         # V4 hash-routed layers (layer_id < n_hash_layers) use tid2eid lookup,
-        # not bias-corrected gate-logit routing — checkpoint has no
+        # not bias-corrected gate-logit routing — a text-only checkpoint has no
         # `gate.bias` for those layers. Only allocate the bias for
         # sqrtsoftplus layers to avoid 3 spurious unloaded-param warnings.
-        if not self.is_hash_layer:
+        if self.is_vl:
+            self.gate.e_score_correction_bias_vl = atom_parameter(
+                torch.empty(self.n_routed_experts, dtype=torch.float32)
+            )
+        if not self.is_hash_layer or self.is_vl:
             self.gate.e_score_correction_bias = atom_parameter(
                 torch.empty(self.n_routed_experts, dtype=torch.float32)
             )
-        else:
+        if self.is_hash_layer:
             # tid2eid: per-token-id top-k expert lookup table (V4 first 3
             # layers use this in lieu of gate-logit routing).
             self.gate.tid2eid = atom_parameter(
@@ -3572,7 +3590,12 @@ class MoE(nn.Module):
             )
         else:
             self.shared_experts = None
-        if self.is_hash_layer:
+        if self.is_vl:
+            # One kernel covers both tid2eid (hash layers) and the two-bias
+            # top-k, so every layer routes through it. `select_experts` takes a
+            # single [E] bias and cannot express the per-token choice.
+            self.experts.custom_routing_function = self._mm_topk
+        elif self.is_hash_layer:
             # Inject hash routing into FusedMoE.select_experts via the
             # custom_routing_function hook (added in atom/model_ops/moe.py).
             self.experts.custom_routing_function = self._hash_topk
@@ -3598,6 +3621,81 @@ class MoE(nn.Module):
             get_current_atom_config().compilation_config.static_forward_context[
                 prefix
             ] = self
+
+    def _routing_dest(self, num_tokens: int, topk: int):
+        """Destination buffers for a custom_routing_function result.
+
+        Custom routing bypasses `select_experts`' shared-expert append, so with a
+        fused shared expert the routed result goes in the first `topk` columns of
+        the global buffer and the full view is returned — otherwise the shared
+        expert is silently dropped.
+
+        Returns `(ids_view, weights_view, result_ids, result_weights)`.
+        """
+        num_fused_shared = getattr(self.experts, "num_fused_shared_experts", 0)
+        if num_fused_shared > 0:
+            import atom.model_ops.topK as _topK_mod
+
+            assert _topK_mod.aiter_topK_meta_data is not None, (
+                "AITER topK meta data is not initialized. "
+                "init_aiter_topK_meta_data must run before MoE routing."
+            )
+            total_weights, total_ids = _topK_mod.aiter_topK_meta_data
+            assert total_weights.shape[0] >= num_tokens
+            return (
+                total_ids[:num_tokens, :topk],
+                total_weights[:num_tokens, :topk],
+                total_ids[:num_tokens],
+                total_weights[:num_tokens],
+            )
+        ids = torch.empty(
+            (num_tokens, topk), dtype=torch.int32, device=self.gate.weight.device
+        )
+        weights = torch.empty(
+            (num_tokens, topk), dtype=torch.float32, device=self.gate.weight.device
+        )
+        return ids, weights, ids, weights
+
+    def _mm_topk(
+        self,
+        hidden_states: torch.Tensor,
+        gating_output: torch.Tensor,
+        topk: int,
+        renormalize: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """V4 vision routing: per-token `bias` vs `bias_vl`, plus hash lookup.
+
+        Runs inside FusedMoE's Dynamo-opaque dispatch; the Triton kernel's JIT
+        builder cannot be traced (see `deepseek_v4_dspark.py`).
+        """
+        from atom.model_ops.topK import mm_topk
+
+        ids = get_forward_context().context.input_ids
+        assert ids is not None, (
+            "forward_context.context.input_ids is None — caller must invoke "
+            "DeepseekV4ForCausalLM.forward, not DeepseekV4Model.forward directly."
+        )
+        ids = ids.flatten()
+        num_tokens = gating_output.shape[0]
+        assert ids.shape[0] == num_tokens, (
+            f"input_ids length {ids.shape[0]} does not match gating_output "
+            f"num_tokens {num_tokens}"
+        )
+
+        ids_view, w_view, out_ids, out_weights = self._routing_dest(num_tokens, topk)
+        mm_topk(
+            ids,
+            gating_output,
+            self.gate.e_score_correction_bias,
+            self.gate.e_score_correction_bias_vl,
+            self.gate.tid2eid if self.is_hash_layer else None,
+            self.vocab_size,
+            renormalize,
+            self.routed_scaling_factor,
+            ids_view,
+            w_view,
+        )
+        return out_weights, out_ids
 
     def _hash_topk(
         self,
@@ -4341,6 +4439,7 @@ class DeepseekV4Model(nn.Module):
         self,
         input_ids: torch.Tensor,  # [num_tokens] int  flat ragged-batch token ids
         positions: torch.Tensor,  # [num_tokens] int  abs positions (required)
+        inputs_embeds: torch.Tensor | None = None,  # [num_tokens, dim]
     ) -> torch.Tensor:  # [num_tokens, hc, dim]  pre-hc_head residual stream
         """Forward over `num_tokens` flat ragged-batch tokens.
 
@@ -4348,6 +4447,10 @@ class DeepseekV4Model(nn.Module):
         reduction — `hc_head + RMSNorm + LM head` are all deferred to
         `compute_logits`. Returning the hc-shaped residual lets the (future)
         MTP draft consume it without re-expanding from a dim-reduced state.
+
+        `inputs_embeds` is how the vision model injects image embeddings. Dynamo
+        specializes on whether it is None, so a caller must pass it consistently
+        across warmup, capture and steady state.
         """
         assert input_ids.dim() == 1, f"input_ids must be 1D, got {input_ids.shape}"
         # PCP note: under PCP, `input_ids`/`positions` arrive already round-robin-
@@ -4356,7 +4459,11 @@ class DeepseekV4Model(nn.Module):
         # out of the compiled graph). So everything here runs on the 1/W shard;
         # the K/V all-gather inside attention reconstructs full KV per layer,
         # and the final all-gather + un-pad happens back in the caller.
-        h = self.embed(input_ids)  # [num_tokens, dim]
+        h = (
+            inputs_embeds
+            if inputs_embeds is not None
+            else self.embed(input_ids)  # [num_tokens, dim]
+        )
         # Expand to hc_mult copies for Hyper-Connections: [num_tokens, hc, dim]
         h = h.unsqueeze(-2).repeat(1, self.hc_mult, 1)
         hc_state = HCState(residual=h, post_mix=None, comb_mix=None, x_prev=None)
@@ -4412,6 +4519,9 @@ class DeepseekV4ForCausalLM(nn.Module):
         }
     )
     weights_mapping: ClassVar[dict[str, str]] = {
+        # Must precede `.gate.bias`: rules apply in order by substring, and
+        # the shorter key is a prefix of this one.
+        ".gate.bias_vl": ".gate.e_score_correction_bias_vl",
         ".gate.bias": ".gate.e_score_correction_bias",
         ".scale": ".weight_scale_inv",
     }
@@ -4463,6 +4573,12 @@ class DeepseekV4ForCausalLM(nn.Module):
             and not uses_routed_all2all
             and self.args.n_hash_layers > 0
         )
+        # One architecture, optional vision tower — the reference
+        # `inference/model.py` builds it under the same condition, which is why
+        # both checkpoints legitimately declare `DeepseekV4ForCausalLM`.
+        self.has_vision = self.args.vision_n_layers > 0
+        if self.has_vision:
+            self._build_vision(config)
 
     @property
     def disable_fused_shared_loading(self) -> bool:
@@ -4476,10 +4592,11 @@ class DeepseekV4ForCausalLM(nn.Module):
                 return not getattr(m, "_fuse_shared_into_routed", True)
         return False
 
-    def forward(
+    def _forward_impl(
         self,
         input_ids: torch.Tensor,  # [num_tokens] int
         positions: torch.Tensor,  # [num_tokens] int  required
+        inputs_embeds: torch.Tensor | None = None,  # [num_tokens, dim]
     ) -> torch.Tensor:  # [num_tokens, dim]  hidden_states
         # Stash input_ids on forward_context for the V4 hash MoE routing
         # callback (`MoE._hash_topk`), which runs inside the Dynamo-opaque
@@ -4503,6 +4620,15 @@ class DeepseekV4ForCausalLM(nn.Module):
         # runs entirely on 1/W; the final hidden is all-gathered + un-padded
         # after self.model(...) returns.
         use_pcp = _pcp_active()
+        if inputs_embeds is not None and use_pcp:
+            # PCP round-robin-splits input_ids/positions below; inputs_embeds
+            # would have to be split identically and gathered back. Unverified,
+            # and silently mis-splitting it would misalign every token's hidden
+            # state against its position. Refuse instead of guessing.
+            raise NotImplementedError(
+                "DeepSeek-V4 vision (inputs_embeds) with PCP is not supported. "
+                "Start the server without prefill context parallelism."
+            )
         # NOTE: moe_merge here is the OUT-OF-GRAPH gate, used only for the
         # input_ids gather below (round-robin split + hash-MoE id alignment).
         # The MoE merge collectives gate themselves separately inside the opaque
@@ -4573,7 +4699,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                 )
         else:
             ctx.context.input_ids = input_ids
-        h = self.model(input_ids, positions)
+        h = self.model(input_ids, positions, inputs_embeds)
 
         # ----- PCP: all-gather shards, restore original order, drop pad -----
         if use_pcp:
@@ -4818,3 +4944,138 @@ class DeepseekV4ForCausalLM(nn.Module):
                 else:
                     ppl()
         return loaded
+
+    def _build_vision(self, config: Config) -> None:
+        """Attach the ViT + aligner. Called only when the config carries one.
+
+        Checkpoint names for the vision half (``vision.*``, ``aligner.*``,
+        ``image_*``) are top-level and match these attributes verbatim — none of
+        the ``weights_mapper`` prefix rules touch them, so no rename is needed.
+        """
+        hf_config = config.hf_config
+        from atom.models.deepseek_v4_vl import (
+            DeepseekV4VisionConfig,
+            build_vision_modules,
+        )
+
+        self.vision_cfg = DeepseekV4VisionConfig.from_hf_config(hf_config)
+        self.vision, self.aligner = build_vision_modules(self.vision_cfg)
+        self.vocab_size = int(hf_config.vocab_size)
+
+        # Learned embeddings for the four non-pixel sentinel slots. Stacked in
+        # sentinel-type order at merge time; the IMAGE slot borrows `image_pad`
+        # and is then overwritten with the aligner output, exactly as the
+        # reference `merge_image_embeddings` does.
+        dim = self.args.dim
+        self.image_start = nn.Parameter(torch.empty(dim))
+        self.image_pad = nn.Parameter(torch.empty(dim))
+        self.image_newline = nn.Parameter(torch.empty(dim))
+        self.image_end = nn.Parameter(torch.empty(dim))
+
+    # -- ATOM multimodal contract -------------------------------------------
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        """Embed token ids, tolerating the above-vocab image sentinels.
+
+        Sentinel ids (>= vocab_size) would index the embedding table out of
+        bounds, so clamp them to a valid row; every clamped position is
+        overwritten by :meth:`merge_multimodal_embeddings` before the value is
+        ever used.
+        """
+        return self.model.embed(input_ids.clamp(max=self.vocab_size - 1))
+
+    def get_vision_embeddings(
+        self, pixel_values: torch.Tensor, grid_thw: torch.Tensor
+    ) -> torch.Tensor:
+        """Run the tower over every image and return rows in token order.
+
+        ``grid_thw`` rows are ``(1, n_vit_h, n_vit_w)``. The aligner emits rows
+        row-major over the downsampled grid, but the prompt lays them out in the
+        N-layout (row pairs walked column-first), so each image's rows are
+        permuted before concatenation. The permutation is derived from the grid
+        — see :func:`atom.models.deepseek_v4_vl.image_block_perm`.
+        """
+        from atom.models.deepseek_v4_vl import image_block_perm, llm_grid_hw
+
+        grids = [(int(h), int(w)) for _, h, w in grid_thw.tolist()]
+        device = self.aligner.w1.weight.device
+        dtype = self.aligner.w1.weight.dtype
+        features = self.vision(pixel_values.to(device=device, dtype=dtype), grids)
+
+        ratio = self.vision_cfg.downsample_ratio
+        out, offset = [], 0
+        for n_vit_h, n_vit_w in grids:
+            count = n_vit_h * n_vit_w
+            aligned = self.aligner(features[offset : offset + count], n_vit_h, n_vit_w)
+            n_llm_h, n_llm_w = llm_grid_hw(n_vit_h, n_vit_w, ratio)
+            perm = image_block_perm(n_llm_h, n_llm_w).to(device)
+            out.append(aligned[perm])
+            offset += count
+        return torch.cat(out)
+
+    def merge_multimodal_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        inputs_embeds: torch.Tensor,
+        vision_embeds: torch.Tensor,
+    ) -> torch.Tensor:
+        """Write sentinel and image embeddings over their token positions."""
+        sentinels = torch.stack(
+            [
+                self.image_start,
+                self.image_pad,
+                self.image_pad,  # IMAGE — placeholder, overwritten below
+                self.image_newline,
+                self.image_end,
+            ]
+        ).to(inputs_embeds.dtype)
+
+        offsets = input_ids - self.vocab_size
+        is_sentinel = offsets >= 0
+        inputs_embeds = torch.where(
+            is_sentinel.unsqueeze(-1),
+            sentinels[offsets.clamp(min=0)],
+            inputs_embeds,
+        )
+
+        image_mask = input_ids == self.vocab_size + _IMAGE_SENTINEL
+        num_slots = int(image_mask.sum())
+        if num_slots != vision_embeds.shape[0]:
+            # The sentinel census tells the two failures apart: a short block
+            # means the prefill was chunked, a wrong IMAGE count means the
+            # layout disagrees.
+            counts = {
+                int(code): int((offsets == code).sum())
+                for code in range(sentinels.shape[0])
+            }
+            raise ValueError(
+                f"DeepSeek-V4 vision produced {vision_embeds.shape[0]} image "
+                f"embeddings for {num_slots} IMAGE token slots over "
+                f"{input_ids.numel()} tokens (sentinel census by type code: "
+                f"{counts}). The prompt's image blocks and its pixel data "
+                "disagree, or a multimodal prefill was chunked."
+            )
+        inputs_embeds[image_mask] = vision_embeds.to(inputs_embeds.dtype)
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Keep the compiled language model on the inputs_embeds path so vision
+        # embeddings are not dropped after text-only CUDAGraph capture.
+        if self.has_vision and inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+        return DeepseekV4ForCausalLM._forward_impl(
+            self, input_ids, positions, inputs_embeds
+        )
+
+
+# Sentinel type code for a pixel-bearing image slot (`IMAGE` in
+# `deepseek_v4_mm`). Duplicated as a literal rather than imported at module
+# scope: `deepseek_v4_mm` pulls in PIL and the engine Config, and this file is
+# imported by weight-loading tests that must stay light. Kept in sync by
+# `tests/test_deepseek_v4_vl.py::test_image_sentinel_code_agrees`.
+_IMAGE_SENTINEL = 2

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -4980,10 +4980,19 @@ class DeepseekV4ForCausalLM(nn.Module):
         # and is then overwritten with the aligner output, exactly as the
         # reference `merge_image_embeddings` does.
         dim = self.args.dim
-        self.image_start = nn.Parameter(torch.empty(dim))
-        self.image_pad = nn.Parameter(torch.empty(dim))
-        self.image_newline = nn.Parameter(torch.empty(dim))
-        self.image_end = nn.Parameter(torch.empty(dim))
+        # `atom_parameter` (not bare `nn.Parameter`) is the single control that
+        # forces requires_grad off under ATOM_REQUIRES_GRAD, and the dtype is
+        # pinned rather than left to `torch.get_default_dtype()`. NaN-filled,
+        # not `empty`: if a checkpoint lacks these tensors the loader only logs
+        # a warning, and uninitialized memory would render as fluent text --
+        # NaN propagates into the logits instead, which is visible.
+        dtype = config.torch_dtype
+        for name in ("image_start", "image_pad", "image_newline", "image_end"):
+            setattr(
+                self,
+                name,
+                atom_parameter(torch.full((dim,), float("nan"), dtype=dtype)),
+            )
 
     # -- ATOM multimodal contract -------------------------------------------
 
@@ -5047,7 +5056,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         is_sentinel = offsets >= 0
         inputs_embeds = torch.where(
             is_sentinel.unsqueeze(-1),
-            sentinels[offsets.clamp(min=0)],
+            sentinels[offsets.clamp(0, sentinels.shape[0] - 1)],
             inputs_embeds,
         )
 
@@ -5077,8 +5086,16 @@ class DeepseekV4ForCausalLM(nn.Module):
         positions: torch.Tensor,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        # Keep the compiled language model on the inputs_embeds path so vision
-        # embeddings are not dropped after text-only CUDAGraph capture.
+        # ALWAYS pass a tensor when this checkpoint has a vision tower: Dynamo
+        # specializes on None-ness, so mixing None (decode) and a tensor
+        # (prefill) compiles two graphs and the captured one then reads the
+        # wrong branch -- measured as `AttributeError: 'NoneType' has no
+        # attribute 'size'` inside the compiled region.
+        #
+        # KNOWN COST, not fixed here: this allocates a fresh `[N, dim]` on every
+        # decode step, outside the CUDAGraph. Making it conditional is what the
+        # paragraph above rules out; the real fix is a persistent buffer, which
+        # is not attempted in this change.
         if self.has_vision and inputs_embeds is None:
             inputs_embeds = self.embed_input_ids(input_ids)
         return DeepseekV4ForCausalLM._forward_impl(
@@ -5086,9 +5103,9 @@ class DeepseekV4ForCausalLM(nn.Module):
         )
 
 
-# Sentinel type code for a pixel-bearing image slot (`IMAGE` in
-# `deepseek_v4_mm`). Duplicated as a literal rather than imported at module
-# scope: `deepseek_v4_mm` pulls in PIL and the engine Config, and this file is
-# imported by weight-loading tests that must stay light. Kept in sync by
-# `tests/test_deepseek_v4_vl.py::test_image_sentinel_code_agrees`.
+# Sentinel type code for a pixel-bearing image slot -- `IMAGE` in
+# `atom.models.deepseek_v4_vl`. Duplicated as a literal rather than imported at
+# module scope so this file stays importable by the light weight-loading tests.
+# `tests/test_deepseek_v4_vl_cpu.py::test_image_sentinel_code_agrees` pins the
+# two together.
 _IMAGE_SENTINEL = 2

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -4952,6 +4952,19 @@ class DeepseekV4ForCausalLM(nn.Module):
         ``image_*``) are top-level and match these attributes verbatim — none of
         the ``weights_mapper`` prefix rules touch them, so no rename is needed.
         """
+        if config.speculative_config is not None:
+            # The draft heads carry their own `mtp.N.ffn.gate.bias_vl`, so the
+            # draft MoE would have to route image tokens the way the target
+            # does, and the draft path has no handling for the out-of-vocab
+            # image sentinel ids the target clamps in `embed_input_ids`.
+            # Neither is implemented, and neither fails on its own: the draft
+            # would route images with the text bias and index past the
+            # embedding table. Refuse instead.
+            raise NotImplementedError(
+                "speculative decoding (MTP/DSpark) is not supported on a "
+                "DeepSeek-V4 vision checkpoint. Re-run without "
+                "--method/--num-speculative-tokens."
+            )
         hf_config = config.hf_config
         from atom.models.deepseek_v4_vl import (
             DeepseekV4VisionConfig,

--- a/atom/models/deepseek_v4_vl.py
+++ b/atom/models/deepseek_v4_vl.py
@@ -1,0 +1,955 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Vision tower, image preprocessing and prompt encoding for
+DeepSeek-V4-Flash-Vision.
+
+Pure PyTorch port of the reference ``inference/vision.py`` shipped inside the
+checkpoint: a 32-layer ViT with 2D RoPE and full bidirectional attention over
+one image, followed by the aligner that 3x3-downsamples the patch grid into the
+language model's width.
+
+Module and parameter names mirror the checkpoint exactly (``vision.*`` /
+``aligner.*``), so the loader needs no rename rules.
+
+The tower is replicated on every TP rank rather than sharded: at ~0.4B params it
+is negligible next to the 43-layer language stack, and replication keeps the
+image embeddings bit-identical across ranks (they are scattered into the token
+embeddings before the first collective). It is BF16 throughout — the checkpoint
+carries no ``.scale`` tensors under either prefix, unlike every ``layers.*``
+weight.
+
+Reference geometry for this checkpoint: ``vision_dim=1024``, ``n_heads=16``
+(head_dim 64, rope over two 32-wide halves), ``patch_size=14``,
+``inter_dim=2816``, ``downsample_ratio=3``, text ``dim=4096``.
+"""
+
+import importlib.util
+import itertools
+import logging
+import math
+import sys
+import threading
+from collections.abc import Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from PIL import Image, ImageOps
+from torch import nn
+
+from atom.config import Config
+
+
+@dataclass(frozen=True)
+class DeepseekV4VisionConfig:
+    """Vision hyperparameters, read off the V4 HF config's ``vision_*`` keys.
+
+    Split out from ``DeepseekV4Args`` so the tower can be built and tested
+    without constructing a full engine ``Config``.
+    """
+
+    n_layers: int = 32  # vision_n_layers
+    dim: int = 1024  # vision_dim
+    n_heads: int = 16  # vision_n_heads
+    inter_dim: int = 2816  # vision_inter_dim
+    patch_size: int = 14  # vision_patch_size
+    rope_theta: float = 10000.0  # vision_rope_theta
+    downsample_ratio: int = 3  # vision_downsample_ratio
+    text_dim: int = 4096  # hidden_size — aligner output width
+    # NOT the language stack's `rms_norm_eps` (1e-20 in this checkpoint). The
+    # reference `vision.py` builds every vision RMSNorm with the class default
+    # and never threads the config value in, so this is a fixed 1e-6. Wiring
+    # `rms_norm_eps` here instead would silently diverge from the reference.
+    norm_eps: float = 1e-6
+
+    @property
+    def head_dim(self) -> int:
+        return self.dim // self.n_heads
+
+    @property
+    def rope_dim(self) -> int:
+        """Width of each rotated half — the 2D table covers half the head."""
+        return self.dim // self.n_heads // 2
+
+    @classmethod
+    def from_hf_config(cls, hf_config) -> "DeepseekV4VisionConfig":
+        def g(key, default):
+            value = getattr(hf_config, key, None)
+            return default if value is None else value
+
+        return cls(
+            n_layers=g("vision_n_layers", 32),
+            dim=g("vision_dim", 1024),
+            n_heads=g("vision_n_heads", 16),
+            inter_dim=g("vision_inter_dim", 2816),
+            patch_size=g("vision_patch_size", 14),
+            rope_theta=g("vision_rope_theta", 10000.0),
+            downsample_ratio=g("vision_downsample_ratio", 3),
+            text_dim=g("hidden_size", 4096),
+            # norm_eps deliberately left at its default — see the field comment.
+        )
+
+
+def llm_grid_hw(n_vit_h: int, n_vit_w: int, downsample_ratio: int) -> tuple[int, int]:
+    """Aligner output grid for a ``n_vit_h x n_vit_w`` patch grid.
+
+    The aligner pads the grid up to a multiple of the downsample ratio before
+    unfolding, so each axis rounds UP. Mirrors ``grid_tokens`` in the reference
+    ``image_processor.py``, and is what lets the model recover ``(n_llm_h,
+    n_llm_w)`` — and from it the N-layout permutation — from nothing but the
+    patch grid carried in ``image_grid_thw``.
+    """
+    ceil_div = -(-n_vit_h // downsample_ratio), -(-n_vit_w // downsample_ratio)
+    return ceil_div
+
+
+@lru_cache(maxsize=64)
+def _cos_sin_table(
+    n_h: int, n_w: int, rope_dim: int, theta: float
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """2D RoPE cos/sin for one ``n_h x n_w`` patch grid, shaped ``[L, 1, D]``.
+
+    Each position contributes ``rope_dim // 2`` height frequencies followed by
+    ``rope_dim // 2`` width frequencies, so a head's first rotated half mixes
+    both axes. Cached because a request's images repeat few distinct grids and
+    the table is pure geometry.
+    """
+    inv_freq = 1.0 / (
+        theta ** (torch.arange(0, rope_dim, 2, dtype=torch.float32) / rope_dim)
+    )
+    hpos = torch.arange(n_h).unsqueeze(1).expand(n_h, n_w)
+    wpos = torch.arange(n_w).unsqueeze(0).expand(n_h, n_w)
+    freqs = torch.stack([hpos, wpos], dim=-1).reshape(-1, 2, 1).float() * inv_freq
+    freqs = freqs.flatten(1)
+    return freqs.cos().unsqueeze(1), freqs.sin().unsqueeze(1)
+
+
+def get_vision_cos_sin(
+    grids: Sequence[tuple[int, int]],
+    rope_dim: int,
+    theta: float,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Packed 2D RoPE tables for a run of images, concatenated in image order."""
+    tables = [_cos_sin_table(int(h), int(w), rope_dim, theta) for h, w in grids]
+    cos = torch.cat([t[0] for t in tables]).to(device)
+    sin = torch.cat([t[1] for t in tables]).to(device)
+    return cos, sin
+
+
+def apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor):
+    """Rotate the two halves of each head against the 2D frequencies.
+
+    ``x`` is ``[L, n_heads, head_dim]``; ``cos``/``sin`` are ``[L, 1,
+    head_dim // 2]`` and broadcast over heads.
+    """
+    dtype = x.dtype
+    x1, x2 = x.float().chunk(2, dim=-1)
+    return torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1).to(dtype)
+
+
+def _segment_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    max_seqlen: int,
+) -> torch.Tensor:
+    """Non-causal packed attention over per-image segments.
+
+    ``cu_seqlens`` bounds each image's patch grid, so a patch only ever attends
+    within its own image — matching the reference, which runs one image at a
+    time. Returns ``[L, n_heads * head_dim]``.
+
+    Uses aiter's varlen flash attention on GPU. The SDPA fallback exists so the
+    tower stays runnable (and numerically checkable against the reference) on a
+    plain CPU box with no aiter build; it is not a perf path.
+    """
+    if q.is_cuda:
+        from aiter import flash_attn_varlen_func
+
+        out = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            cu_seqlens,
+            cu_seqlens,
+            max_seqlen,
+            max_seqlen,
+            softmax_scale=q.shape[-1] ** -0.5,
+            causal=False,
+        )
+        if isinstance(out, tuple):
+            out = out[0]
+        return out.flatten(start_dim=-2)
+
+    chunks = []
+    for start, end in itertools.pairwise(cu_seqlens.tolist()):
+        # [S, H, D] -> [H, S, D] for SDPA, then back.
+        seg = F.scaled_dot_product_attention(
+            q[start:end].transpose(0, 1),
+            k[start:end].transpose(0, 1),
+            v[start:end].transpose(0, 1),
+        )
+        chunks.append(seg.transpose(0, 1))
+    return torch.cat(chunks).flatten(start_dim=-2)
+
+
+class RMSNorm(nn.Module):
+    """Float32 RMSNorm with a float32 weight, matching the reference exactly.
+
+    Not ATOM's fused `model_ops` RMSNorm: that one keeps the weight in the
+    activation dtype, while these checkpoint tensors are stored float32 and the
+    reference normalizes in float32 before casting back.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        dtype = x.dtype
+        x = x.float()
+        x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+class PatchEmbed(nn.Module):
+    """Per-patch linear projection over already-patchified pixels.
+
+    The image processor hands over ``[L, 3, patch, patch]``, so the reference's
+    projection is a plain Linear over the flattened patch rather than a Conv2d.
+    """
+
+    def __init__(self, cfg: DeepseekV4VisionConfig):
+        super().__init__()
+        self.proj = nn.Linear(3 * cfg.patch_size**2, cfg.dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.proj(x.flatten(1))
+
+
+class Attention(nn.Module):
+    def __init__(self, cfg: DeepseekV4VisionConfig):
+        super().__init__()
+        self.n_heads = cfg.n_heads
+        self.head_dim = cfg.head_dim
+        self.wqkv = nn.Linear(cfg.dim, 3 * cfg.dim)
+        self.wo = nn.Linear(cfg.dim, cfg.dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        n = x.size(0)
+        q, k, v = (
+            t.view(n, self.n_heads, self.head_dim)
+            for t in self.wqkv(x).chunk(3, dim=-1)
+        )
+        q = apply_rotary(q, cos, sin)
+        k = apply_rotary(k, cos, sin)
+        return self.wo(_segment_attention(q, k, v, cu_seqlens, max_seqlen))
+
+
+class MLP(nn.Module):
+    """SwiGLU with gate and up fused into a single ``w1`` projection."""
+
+    def __init__(self, cfg: DeepseekV4VisionConfig):
+        super().__init__()
+        self.w1 = nn.Linear(cfg.dim, 2 * cfg.inter_dim, bias=False)
+        self.w2 = nn.Linear(cfg.inter_dim, cfg.dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate, up = self.w1(x).chunk(2, dim=-1)
+        return self.w2(F.silu(gate) * up)
+
+
+class Block(nn.Module):
+    def __init__(self, cfg: DeepseekV4VisionConfig):
+        super().__init__()
+        self.norm1 = RMSNorm(cfg.dim, cfg.norm_eps)
+        self.attn = Attention(cfg)
+        self.norm2 = RMSNorm(cfg.dim, cfg.norm_eps)
+        self.mlp = MLP(cfg)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        x = x + self.attn(self.norm1(x), cos, sin, cu_seqlens, max_seqlen)
+        return x + self.mlp(self.norm2(x))
+
+
+class ViT(nn.Module):
+    """DeepSeek ViT: full bidirectional attention within one image, 2D RoPE.
+
+    Unlike the reference — which takes one image per call — this packs a run of
+    images into a single sequence and segments attention with ``cu_seqlens``, so
+    a multi-image prompt runs the 32 blocks once instead of once per image. The
+    per-image math is unchanged.
+    """
+
+    def __init__(self, cfg: DeepseekV4VisionConfig):
+        super().__init__()
+        self.cfg = cfg
+        self.patch_embed = PatchEmbed(cfg)
+        self.blocks = nn.ModuleList([Block(cfg) for _ in range(cfg.n_layers)])
+        self.norm = RMSNorm(cfg.dim, cfg.norm_eps)
+
+    def forward(
+        self, patches: torch.Tensor, grids: Sequence[tuple[int, int]]
+    ) -> torch.Tensor:
+        """``patches``: ``[sum(h*w), 3, p, p]``; ``grids``: per-image ``(h, w)``."""
+        lengths = [int(h) * int(w) for h, w in grids]
+        if sum(lengths) != patches.size(0):
+            raise ValueError(
+                f"patch count {patches.size(0)} does not match grids {list(grids)} "
+                f"(expected {sum(lengths)})"
+            )
+        cos, sin = get_vision_cos_sin(
+            grids, self.cfg.rope_dim, self.cfg.rope_theta, patches.device
+        )
+        cu_seqlens = torch.tensor(
+            [0, *lengths], dtype=torch.int32, device=patches.device
+        ).cumsum(0, dtype=torch.int32)
+        max_seqlen = max(lengths)
+
+        x = self.patch_embed(patches)
+        for block in self.blocks:
+            x = block(x, cos, sin, cu_seqlens, max_seqlen)
+        return self.norm(x)
+
+
+class Aligner(nn.Module):
+    """Projects the ViT grid into the language width, 3x3-downsampling first.
+
+    The grid is padded up (right/bottom) to a multiple of the ratio, then
+    unfolded into non-overlapping ``r x r`` blocks — so the feature layout the
+    ``w1`` weight expects is ``(channel, kh, kw)``, which is exactly what
+    ``F.unfold`` emits. Output rows are row-major over the downsampled grid.
+    """
+
+    def __init__(self, cfg: DeepseekV4VisionConfig):
+        super().__init__()
+        self.downsample_ratio = cfg.downsample_ratio
+        self.w1 = nn.Linear(cfg.dim * cfg.downsample_ratio**2, cfg.text_dim)
+        self.w2 = nn.Linear(cfg.text_dim, cfg.text_dim)
+
+    def forward(self, x: torch.Tensor, n_h: int, n_w: int) -> torch.Tensor:
+        r = self.downsample_ratio
+        x = x.view(n_h, n_w, -1).permute(2, 0, 1)
+        x = F.pad(x, (0, -n_w % r, 0, -n_h % r))
+        x = F.unfold(x.unsqueeze(0), r, stride=r).squeeze(0).transpose(0, 1)
+        return self.w2(F.gelu(self.w1(x)))
+
+
+def build_vision_modules(cfg: DeepseekV4VisionConfig) -> tuple[ViT, Aligner]:
+    """Build the ``(vision, aligner)`` pair for a DeepSeek-V4 vision config."""
+    return ViT(cfg), Aligner(cfg)
+
+
+# --------------------------------------------------------------------------
+# Image preprocessing and prompt encoding
+# --------------------------------------------------------------------------
+#
+# Port of the reference ``inference/image_processor.py`` shipped inside the
+# checkpoint, adapted to ATOM's multimodal contract. Three things here are
+# specific to this model and worth reading before touching any of it:
+#
+# **Sentinel token ids live ABOVE the vocabulary.** Each ``<｜deepseek_image｜>``
+# placeholder (id 129264, a real token) expands into a run of ``vocab_size +
+# type`` ids — 129280..129284 for a 129280-entry vocab. The model detects image
+# positions with ``input_ids >= vocab_size`` and never embeds them from the table;
+# ``DeepseekV4ForCausalLM`` overwrites every one of them when it carries a
+# vision tower. Anything
+# that indexes a vocab-sized table by ``input_ids`` (embedding, hash routing) must
+# clamp first.
+#
+# **The N-layout is not row-major.** A row of the aligner grid is followed by an
+# ``IMAGE_NEW_LINE``, rows are padded to an even count, and then *pairs of rows
+# are transposed* so the sequence walks columns within each row pair. ``perm``
+# maps that slot order back onto the aligner's row-major output.
+#
+# **Image blocks are aligned to the ratio-4 compression grid.** ``compress_pad``
+# leading pads put ``IMAGE_START`` at ``pos ≡ 3 (mod 4)``, so image content starts
+# exactly on a compression-block boundary of the CSA attention layers.
+#
+# Prompt formatting is NOT reimplemented here: ``encoding/encoding_dsv4.py`` ships
+# inside the checkpoint and is loaded from there, so the template can never drift
+# from the weights it was trained with. See :func:`load_checkpoint_encoding`.
+
+logger = logging.getLogger("atom")
+
+# Sentinel types, in the order the model's embedding table expects them. The
+# numeric values are checkpoint ABI: they are added to `vocab_size` to form
+# token ids, so they cannot be reordered.
+IMAGE_START, IMAGE_PAD, IMAGE, IMAGE_NEW_LINE, IMAGE_END = range(5)
+
+# Image blocks are padded so IMAGE_START lands on the last slot of a 4-token
+# compression block — see the module docstring.
+COMPRESS_PAD_TO = 4
+
+IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
+
+
+# ---------------------------------------------------------------------------
+# Prompt encoding: loaded from the checkpoint, not vendored
+# ---------------------------------------------------------------------------
+
+_encoding_module = None
+_encoding_lock = threading.Lock()
+
+
+def load_checkpoint_encoding(model_path: str):
+    """Import ``encoding/encoding_dsv4.py`` from the checkpoint directory.
+
+    The prompt template (roles, thinking modes, reasoning-effort preambles, DSML
+    tool rendering) is versioned with the weights, so it is loaded from the
+    checkpoint rather than copied into ATOM — a vendored copy would silently
+    serve a stale template after a model update, which shows up as an accuracy
+    regression with no error anywhere.
+
+    This executes code from the model directory, the same trust boundary
+    ``AutoProcessor(trust_remote_code=True)`` already crosses for Kimi-K3.
+    """
+    global _encoding_module
+    with _encoding_lock:
+        if _encoding_module is not None:
+            return _encoding_module
+
+        path = f"{model_path}/encoding/encoding_dsv4.py"
+        spec = importlib.util.spec_from_file_location("atom_dsv4_encoding", path)
+        if spec is None or spec.loader is None:
+            raise FileNotFoundError(
+                f"DeepSeek-V4 vision needs the checkpoint's prompt encoder at "
+                f"{path}, which is missing. It ships with the model repo; a "
+                f"partial download or a stripped checkpoint will not serve "
+                f"image requests."
+            )
+        module = importlib.util.module_from_spec(spec)
+        # encoding_dsv4 is self-contained (stdlib only), but register it so a
+        # traceback inside it resolves its source lines.
+        sys.modules["atom_dsv4_encoding"] = module
+        spec.loader.exec_module(module)
+        logger.info(f"Loaded DeepSeek-V4 prompt encoder from {path}")
+        _encoding_module = module
+        return module
+
+
+# ---------------------------------------------------------------------------
+# Image geometry — faithful port of the reference
+# ---------------------------------------------------------------------------
+
+
+def grid_tokens(
+    best_height: int, best_width: int, patch_size: int, downsample_ratio: int
+) -> tuple[int, int, int]:
+    """LLM token count for an aligner grid, including row and align padding.
+
+    Counts the N-layout: one ``IMAGE_NEW_LINE`` per row, two for
+    ``IMAGE_START``/``IMAGE_END``, a padding row when the row count is odd, and
+    a trailing pad pair when the transposed layout ends mid-pair.
+    """
+    n_llm_h = math.ceil((best_height // patch_size) / downsample_ratio)
+    n_llm_w = math.ceil((best_width // patch_size) / downsample_ratio)
+    num_tokens = n_llm_h * (n_llm_w + 1) + 2
+    if n_llm_h % 2 == 1:
+        num_tokens += n_llm_w + 1
+    num_tokens += (n_llm_h + 1) // 2 * (n_llm_w + 1) % 2 * 2
+    return n_llm_h, n_llm_w, num_tokens
+
+
+def solve_resize_ratio(
+    height: int, width: int, patch_size: int, downsample_ratio: int, max_n_token: int
+) -> tuple[int, int, int, int, int]:
+    """Largest grid preserving aspect ratio that fits within ``max_n_token``.
+
+    Solves ``h * (w + 1) + 2 <= max_n_token`` under ``h / w == height / width``,
+    then falls back to degenerate shapes for extreme aspect ratios.
+    """
+    r = height / width
+    max_w_float = math.sqrt((max_n_token - 2) / r + 0.25) - 0.5
+    max_h_float = max_w_float * r
+    if max_w_float < 1.0:
+        max_w = 1
+        max_h = (max_n_token - 2) // (max_w + 1)
+        if max_h % 2 == 1:
+            max_h -= 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    elif max_h_float < 2.0:
+        max_h = 2
+        max_w = ((max_n_token - 2) // max_h) - 1
+        assert max_w > 1
+        best_width = max_w * patch_size * downsample_ratio
+        best_height = max_h * patch_size * downsample_ratio
+    else:
+        max_w = math.floor(max_w_float)
+        max_h = math.floor(max_h_float)
+        if max_h % 2 == 1:
+            max_h -= 1
+        beta = min(
+            max_w * patch_size * downsample_ratio / width,
+            max_h * patch_size * downsample_ratio / height,
+        )
+        best_width = math.floor(width * beta / patch_size) * patch_size
+        best_height = math.floor(height * beta / patch_size) * patch_size
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio
+    )
+    return n_llm_h, n_llm_w, best_height, best_width, num_tokens
+
+
+def safe_resize(
+    height: int,
+    width: int,
+    best_height: int,
+    best_width: int,
+    patch_size: int,
+    downsample_ratio: int,
+    max_n_token: int,
+) -> tuple[int, int, int, int]:
+    """Shrink the grid until its N-layout token count fits the budget.
+
+    The budget is reduced by ``COMPRESS_PAD_TO - 1`` up front to leave room for
+    the worst-case leading compression pad, then walked down one token at a time
+    because ``grid_tokens`` is not monotonic in the solver's input budget.
+    """
+    max_n_token -= COMPRESS_PAD_TO - 1
+    n_llm_h, n_llm_w, num_tokens = grid_tokens(
+        best_height, best_width, patch_size, downsample_ratio
+    )
+    budget = max_n_token
+    while num_tokens > max_n_token:
+        n_llm_h, n_llm_w, best_height, best_width, num_tokens = solve_resize_ratio(
+            height, width, patch_size, downsample_ratio, budget
+        )
+        budget -= 1
+    return n_llm_h, n_llm_w, best_height, best_width
+
+
+class VisionPreprocessConfig:
+    """The ``vision_*`` geometry knobs :func:`preprocess_image` reads."""
+
+    __slots__ = (
+        "downsample_ratio",
+        "max_n_token",
+        "max_wh_ratio",
+        "min_pixels",
+        "patch_size",
+    )
+
+    def __init__(
+        self,
+        patch_size: int = 14,
+        downsample_ratio: int = 3,
+        max_n_token: int = 384,
+        min_pixels: int = 147456,
+        max_wh_ratio: int | None = 8,
+    ):
+        self.patch_size = patch_size
+        self.downsample_ratio = downsample_ratio
+        self.max_n_token = max_n_token
+        self.min_pixels = min_pixels
+        self.max_wh_ratio = max_wh_ratio
+
+    @classmethod
+    def from_hf_config(cls, hf_config) -> "VisionPreprocessConfig":
+        def g(key, default):
+            value = getattr(hf_config, key, None)
+            return default if value is None else value
+
+        return cls(
+            patch_size=g("vision_patch_size", 14),
+            downsample_ratio=g("vision_downsample_ratio", 3),
+            max_n_token=g("vision_max_n_token", 384),
+            min_pixels=g("vision_min_pixels", 147456),
+            max_wh_ratio=g("vision_max_wh_ratio", 8),
+        )
+
+
+def preprocess_image(
+    image: "Image.Image", cfg: VisionPreprocessConfig
+) -> tuple[torch.Tensor, int, int, int, int]:
+    """Resize/pad one image and patchify it.
+
+    Returns ``(patches[L, 3, p, p], n_vit_h, n_vit_w, n_llm_h, n_llm_w)``.
+
+    Note the deliberate asymmetry carried over from the reference: the aspect
+    clamp and min-pixel upscale adjust the *geometry* variables `width`/`height`
+    used to solve for the target grid, while the choice between `resize` and
+    letterbox `pad` re-reads the image's ORIGINAL dimensions. Keep it —
+    "tidying" it changes which images get letterboxed and silently shifts
+    outputs away from the reference.
+    """
+    p = cfg.patch_size
+    image = image.convert("RGB")
+    width, height = image.size
+    if cfg.max_wh_ratio is not None and width > height * cfg.max_wh_ratio:
+        width = height * cfg.max_wh_ratio
+    if 0 < width * height < cfg.min_pixels:
+        ratio = (cfg.min_pixels / (width * height)) ** 0.5
+        width = int(width * ratio)
+        height = int(height * ratio)
+    best_width = math.ceil(width / p) * p
+    best_height = math.ceil(height / p) * p
+    n_llm_h, n_llm_w, best_height, best_width = safe_resize(
+        height, width, best_height, best_width, p, cfg.downsample_ratio, cfg.max_n_token
+    )
+    n_vit_h, n_vit_w = best_height // p, best_width // p
+
+    if cfg.max_wh_ratio is not None and image.width >= cfg.max_wh_ratio * image.height:
+        image = image.resize((best_width, best_height))
+    else:
+        image = ImageOps.pad(image, (best_width, best_height), color=(127, 127, 127))
+
+    x = torch.from_numpy(np.asarray(image, dtype=np.float32)).permute(2, 0, 1) / 255
+    x = ((x - 0.5) / 0.5).to(torch.bfloat16)
+    patches = (
+        x.reshape(3, n_vit_h, p, n_vit_w, p)
+        .permute(1, 3, 0, 2, 4)
+        .reshape(n_vit_h * n_vit_w, 3, p, p)
+    )
+    return patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w
+
+
+# ---------------------------------------------------------------------------
+# N-layout
+# ---------------------------------------------------------------------------
+
+
+def image_block_perm(n_llm_h: int, n_llm_w: int) -> torch.Tensor:
+    """Map N-layout IMAGE slot order onto the aligner's row-major output.
+
+    Depends only on the grid — NOT on where the block lands in the prompt, since
+    ``start_pos`` only controls how many leading pads precede ``IMAGE_START``.
+    That is what lets the model rebuild this from ``image_grid_thw`` alone
+    instead of shipping it through ``multimodal_data``.
+    """
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    # Walk each pair of rows column-first.
+    order = torch.arange(rows * row_len).view(rows // 2, 2, row_len).transpose(1, 2)
+    order = order.reshape(-1)
+    image_idx = torch.full((rows * row_len,), -1, dtype=torch.int64)
+    image_idx.view(rows, row_len)[:n_llm_h, :n_llm_w] = torch.arange(
+        n_llm_h * n_llm_w
+    ).view(n_llm_h, n_llm_w)
+    perm = image_idx[order]
+    return perm[perm >= 0]
+
+
+def build_image_block(
+    n_llm_h: int, n_llm_w: int, start_pos: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Sentinel types in final token order, plus the aligner-row permutation.
+
+    ``start_pos`` is the number of tokens already emitted, which fixes the
+    leading compression pad so ``IMAGE_START`` lands at ``pos ≡ 3 (mod 4)``.
+    """
+    compress_pad = COMPRESS_PAD_TO - 1 - start_pos % COMPRESS_PAD_TO
+    pad_h = n_llm_h % 2
+    rows = n_llm_h + pad_h
+    row_len = n_llm_w + 1
+    pad_last = rows // 2 * row_len % 2 * 2
+    types = torch.tensor(
+        ([IMAGE] * n_llm_w + [IMAGE_NEW_LINE]) * n_llm_h
+        + [IMAGE_PAD] * (row_len * pad_h),
+        dtype=torch.int64,
+    )
+    order = torch.arange(rows * row_len).view(rows // 2, 2, row_len).transpose(1, 2)
+    order = order.reshape(-1)
+    types = torch.cat(
+        [
+            torch.full((compress_pad,), IMAGE_PAD, dtype=torch.int64),
+            torch.tensor([IMAGE_START]),
+            types[order],
+            torch.full((pad_last,), IMAGE_PAD, dtype=torch.int64),
+            torch.tensor([IMAGE_END]),
+        ]
+    )
+    return types, image_block_perm(n_llm_h, n_llm_w)
+
+
+def expand_image_placeholders(
+    prompt_tokens: list[int],
+    images: list,
+    image_token_id: int,
+    vocab_size: int,
+    cfg: VisionPreprocessConfig,
+) -> tuple[list[int], list[torch.Tensor], list[tuple[int, int]]]:
+    """Replace each placeholder token with its sentinel block.
+
+    Must run sequentially: each block's leading compression pad is a function of
+    how many tokens precede it, so blocks cannot be built independently.
+
+    Returns ``(input_ids, per-image patches, per-image (n_vit_h, n_vit_w))``.
+    """
+    num_placeholders = sum(1 for token in prompt_tokens if token == image_token_id)
+    if num_placeholders != len(images):
+        raise ValueError(
+            f"prompt has {num_placeholders} image placeholder tokens but "
+            f"{len(images)} images were supplied"
+        )
+
+    tokens: list[int] = []
+    patches_per_image: list[torch.Tensor] = []
+    grids: list[tuple[int, int]] = []
+    image_iter = iter(images)
+    for token in prompt_tokens:
+        if token != image_token_id:
+            tokens.append(token)
+            continue
+        patches, n_vit_h, n_vit_w, n_llm_h, n_llm_w = preprocess_image(
+            next(image_iter), cfg
+        )
+        types, _ = build_image_block(n_llm_h, n_llm_w, len(tokens))
+        patches_per_image.append(patches)
+        grids.append((n_vit_h, n_vit_w))
+        tokens += (vocab_size + types).tolist()
+    return tokens, patches_per_image, grids
+
+
+# ---------------------------------------------------------------------------
+# ATOM input builder
+# ---------------------------------------------------------------------------
+
+
+def _resolve_thinking(chat_template_kwargs: dict) -> tuple[str, str | None]:
+    """Map ATOM's chat-template kwargs onto the encoder's thinking controls."""
+    mode = chat_template_kwargs.get("thinking_mode")
+    if mode is None:
+        enable = chat_template_kwargs.get("enable_thinking")
+        mode = "thinking" if enable else "chat"
+    if mode not in ("chat", "thinking"):
+        raise ValueError(f"thinking_mode must be 'chat' or 'thinking', got {mode!r}")
+    return mode, chat_template_kwargs.get("reasoning_effort")
+
+
+def _messages_for_encoder(messages: list[dict]) -> list[dict]:
+    """Rewrite already-loaded image parts into blocks the encoder accepts.
+
+    ``api_server._collect_multimodal_parts`` has already decoded every image into
+    a PIL object and collected them in prompt order, so the encoder only needs to
+    emit one placeholder per image — it does not need to reload pixels. The
+    pixel source stays the caller's ordered `images` list; the traversal order of
+    both walks is identical (messages in order, parts in order).
+    """
+    rewritten = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            rewritten.append(message)
+            continue
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in ("image", "image_url"):
+                parts.append({"type": "image", "url": "atom://preloaded"})
+            else:
+                parts.append(part)
+        rewritten.append({**message, "content": parts})
+    return rewritten
+
+
+def build_deepseek_v4_inputs(
+    atom_config: Config,
+    processor: Any,
+    messages: list[dict],
+    images: list,
+    chat_template_kwargs: dict,
+    tools: Any = None,
+) -> tuple[list[int], dict] | None:
+    """Build DeepSeek-V4 vision inputs, or None on a text-only V4 checkpoint."""
+    hf_config = atom_config.hf_config
+    if int(getattr(hf_config, "vision_n_layers", 0) or 0) <= 0:
+        return None
+
+    encoding = load_checkpoint_encoding(atom_config.model)
+    thinking_mode, reasoning_effort = _resolve_thinking(chat_template_kwargs)
+
+    encoder_messages = _messages_for_encoder(messages)
+    if tools:
+        if not encoder_messages:
+            raise ValueError("a request with tools must contain at least one message")
+        # The encoder reads tools off the first message, not a separate arg.
+        encoder_messages[0] = {**encoder_messages[0], "tools": tools}
+
+    prompt, media = encoding.encode_messages(
+        encoder_messages,
+        thinking_mode=thinking_mode,
+        reasoning_effort=reasoning_effort,
+        return_multi_modal_data=True,
+    )
+    if len(media["images"]) != len(images):
+        raise ValueError(
+            f"prompt encoder emitted {len(media['images'])} image placeholders "
+            f"but {len(images)} images were loaded from the request"
+        )
+
+    tokenizer = _resolve_tokenizer(processor, atom_config)
+    image_token_id = tokenizer.convert_tokens_to_ids(IMAGE_PLACEHOLDER)
+    if image_token_id is None or image_token_id == getattr(
+        tokenizer, "unk_token_id", None
+    ):
+        raise ValueError(f"tokenizer has no {IMAGE_PLACEHOLDER} token")
+
+    vocab_size = int(hf_config.vocab_size)
+    input_ids, patches_per_image, grids = expand_image_placeholders(
+        tokenizer.encode(prompt),
+        images,
+        image_token_id,
+        vocab_size,
+        VisionPreprocessConfig.from_hf_config(hf_config),
+    )
+
+    multimodal_data = {
+        "pixel_values": torch.cat(patches_per_image, dim=0),
+        # (t, h, w) with t=1 to match the engine's generic multimodal contract;
+        # the vision tower only ever reads (h, w).
+        "image_grid_thw": torch.tensor(
+            [[1, h, w] for h, w in grids], dtype=torch.int64
+        ),
+    }
+    return input_ids, multimodal_data
+
+
+def _resolve_tokenizer(processor: Any, atom_config: Config):
+    """Get a tokenizer from whatever the caller handed us.
+
+    This checkpoint ships no ``preprocessor_config.json``, so there is no HF
+    processor to unwrap — the server passes the tokenizer straight through, but
+    accept a processor-shaped object too so the offline example can share this
+    path.
+    """
+    if processor is not None:
+        if hasattr(processor, "encode") and hasattr(processor, "convert_tokens_to_ids"):
+            return processor
+        inner = getattr(processor, "tokenizer", None)
+        if inner is not None:
+            return inner
+
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(atom_config.model, trust_remote_code=True)
+
+
+# ---------------------------------------------------------------------------
+# Attention visibility for image spans
+# ---------------------------------------------------------------------------
+
+
+def image_visible_spans(
+    input_ids: np.ndarray,
+    vocab_size: int,
+    max_image_tokens: int,
+    seq_lens: "list[int] | None" = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-token visible distance left/right within its ``[START, END]`` span.
+
+    NumPy port of the reference ``model.get_image_visible``. Tokens outside any
+    image span get ``(0, 0)``, which collapses the caller's window arithmetic
+    back to the plain causal sliding window — that is what keeps text batches
+    bit-identical.
+
+    ``input_ids`` is ATOM's flat ragged prefill batch. Spans are resolved per
+    sequence rather than across the whole concatenation: a run-on span (an
+    ``IMAGE_START`` whose ``IMAGE_END`` was never emitted) would otherwise let
+    one request's tokens see the next request's, and the balanced-cumsum trick
+    would hide it instead of failing.
+    """
+    input_ids = np.asarray(input_ids)
+    if input_ids.ndim != 1:
+        raise ValueError(f"expected a flat token array, got shape {input_ids.shape}")
+    total = input_ids.shape[0]
+    lens = [total] if seq_lens is None else list(seq_lens)
+    if sum(lens) != total:
+        raise ValueError(f"seq_lens {lens} do not sum to {total} tokens")
+
+    left = np.zeros(total, dtype=np.int32)
+    right = np.zeros(total, dtype=np.int32)
+    offset = 0
+    for length in lens:
+        if length == 0:
+            continue
+        ids = input_ids[offset : offset + length]
+        idx = np.arange(length, dtype=np.int32)
+        is_start = ids == vocab_size + IMAGE_START
+        is_end = ids == vocab_size + IMAGE_END
+        if is_start.sum() != is_end.sum():
+            raise ValueError(
+                f"unbalanced image span in a {length}-token sequence: "
+                f"{int(is_start.sum())} IMAGE_START vs {int(is_end.sum())} "
+                "IMAGE_END. Multimodal prefills must not be chunked."
+            )
+        # Inside a span, or the closing token itself.
+        valid = (np.cumsum(is_start) > np.cumsum(is_end)) | is_end
+        starts = np.maximum.accumulate(np.where(is_start, idx, 0))
+        # Nearest IMAGE_END at or after each position.
+        ends = np.minimum.accumulate(np.where(is_end, idx, length)[::-1])[::-1]
+        left[offset : offset + length] = (idx - starts) * valid
+        right[offset : offset + length] = (ends - idx) * valid
+        offset += length
+
+    np.clip(left, None, max_image_tokens - 1, out=left)
+    np.clip(right, None, max_image_tokens, out=right)
+    return left, right
+
+
+def image_aware_extend_window(
+    positions: np.ndarray,
+    img_left: np.ndarray,
+    img_right: np.ndarray,
+    window_size: int,
+    width: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Widen each token's sliding window to cover its whole image span.
+
+    NumPy port of the reference ``model.get_window_topk_idxs_visible``, returned
+    as ``(extend_start, extend_count)`` because ATOM's prefill attention consumes
+    a per-token contiguous index range rather than a padded matrix.
+
+    The window grows in BOTH directions: ``extend_start`` reaches back past the
+    128-token window to the image's first token, and the range runs forward to
+    ``position + right`` — past the token itself, which is how in-image
+    attention becomes bidirectional. That is only sound because the prefill
+    kernel is purely index-driven with no causal mask, and because the scheduler
+    never chunks a multimodal prefill, so every future row named here is already
+    materialized in the current forward's ``kv`` tensor.
+
+    With ``img_left == img_right == 0`` this reduces exactly to the causal
+    ``(max(pos - win + 1, 0), min(pos + 1, win))`` the text path already uses.
+    """
+    positions = np.asarray(positions, dtype=np.int64)
+    left_add = np.maximum(np.asarray(img_left, dtype=np.int64) - (window_size - 1), 0)
+    extend_start = np.maximum(positions - (window_size - 1) - left_add, 0)
+    # The reference materializes a fixed `width`-column matrix and masks past
+    # `pos + right`; the effective last column is whichever comes first.
+    extend_last = np.minimum(
+        positions + np.asarray(img_right, dtype=np.int64), extend_start + width - 1
+    )
+    extend_count = extend_last - extend_start + 1
+    return extend_start.astype(np.int32), extend_count.astype(np.int32)
+
+
+def image_window_width(seq_len: int, window_size: int, max_image_tokens: int) -> int:
+    """Column budget the reference allots per token: ``min(seqlen, win + max)``.
+
+    Bounds how far :func:`image_aware_extend_window` can widen a single token's
+    index list — 512 for this checkpoint (128 window + 384 image tokens) — which
+    is what keeps the prefill index buffers from growing without limit.
+    """
+    return min(seq_len, window_size + max_image_tokens)

--- a/atom/models/deepseek_v4_vl.py
+++ b/atom/models/deepseek_v4_vl.py
@@ -33,15 +33,17 @@ import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
 import torch.nn.functional as F
-from PIL import Image, ImageOps
 from torch import nn
 
 from atom.config import Config
+
+if TYPE_CHECKING:
+    from PIL import Image
 
 
 @dataclass(frozen=True)
@@ -409,7 +411,7 @@ IMAGE_PLACEHOLDER = "<｜deepseek_image｜>"
 # Prompt encoding: loaded from the checkpoint, not vendored
 # ---------------------------------------------------------------------------
 
-_encoding_module = None
+_encoding_modules: dict[str, object] = {}
 _encoding_lock = threading.Lock()
 
 
@@ -425,13 +427,20 @@ def load_checkpoint_encoding(model_path: str):
     This executes code from the model directory, the same trust boundary
     ``AutoProcessor(trust_remote_code=True)`` already crosses for Kimi-K3.
     """
-    global _encoding_module
     with _encoding_lock:
-        if _encoding_module is not None:
-            return _encoding_module
+        # Keyed on `model_path`: a process that touches two V4 vision
+        # checkpoints (an eval harness comparing revisions, a heterogeneous
+        # disagg/PP setup) must not serve the first checkpoint's roles,
+        # thinking modes and tool rendering against the second's weights --
+        # that is the stale-template regression this function exists to
+        # prevent, just moved from disk into memory.
+        cached = _encoding_modules.get(model_path)
+        if cached is not None:
+            return cached
 
         path = f"{model_path}/encoding/encoding_dsv4.py"
-        spec = importlib.util.spec_from_file_location("atom_dsv4_encoding", path)
+        mod_name = f"atom_dsv4_encoding_{abs(hash(model_path)):x}"
+        spec = importlib.util.spec_from_file_location(mod_name, path)
         if spec is None or spec.loader is None:
             raise FileNotFoundError(
                 f"DeepSeek-V4 vision needs the checkpoint's prompt encoder at "
@@ -442,10 +451,10 @@ def load_checkpoint_encoding(model_path: str):
         module = importlib.util.module_from_spec(spec)
         # encoding_dsv4 is self-contained (stdlib only), but register it so a
         # traceback inside it resolves its source lines.
-        sys.modules["atom_dsv4_encoding"] = module
+        sys.modules[mod_name] = module
         spec.loader.exec_module(module)
         logger.info(f"Loaded DeepSeek-V4 prompt encoder from {path}")
-        _encoding_module = module
+        _encoding_modules[model_path] = module
         return module
 
 
@@ -532,8 +541,22 @@ def safe_resize(
     n_llm_h, n_llm_w, num_tokens = grid_tokens(
         best_height, best_width, patch_size, downsample_ratio
     )
+    # The walk needs a floor. `solve_resize_ratio` evaluates
+    # `sqrt((budget - 2) / r + 0.25)`, so a budget below 2 drives the radicand
+    # negative and raises `math domain error` -- and `r` is the aspect ratio of
+    # a caller-supplied image, i.e. request-controlled. `grid_tokens` is not
+    # monotonic in the budget, so non-convergence is a real case rather than a
+    # theoretical one; stop at the smallest budget that still admits a grid.
+    _MIN_BUDGET = 3
     budget = max_n_token
     while num_tokens > max_n_token:
+        if budget < _MIN_BUDGET:
+            raise ValueError(
+                f"cannot fit a {height}x{width} image into {max_n_token} "
+                f"language tokens: the grid solver stopped converging at "
+                f"{num_tokens} tokens. The aspect ratio is too extreme for "
+                f"this checkpoint's token budget."
+            )
         n_llm_h, n_llm_w, best_height, best_width, num_tokens = solve_resize_ratio(
             height, width, patch_size, downsample_ratio, budget
         )
@@ -595,6 +618,13 @@ def preprocess_image(
     "tidying" it changes which images get letterboxed and silently shifts
     outputs away from the reference.
     """
+    # Pillow is not a declared base dependency (pyproject lists it only under
+    # the diffusion extra), and this module is imported by the model
+    # constructor and by the attention builder on every prefill -- a
+    # module-scope PIL import would make a base install fail to build a V4
+    # vision model with an ImportError instead of a named error.
+    from PIL import ImageOps
+
     p = cfg.patch_size
     image = image.convert("RGB")
     width, height = image.size
@@ -734,10 +764,21 @@ def _resolve_thinking(chat_template_kwargs: dict) -> tuple[str, str | None]:
     mode = chat_template_kwargs.get("thinking_mode")
     if mode is None:
         enable = chat_template_kwargs.get("enable_thinking")
-        mode = "thinking" if enable else "chat"
+        # Default ON, matching the text path for this same model: the server
+        # builds its adapter with `defaults={"thinking_mode": "thinking"}`
+        # (chat_encoders.py) and only writes `thinking_mode` when the request
+        # says something about it. Defaulting to "chat" here gave one server
+        # thinking-on for text and thinking-off for images.
+        mode = "chat" if enable is False else "thinking"
     if mode not in ("chat", "thinking"):
         raise ValueError(f"thinking_mode must be 'chat' or 'thinking', got {mode!r}")
-    return mode, chat_template_kwargs.get("reasoning_effort")
+    # The server writes `thinking_effort` (api_server.py); `reasoning_effort` is
+    # what a client passing raw `chat_template_kwargs` would use. Read both, or
+    # the effort is silently dropped on every image request served over HTTP.
+    effort = chat_template_kwargs.get("thinking_effort")
+    if effort is None:
+        effort = chat_template_kwargs.get("reasoning_effort")
+    return mode, effort
 
 
 def _messages_for_encoder(messages: list[dict]) -> list[dict]:

--- a/atom/models/kimi_k3_vl.py
+++ b/atom/models/kimi_k3_vl.py
@@ -16,12 +16,16 @@ embeddings before the first collective).
 
 import math
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 from aiter import flash_attn_varlen_func
 from torch import nn
+
+from atom.config import Config
+from atom.multimodal.registry import expand_media_placeholders
 
 # The 2D RoPE grid is precomputed per (height, width); the processor caps both
 # at `patch_limit_on_one_side` (512 in preprocessor_config.json).
@@ -488,3 +492,85 @@ def build_vision_modules(vision_config) -> tuple[nn.Module, nn.Module]:
     if projector_type != "patchmergerv2":
         raise NotImplementedError(f"Unsupported mm_projector_type: {projector_type}")
     return KimiK3VisionTower(vision_config), KimiK3PatchMergerProjector(vision_config)
+
+
+# --------------------------------------------------------------------------
+# Multimodal input building
+# --------------------------------------------------------------------------
+# The processor takes messages plus a separate `medias` list (the chat
+# encoder is Python, not Jinja), returns `grid_thws` rather than
+# `image_grid_thw`, and emits a single `<|media_pad|>` per image that the
+# reference model expands while merging embeddings. This normalizes all three.
+
+
+def _as_pair(value) -> tuple[int, int]:
+    if isinstance(value, int):
+        return (value, value)
+    return (int(value[0]), int(value[1]))
+
+
+def kimi_k3_tokens_per_image(grid_thws, merge_kernel_size) -> list[int]:
+    """Image-token count per grid after the ``sd2_tpool`` merge.
+
+    The merge pools the temporal axis away and downsamples each spatial axis by
+    the merge kernel, so a ``(t, h, w)`` patch grid yields ``(h // kh) * (w //
+    kw)`` tokens regardless of ``t``.
+    """
+    kernel_h, kernel_w = _as_pair(merge_kernel_size)
+    grids = grid_thws.tolist() if hasattr(grid_thws, "tolist") else grid_thws
+    return [(int(h) // kernel_h) * (int(w) // kernel_w) for _, h, w in grids]
+
+
+def build_kimi_k3_inputs(
+    atom_config: Config,
+    processor: Any,
+    messages: list[dict],
+    images: list,
+    chat_template_kwargs: dict,
+    tools: Any = None,
+) -> tuple[list[int], dict]:
+    """Build Kimi-K3 inputs via ``KimiK3Processor``.
+
+    The K3 processor takes messages plus a separate ``medias`` list (its chat
+    encoder is Python, not Jinja), returns ``grid_thws`` rather than
+    ``image_grid_thw``, and emits a single ``<|media_pad|>`` per image that the
+    reference model expands while merging embeddings. Normalize all three so the
+    engine sees the same contract as every other multimodal model.
+    """
+    multimodal_config = getattr(atom_config, "multimodal_config", None)
+    if multimodal_config is None:
+        raise ValueError(
+            "Kimi-K3 image requests need the full HF config; start the server "
+            "with --trust-remote-code."
+        )
+
+    template_kwargs = dict(chat_template_kwargs)
+    template_kwargs.pop("tokenize", None)
+    if tools:
+        template_kwargs["tools"] = tools
+
+    medias = [{"type": "image", "image": image} for image in images]
+    inputs = processor(
+        messages=messages,
+        medias=medias,
+        return_tensors="pt",
+        **template_kwargs,
+    )
+
+    grid_thws = inputs["grid_thws"]
+    input_ids = inputs["input_ids"][0].tolist()
+    placeholder_token_id = int(
+        getattr(multimodal_config, "media_placeholder_token_id", 163605)
+    )
+    tokens_per_image = kimi_k3_tokens_per_image(
+        grid_thws, multimodal_config.vision_config.merge_kernel_size
+    )
+    input_ids = expand_media_placeholders(
+        input_ids, tokens_per_image, placeholder_token_id
+    )
+
+    multimodal_data = {
+        "pixel_values": inputs["pixel_values"],
+        "image_grid_thw": grid_thws,
+    }
+    return input_ids, multimodal_data

--- a/atom/models/kimi_k3_vl.py
+++ b/atom/models/kimi_k3_vl.py
@@ -503,12 +503,6 @@ def build_vision_modules(vision_config) -> tuple[nn.Module, nn.Module]:
 # reference model expands while merging embeddings. This normalizes all three.
 
 
-def _as_pair(value) -> tuple[int, int]:
-    if isinstance(value, int):
-        return (value, value)
-    return (int(value[0]), int(value[1]))
-
-
 def kimi_k3_tokens_per_image(grid_thws, merge_kernel_size) -> list[int]:
     """Image-token count per grid after the ``sd2_tpool`` merge.
 

--- a/atom/multimodal/__init__.py
+++ b/atom/multimodal/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Multimodal input handling: the registry and its contract.
+
+The engine talks to this package through :func:`build_multimodal_inputs` and
+:func:`get_mrope_input_positions`. Nothing model-specific lives here — each
+model's preprocessing sits beside the model itself, in
+``atom/models/<family>_vl.py``, and is reached through the registry.
+"""
+
+from atom.multimodal.protocol import MultiModalInputBuilder
+from atom.multimodal.registry import (
+    build_multimodal_inputs,
+    expand_media_placeholders,
+    get_mrope_input_positions,
+)
+
+__all__ = [
+    "MultiModalInputBuilder",
+    "build_multimodal_inputs",
+    "expand_media_placeholders",
+    "get_mrope_input_positions",
+]

--- a/atom/multimodal/protocol.py
+++ b/atom/multimodal/protocol.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""The contract an architecture's multimodal input builder implements.
+
+Most checkpoints follow the Qwen convention — ``processor(text=..., images=...)``
+returns already-expanded placeholders — and the server handles them inline. A
+model whose processor deviates registers a builder in
+:mod:`atom.multimodal.registry` instead; this is the shape that builder has.
+"""
+
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+from atom.config import Config
+
+
+class MultiModalInputBuilder(Protocol):
+    """Turn chat messages plus already-loaded media into engine inputs.
+
+    Returns ``(input_ids, multimodal_data)``, or ``None`` when the builder does
+    not apply to this checkpoint and the caller should fall back to its text
+    path — a registry key is an architecture string, which for some families is
+    shared by a text-only and a multimodal checkpoint.
+
+    ``multimodal_data`` carries whatever the model's ``get_vision_embeddings``
+    consumes. The engine only requires the two keys it marshals itself:
+
+    * ``pixel_values``    — media tensor, concatenated over items
+    * ``image_grid_thw``  — ``(t, h, w)`` per item, so the model can split it
+    """
+
+    def __call__(
+        self,
+        atom_config: Config,
+        processor: Any,
+        messages: list[dict],
+        images: Sequence[Any],
+        chat_template_kwargs: dict,
+        tools: Any = None,
+    ) -> tuple[list[int], dict] | None: ...

--- a/atom/multimodal/protocol.py
+++ b/atom/multimodal/protocol.py
@@ -9,7 +9,6 @@ model whose processor deviates registers a builder in
 :mod:`atom.multimodal.registry` instead; this is the shape that builder has.
 """
 
-from collections.abc import Sequence
 from typing import Any, Protocol
 
 from atom.config import Config
@@ -35,7 +34,7 @@ class MultiModalInputBuilder(Protocol):
         atom_config: Config,
         processor: Any,
         messages: list[dict],
-        images: Sequence[Any],
+        images: list,
         chat_template_kwargs: dict,
         tools: Any = None,
     ) -> tuple[list[int], dict] | None: ...

--- a/atom/multimodal/registry.py
+++ b/atom/multimodal/registry.py
@@ -14,12 +14,13 @@ Two model-specific hooks live here:
   deviate register a builder below.
 """
 
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
 
 from atom.config import Config
+from atom.multimodal.protocol import MultiModalInputBuilder
 from atom.utils import resolve_obj_by_qualname
 
 _MULTIMODAL_ARCH_TO_MODEL: dict[str, str] = {
@@ -84,7 +85,7 @@ def build_multimodal_inputs(
     if builder_qualname is None:
         return None
 
-    builder: Callable = resolve_obj_by_qualname(builder_qualname)
+    builder: MultiModalInputBuilder = resolve_obj_by_qualname(builder_qualname)
     return builder(
         atom_config,
         processor,

--- a/atom/multimodal/registry.py
+++ b/atom/multimodal/registry.py
@@ -30,9 +30,11 @@ _MULTIMODAL_ARCH_TO_MODEL: dict[str, str] = {
 }
 
 _MULTIMODAL_ARCH_TO_INPUT_BUILDER: dict[str, str] = {
-    "KimiK3ForConditionalGeneration": (
-        "atom.model_engine.multimodal.build_kimi_k3_inputs"
-    ),
+    "KimiK3ForConditionalGeneration": ("atom.models.kimi_k3_vl.build_kimi_k3_inputs"),
+    # DeepSeek-V4 is one architecture with an optional vision tower, so this
+    # builder returns None when the config has none and the caller falls back
+    # to its text path.
+    "DeepseekV4ForCausalLM": ("atom.models.deepseek_v4_vl.build_deepseek_v4_inputs"),
 }
 
 
@@ -121,76 +123,3 @@ def expand_media_placeholders(
         else:
             expanded.append(token)
     return expanded
-
-
-def _as_pair(value) -> tuple[int, int]:
-    if isinstance(value, int):
-        return (value, value)
-    return (int(value[0]), int(value[1]))
-
-
-def kimi_k3_tokens_per_image(grid_thws, merge_kernel_size) -> list[int]:
-    """Image-token count per grid after the ``sd2_tpool`` merge.
-
-    The merge pools the temporal axis away and downsamples each spatial axis by
-    the merge kernel, so a ``(t, h, w)`` patch grid yields ``(h // kh) * (w //
-    kw)`` tokens regardless of ``t``.
-    """
-    kernel_h, kernel_w = _as_pair(merge_kernel_size)
-    grids = grid_thws.tolist() if hasattr(grid_thws, "tolist") else grid_thws
-    return [(int(h) // kernel_h) * (int(w) // kernel_w) for _, h, w in grids]
-
-
-def build_kimi_k3_inputs(
-    atom_config: Config,
-    processor: Any,
-    messages: list[dict],
-    images: list,
-    chat_template_kwargs: dict,
-    tools: Any = None,
-) -> tuple[list[int], dict]:
-    """Build Kimi-K3 inputs via ``KimiK3Processor``.
-
-    The K3 processor takes messages plus a separate ``medias`` list (its chat
-    encoder is Python, not Jinja), returns ``grid_thws`` rather than
-    ``image_grid_thw``, and emits a single ``<|media_pad|>`` per image that the
-    reference model expands while merging embeddings. Normalize all three so the
-    engine sees the same contract as every other multimodal model.
-    """
-    multimodal_config = getattr(atom_config, "multimodal_config", None)
-    if multimodal_config is None:
-        raise ValueError(
-            "Kimi-K3 image requests need the full HF config; start the server "
-            "with --trust-remote-code."
-        )
-
-    template_kwargs = dict(chat_template_kwargs)
-    template_kwargs.pop("tokenize", None)
-    if tools:
-        template_kwargs["tools"] = tools
-
-    medias = [{"type": "image", "image": image} for image in images]
-    inputs = processor(
-        messages=messages,
-        medias=medias,
-        return_tensors="pt",
-        **template_kwargs,
-    )
-
-    grid_thws = inputs["grid_thws"]
-    input_ids = inputs["input_ids"][0].tolist()
-    placeholder_token_id = int(
-        getattr(multimodal_config, "media_placeholder_token_id", 163605)
-    )
-    tokens_per_image = kimi_k3_tokens_per_image(
-        grid_thws, multimodal_config.vision_config.merge_kernel_size
-    )
-    input_ids = expand_media_placeholders(
-        input_ids, tokens_per_image, placeholder_token_id
-    )
-
-    multimodal_data = {
-        "pixel_values": inputs["pixel_values"],
-        "image_grid_thw": grid_thws,
-    }
-    return input_ids, multimodal_data

--- a/atom/plugin/vllm/models/deepseek_v4.py
+++ b/atom/plugin/vllm/models/deepseek_v4.py
@@ -375,8 +375,18 @@ class DeepseekV4ModelVllm(DeepseekV4ModelBase):
             device=self.embed.weight.device,
         )
 
-    def forward(self, input_ids: torch.Tensor, positions: torch.Tensor) -> torch.Tensor:
-        h = super().forward(input_ids, positions)
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Mirror the base signature exactly: `DeepseekV4ForCausalLM.forward`
+        # calls `self.model(input_ids, positions, inputs_embeds)` positionally,
+        # and the plugin rebinds this class over `DeepseekV4Model`, so a
+        # narrower signature here breaks every V4 forward under the plugin --
+        # text-only included, since `inputs_embeds=None` is still passed.
+        h = super().forward(input_ids, positions, inputs_embeds)
         # In-graph copy_: captured into the CUDAGraph so it refreshes the buffer
         # on every replay, keeping the MTP draft's input hidden states current.
         num_tokens = h.shape[0]

--- a/docs/model_support_guide.md
+++ b/docs/model_support_guide.md
@@ -154,7 +154,7 @@ ATOM resolves the HuggingFace `architectures` field from a model's `config.json`
 - **KDA Recurrent State:** The KDA layers keep per-request recurrent state in the generic per-request slot pool, like Qwen3-Next's Gated DeltaNet.
 - **MoE:** MXFP4 latent MoE (`KimiSparseMoeBlock`) with SiTU activation and optional dual-stream shared/routed overlap (`ATOM_K3_SHARED_EXPERT_OVERLAP`).
 - **Vision:** `atom/models/kimi_k3_vl.py` implements MoonViT3d — patch embed with a bilinearly resampled learnable position grid, 27 blocks with packed `wqkv` and complex 2D RoPE over non-causal varlen attention, then an `sd2_tpool` 2x2 merge and a `patchmergerv2` projector into the 7168-wide text space. Replicated per TP rank (~0.9 GB bf16), built only on the first pipeline rank.
-- **Image tokens:** The HF processor emits one `<|media_pad|>` per image and expands it inside the model. ATOM instead expands it during input processing (`atom/model_engine/multimodal.py`) so the scheduler, KV blocks and positions see the true prompt length. Multimodal prefills are consequently never chunked.
+- **Image tokens:** The HF processor emits one `<|media_pad|>` per image and expands it inside the model. ATOM instead expands it during input processing (`atom/multimodal/`) so the scheduler, KV blocks and positions see the true prompt length. Multimodal prefills are consequently never chunked.
 
 ### Qwen3.5 MTP (`Qwen3_5MTP`)
 

--- a/recipes/DeepSeek-V4-Flash-Vision.md
+++ b/recipes/DeepSeek-V4-Flash-Vision.md
@@ -1,0 +1,174 @@
+# DeepSeek-V4-Flash-Vision-Exp
+
+The first multimodal model in the DeepSeek-V4 family: the V4-Flash language
+stack (43 layers, DFlash sparse attention, mHC, FP8/FP4 MoE) plus a 32-layer ViT
+and an aligner. ATOM serves it through the same `deepseek_v4.py` stack as the
+text-only V4 checkpoints.
+
+## Running
+
+```bash
+# Offline, single card — the weights are 156 GiB and a 288 GiB card fits them
+# whole, so tp=1 is the simplest way to run it.
+AITER_LOG_LEVEL=WARNING python -m atom.examples.multimodal_inference \
+  --model /data/DeepSeek-V4-Flash-Vision-Exp \
+  --image path/to/image.jpg \
+  --prompt "What is in this image?" -tp 1
+
+# OpenAI-compatible server
+AITER_LOG_LEVEL=WARNING python -m atom.entrypoints.openai_server \
+  --model /data/DeepSeek-V4-Flash-Vision-Exp -tp 1
+```
+
+Images are passed as normal OpenAI `image_url` content parts.
+
+## What is model-specific
+
+**One architecture, optional vision tower.** Both checkpoints declare
+`DeepseekV4ForCausalLM` because that is what they are: `DeepseekV4ForCausalLM`
+builds the ViT + aligner iff `vision_n_layers > 0`, mirroring the reference's
+own `Transformer.__init__`. No arch-string rewriting or config-based class
+dispatch is involved. The registered multimodal input builder is keyed on the
+same string and returns `None` for a text-only config so the caller falls back
+to its text path.
+
+**No HF processor.** The checkpoint ships no `preprocessor_config.json` and no
+chat template. Image preprocessing is ported into
+`atom/model_engine/deepseek_v4_mm.py`, and the prompt template is loaded at
+runtime from the checkpoint's own `encoding/encoding_dsv4.py` — versioned with
+the weights, so it cannot drift the way a vendored copy would. That executes
+code from the model directory, the same trust boundary
+`AutoProcessor(trust_remote_code=True)` already crosses for Kimi-K3.
+
+**Image tokens live above the vocabulary.** Each `<｜deepseek_image｜>` expands
+into a run of `vocab_size + type` ids (129280..129284). Anything indexing a
+vocab-sized table by `input_ids` must clamp; `embed_input_ids` does, and the
+routing kernel treats `>= vocab_size` as the image predicate.
+
+**Two router biases.** Every layer carries `gate.bias_vl` alongside `gate.bias`,
+selected per token. `FusedMoE.select_experts` takes a single `[E]` bias, so
+vision checkpoints route through `atom/model_ops/triton_vl_topk.py` on every
+layer via the `custom_routing_function` hook.
+
+**Bidirectional attention inside an image.** Tokens within an
+`[IMAGE_START, IMAGE_END]` span attend to each other in both directions. ATOM's
+prefill attention is purely index-driven with no causal mask, so this is
+expressed by widening each token's index list
+(`image_aware_extend_window`) rather than by changing the attention kernel. The
+compressed (CSA/HCA) paths stay causal, matching the reference.
+
+**Multimodal prefills are never chunked.** The vision embeddings are produced
+for the whole prompt and scattered onto its placeholder positions, and in-image
+attention reads across the whole block. The scheduler takes such a prompt whole
+or waits; `_finalize_prefill_chunk(atomic=True)` also suppresses the checkpoint
+cut, which means **no state checkpoint is kept for a multimodal request** — the
+cost is prefix-cache reuse on image prompts, which are single-shot anyway.
+`max_num_batched_tokens` therefore caps multimodal prompt length even with
+chunked prefill enabled.
+
+## Compilation
+
+`--level` (default 3) drives the **language model**: `DeepseekV4Model` carries
+`@support_torch_compile`, so it gets piecewise compilation plus CUDAGraph
+capture on decode. Verified at level 3 — image answers are token-identical to
+level 0, and GSM8K matches within noise.
+
+The vision tower runs eager, like every other ATOM vision tower. It sits outside
+`@support_torch_compile`, so `--level` does not reach it; wrapping it in
+`torch.compile(dynamic=True)` measured 1.31x (42x61 grid) to 1.57x (30x40) on
+the tower alone — ~3-5 ms per image against a prefill of a few hundred ms — which
+did not justify a bespoke toggle. Revisit if image throughput ever matters.
+
+CUDAGraph never covers the tower, but that is engine-wide rather than a vision
+decision: `forward_context` gates capture on `not is_prefill`, and the tower runs
+only during prefill.
+
+## Not supported
+
+- **PCP** (prefill context parallelism) with images — `inputs_embeds` would have
+  to be round-robin split alongside `input_ids`. Raises rather than guessing.
+- **DSpark / MTP speculative decoding** — the `mtp.*` gates carry `bias_vl`
+  too and the draft path has no sentinel handling yet. Raises at startup rather
+  than routing images with the text bias; run without `--method`.
+- **Chunked multimodal prefill** — see above.
+- **Images behind a KV connector (PD disaggregation).** A request parked for a
+  remote KV load still carries its `multimodal_data`, and the resume path's
+  `_finalize_prefill_chunk` call does not pass `atomic`, so the checkpoint cut
+  could split its image block — silently, the same way the main path did before
+  it was fixed. Left alone deliberately: that path cannot be exercised here, and
+  changing behaviour on an untestable path is worse than recording the gap.
+- **TBO prefill micro-batching** with images — a token-split ubatch would cut an
+  image span in half. Raises; start without `--enable-tbo`.
+- **Images at TP > 1 are unverified.** The language stack is exercised at `tp=8`
+  (GSM8K below), but every image request so far has run at `tp=1`. The tower is
+  replicated per rank like Kimi-K3's, so nothing in the design is TP-specific —
+  it simply has not been run.
+
+## Accuracy
+
+GSM8K 3-shot, 1319 samples, `tp=8`, `--kv_cache_dtype fp8` (text-only, so this
+covers the `bias_vl` routing kernel on all 43 layers):
+
+| | flexible-extract | strict-match |
+|---|---|---|
+| `--level 0` | 0.9416 ± 0.0065 | 0.9424 ± 0.0064 |
+| `--level 3` (default) | 0.9340 ± 0.0068 | 0.9348 ± 0.0068 |
+| `--level 3`, re-measured after the rebase onto `5a9c2068` | 0.9393 ± 0.0066 | 0.9393 ± 0.0066 |
+
+The 0.76pp level-0/3 gap is ~0.8σ, and the post-rebase re-measurement sits
+0.53pp above its own earlier run — both inside one noise band, so neither is a
+real difference. CI has no baseline for this model; V4-Pro's 0.96 is a larger
+model (61 layers, hidden 7168) and not a fair comparison.
+
+Vision, via `/app/scripts/run_vision_bench.sh` (lmms_eval against the OpenAI
+server), `tp=8`, `--kv_cache_dtype fp8`, greedy:
+
+| Task | Metric | Value |
+|---|---|---|
+| chartqa (2500 samples, 0 failed) | relaxed_overall | 0.8888 ± 0.0063 |
+| | relaxed_augmented_split | 0.9576 ± 0.0057 |
+| | relaxed_human_split | 0.8200 ± 0.0109 |
+
+ZeroBench, via `/app/scripts/run_zerobench.py` (ungated `mm-eval/ZeroBench`
+mirror; grading imports lmms_eval's own `_is_exact_match`), thinking mode at
+`max` reasoning effort, `temperature=1.0 top_p=0.95`, `max_tokens=16384`,
+0 failed requests in 2170 samples:
+
+| Split | Pass@1 | Pass@5 |
+|---|---|---|
+| `zerobench` (100 main) | 1.0 | 3.0 |
+| `zerobench_subquestions` (334) | 21.0 | **39.5** |
+| `zerobench_subquestions`, thinking OFF | 14.7 | — |
+
+**Card comparison, with caveats.** The card reports "ZeroBench (Pass@5) 35.0"
+without naming a split. The main split cannot be it — 3.0 here, and published
+frontier results sit at 0-7% Pass@1 by design — so it must mean the
+subquestions, where we get 39.5 against the card's 35.0. Treat that as
+"same magnitude, consistent", NOT a reproduction. DeepSeek Harness itself IS
+open source (github.com/deepseek-ai/deepseek-harness, MIT, branch `master`), but
+it ships no evaluation tooling: `BENCHMARK.md` is a three-line pointer to the
+Python SDK guide, and a full-tree scan of its 10,294 files contains no task
+definitions, prompts, graders or scores for any of the card's benchmarks. So the
+prompt template and grader cannot be matched, and scoring *above* the card is as
+likely to mean a more lenient exact-match as a better serve. The card's note 1
+also scopes the harness to the TEXT rows only — it states no methodology at all
+for the four multimodal ones.
+
+ApexBench and Agents' Last Exam are **not** reproducible: no public task set,
+prompts or grader exists for either. The public APEX-Agents (Mercor, arXiv
+2601.14242) is a different benchmark — a score from it must not be reported as
+ApexBench. Chartography has a public dataset (`surgeai/chartography`) but it
+could not be confirmed as the card's benchmark. ChartQA above is a separate,
+public benchmark — do not compare it to the card's Chartography row.
+
+## Tests
+
+```bash
+python -m pytest tests/test_deepseek_v4_vl.py          # CPU, vs the reference impl
+python -m pytest tests/test_prefill_indices_paged.py   # needs a GPU
+```
+
+`tests/test_deepseek_v4_vl.py` compares against the reference implementation
+shipped inside the checkpoint (`inference/vision.py`,
+`inference/image_processor.py`, `encoding/encoding_dsv4.py`) rather than against
+hand-written expectations, and skips when the checkpoint is not present.

--- a/recipes/DeepSeek-V4-Flash-Vision.md
+++ b/recipes/DeepSeek-V4-Flash-Vision.md
@@ -34,7 +34,7 @@ to its text path.
 
 **No HF processor.** The checkpoint ships no `preprocessor_config.json` and no
 chat template. Image preprocessing is ported into
-`atom/model_engine/deepseek_v4_mm.py`, and the prompt template is loaded at
+`atom/models/deepseek_v4_vl.py`, and the prompt template is loaded at
 runtime from the checkpoint's own `encoding/encoding_dsv4.py` — versioned with
 the weights, so it cannot drift the way a vendored copy would. That executes
 code from the model directory, the same trust boundary
@@ -47,7 +47,7 @@ routing kernel treats `>= vocab_size` as the image predicate.
 
 **Two router biases.** Every layer carries `gate.bias_vl` alongside `gate.bias`,
 selected per token. `FusedMoE.select_experts` takes a single `[E]` bias, so
-vision checkpoints route through `atom/model_ops/triton_vl_topk.py` on every
+vision checkpoints route through `atom/model_ops/triton_mm_topk.py` on every
 layer via the `custom_routing_function` hook.
 
 **Bidirectional attention inside an image.** Tokens within an
@@ -60,9 +60,10 @@ compressed (CSA/HCA) paths stay causal, matching the reference.
 **Multimodal prefills are never chunked.** The vision embeddings are produced
 for the whole prompt and scattered onto its placeholder positions, and in-image
 attention reads across the whole block. The scheduler takes such a prompt whole
-or waits; `_finalize_prefill_chunk(atomic=True)` also suppresses the checkpoint
-cut, which means **no state checkpoint is kept for a multimodal request** — the
-cost is prefix-cache reuse on image prompts, which are single-shot anyway.
+or waits; `_finalize_prefill_chunk` also skips the state-checkpoint rung cut
+for a sequence carrying `multimodal_data` (#2110), which means **no state
+checkpoint is kept for a multimodal request** — the cost is prefix-cache reuse
+on image prompts, which are single-shot anyway.
 `max_num_batched_tokens` therefore caps multimodal prompt length even with
 chunked prefill enabled.
 
@@ -91,18 +92,15 @@ only during prefill.
   too and the draft path has no sentinel handling yet. Raises at startup rather
   than routing images with the text bias; run without `--method`.
 - **Chunked multimodal prefill** — see above.
-- **Images behind a KV connector (PD disaggregation).** A request parked for a
-  remote KV load still carries its `multimodal_data`, and the resume path's
-  `_finalize_prefill_chunk` call does not pass `atomic`, so the checkpoint cut
-  could split its image block — silently, the same way the main path did before
-  it was fixed. Left alone deliberately: that path cannot be exercised here, and
-  changing behaviour on an untestable path is worse than recording the gap.
+- **Images behind a KV connector (PD disaggregation).** Untested here; the
+  resume path is not exercisable on this machine, so the interaction between a
+  parked `multimodal_data` request and its resumed prefill is unverified.
 - **TBO prefill micro-batching** with images — a token-split ubatch would cut an
   image span in half. Raises; start without `--enable-tbo`.
-- **Images at TP > 1 are unverified.** The language stack is exercised at `tp=8`
-  (GSM8K below), but every image request so far has run at `tp=1`. The tower is
-  replicated per rank like Kimi-K3's, so nothing in the design is TP-specific —
-  it simply has not been run.
+- **Images at TP > 1 are lightly covered.** The ChartQA and ZeroBench runs below
+  were served at `tp=8`; the interactive/offline checks were `tp=1`. The tower is
+  replicated per rank like Kimi-K3's, so nothing in the design is TP-specific,
+  but no test pins per-rank image-embedding equality.
 
 ## Accuracy
 
@@ -164,11 +162,11 @@ public benchmark — do not compare it to the card's Chartography row.
 ## Tests
 
 ```bash
-python -m pytest tests/test_deepseek_v4_vl.py          # CPU, vs the reference impl
+python -m pytest tests/test_deepseek_v4_vl_cpu.py          # CPU, vs the reference impl
 python -m pytest tests/test_prefill_indices_paged.py   # needs a GPU
 ```
 
-`tests/test_deepseek_v4_vl.py` compares against the reference implementation
+`tests/test_deepseek_v4_vl_cpu.py` compares against the reference implementation
 shipped inside the checkpoint (`inference/vision.py`,
 `inference/image_processor.py`, `encoding/encoding_dsv4.py`) rather than against
 hand-written expectations, and skips when the checkpoint is not present.

--- a/recipes/Kimi-K3.md
+++ b/recipes/Kimi-K3.md
@@ -76,7 +76,7 @@ The tower is replicated on every TP rank rather than sharded, costing ~0.9 GB bf
 
 ### How images reach the model
 
-Kimi-K3's processor differs from the Qwen convention in two ways that ATOM handles in `atom/model_engine/multimodal.py`:
+Kimi-K3's processor differs from the Qwen convention in two ways that ATOM handles in `atom/models/kimi_k3_vl.py`:
 
 - it takes `messages` plus a separate `medias` list (chat rendering is Python, not Jinja) and returns `grid_thws` rather than `image_grid_thw`;
 - it emits **one** `<|media_pad|>` token per image, leaving the expansion to the model. ATOM expands it to `(h // 2) * (w // 2)` tokens up front so the scheduler, KV blocks and positions all see the real prompt length.

--- a/tests/test_deepseek_v4_vl_cpu.py
+++ b/tests/test_deepseek_v4_vl_cpu.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""CPU-only checks for DeepSeek-V4 vision.
+
+The in-image visibility math is pure NumPy, so it runs on the CPU-only CI
+runner that `.github/scripts/run_unit_tests.sh` uses -- unlike
+`tests/test_prefill_indices_paged.py`, which needs a GPU and is skipped there.
+"""
+
+import numpy as np
+import pytest
+
+from atom.models.deepseek_v4_vl import (
+    IMAGE,
+    IMAGE_END,
+    IMAGE_START,
+    image_aware_extend_window,
+    image_visible_spans,
+    image_window_width,
+)
+
+VOCAB = 1000
+MAX_IMG = 32
+WIN = 8
+
+
+def _seq(*blocks) -> np.ndarray:
+    return np.array([t for b in blocks for t in b], dtype=np.int64)
+
+
+def _image_block(n: int) -> list[int]:
+    return [VOCAB + IMAGE_START] + [VOCAB + IMAGE] * n + [VOCAB + IMAGE_END]
+
+
+def test_image_sentinel_code_agrees():
+    """The literal duplicated in `deepseek_v4.py` must track the real code."""
+    # `deepseek_v4` imports aiter at module scope; the rest of this file does
+    # not, so only this one check is skipped on a runner without it.
+    pytest.importorskip("aiter")
+    from atom.models.deepseek_v4 import _IMAGE_SENTINEL
+
+    assert _IMAGE_SENTINEL == IMAGE
+
+
+def test_text_only_spans_are_all_zero():
+    """No image -> (0, 0) everywhere, which collapses to the causal window."""
+    ids = _seq([5, 6, 7, 8])
+    left, right = image_visible_spans(ids, VOCAB, MAX_IMG)
+    assert not left.any() and not right.any()
+
+    start, count = image_aware_extend_window(
+        np.arange(ids.size), left, right, WIN, WIN + MAX_IMG
+    )
+    pos = np.arange(ids.size)
+    np.testing.assert_array_equal(start, np.maximum(pos - WIN + 1, 0))
+    np.testing.assert_array_equal(count, np.minimum(pos + 1, WIN))
+
+
+def test_image_end_is_inside_its_own_span():
+    """`IMAGE_END` is visible from the block: its left side must be nonzero.
+
+    It is the one token whose membership comes from the `| is_end` disjunct
+    rather than the cumsum comparison, so it is easy to drop by accident.
+    """
+    ids = _seq([1, 2], _image_block(3), [9])
+    left, right = image_visible_spans(ids, VOCAB, MAX_IMG)
+    end_idx = int(np.flatnonzero(ids == VOCAB + IMAGE_END)[0])
+    assert left[end_idx] > 0
+    assert right[end_idx] == 0
+    # The token right after the block is outside it.
+    assert left[end_idx + 1] == 0 and right[end_idx + 1] == 0
+
+
+def test_image_tokens_see_forward_to_the_block_end():
+    ids = _seq([1, 2], _image_block(4), [9, 10])
+    left, right = image_visible_spans(ids, VOCAB, MAX_IMG)
+    start, count = image_aware_extend_window(
+        np.arange(ids.size),
+        left,
+        right,
+        WIN,
+        image_window_width(ids.size, WIN, MAX_IMG),
+    )
+    start_idx = int(np.flatnonzero(ids == VOCAB + IMAGE_START)[0])
+    end_idx = int(np.flatnonzero(ids == VOCAB + IMAGE_END)[0])
+    for t in range(start_idx, end_idx + 1):
+        last = start[t] + count[t] - 1
+        assert start[t] <= start_idx, f"token {t} cannot see the block start"
+        assert last >= end_idx, f"token {t} cannot see the block end"
+
+
+def test_spans_do_not_cross_a_sequence_boundary():
+    """Ragged batches resolve spans per sequence, not across the concatenation."""
+    a = _seq([1], _image_block(2))
+    b = _seq([2], _image_block(2))
+    ids = np.concatenate([a, b])
+    left, right = image_visible_spans(ids, VOCAB, MAX_IMG, seq_lens=[a.size, b.size])
+    # The last token of sequence A is its IMAGE_END; it must not see into B.
+    assert right[a.size - 1] == 0
+    # Sequence B's IMAGE_START must not reach back into A.
+    b_start = a.size + int(np.flatnonzero(b == VOCAB + IMAGE_START)[0])
+    assert left[b_start] == 0
+
+
+def test_unbalanced_span_is_rejected():
+    ids = _seq([1], [VOCAB + IMAGE_START], [VOCAB + IMAGE])  # no IMAGE_END
+    with pytest.raises(ValueError):
+        image_visible_spans(ids, VOCAB, MAX_IMG)
+
+
+def test_extend_window_is_bounded_by_the_column_budget():
+    ids = _seq([1, 2], _image_block(MAX_IMG + 40), [9])
+    left, right = image_visible_spans(ids, VOCAB, MAX_IMG)
+    width = image_window_width(ids.size, WIN, MAX_IMG)
+    _, count = image_aware_extend_window(np.arange(ids.size), left, right, WIN, width)
+    assert count.max() <= width

--- a/tests/test_prefill_indices_paged.py
+++ b/tests/test_prefill_indices_paged.py
@@ -246,3 +246,119 @@ def test_hca_k2_offsets_are_block_packed(hca_k2):
         f"(the HCA paged-gather bug)\n"
         f"got={ker.tolist()}\nexp={oracle.tolist()}"
     )
+
+
+# ---------------------------------------------------------------------------
+# In-image bidirectional visibility (DeepSeek-V4 vision)
+# ---------------------------------------------------------------------------
+
+
+def _visibility_case(geometry):
+    """One unchunked sequence holding a small image block.
+
+    Mirrors what `_build_paged_prefill_meta` hands the kernel on a vision
+    prefill: a per-token `(extend_start, extend_count)` widened to each image
+    token's whole span, with `chunk_start == 0` throughout.
+    """
+    from atom.models.deepseek_v4_vl import (
+        IMAGE,
+        IMAGE_END,
+        IMAGE_START,
+        image_aware_extend_window,
+        image_visible_spans,
+    )
+
+    vocab, max_img = 1000, 32
+    ids = (
+        [7, 8]
+        + [vocab + IMAGE_START]
+        + [vocab + IMAGE] * 9
+        + [vocab + IMAGE_END]
+        + [9, 10, 11]
+    )
+    total = len(ids)
+    positions = torch.arange(total, dtype=torch.int32, device=DEV)
+    bid_per_token = torch.zeros(total, dtype=torch.int32, device=DEV)
+    chunk_start = torch.zeros(1, dtype=torch.int32, device=DEV)
+    state_slot = torch.tensor([1], dtype=torch.int32, device=DEV)
+    block_tables = torch.zeros((1, 8), dtype=torch.int32, device=DEV)
+
+    left, right = image_visible_spans(np.array(ids), vocab, max_img)
+    start_np, count_np = image_aware_extend_window(
+        np.arange(total), left, right, WIN, WIN + max_img
+    )
+    extend_start = torch.tensor(start_np, dtype=torch.int32, device=DEV)
+    extend_count_t = torch.tensor(count_np, dtype=torch.int32, device=DEV)
+
+    # chunk_start == 0 everywhere, so there is no SWA/CSA prefix; HCA rows the
+    # reference derives from position still need room (same count as upstream's
+    # own case builds).
+    prefix_swa_count = np.zeros(total, dtype=np.int64)
+    n_hca = (np.arange(total, dtype=np.int64) + 1) // HCA_RATIO
+    ptrs = {
+        "extend_indptr": _indptr(count_np.astype(np.int64), total),
+        "prefix_swa_indptr": _indptr(prefix_swa_count, total),
+        "prefix_csa_indptr": _indptr(prefix_swa_count, total),
+        "prefix_hca_indptr": _indptr(n_hca, total),
+    }
+
+    def run(fn):
+        bufs = {
+            name.replace("_indptr", "_indices"): torch.full(
+                (max(int(p[-1]), 1),), -9, dtype=torch.int32, device=DEV
+            )
+            for name, p in ptrs.items()
+        }
+        fn(
+            positions=positions,
+            bid_per_token=bid_per_token,
+            chunk_start_per_seq=chunk_start,
+            cu_seqlens_q_per_seq=torch.zeros(1, dtype=torch.int32, device=DEV),
+            state_slot_per_seq=state_slot,
+            block_tables=block_tables,
+            T=total,
+            win=WIN,
+            geometry=geometry,
+            hca_ratio=HCA_RATIO,
+            extend_start=extend_start,
+            extend_count=extend_count_t,
+            **ptrs,
+            **bufs,
+        )
+        return bufs
+
+    return ids, vocab, count_np, ptrs, run
+
+
+def test_visibility_kernel_matches_reference(geometry=GEOMETRY):
+    _, _, _, _, run = _visibility_case(geometry)
+    ref = run(write_v4_paged_prefill_indices_reference)
+    ker = run(write_v4_paged_prefill_indices)
+    torch.cuda.synchronize()
+    assert torch.equal(ker["extend_indices"], ref["extend_indices"])
+
+
+def test_visibility_lets_image_tokens_read_forward(geometry=GEOMETRY):
+    """An in-image token's index list must include rows AFTER its own.
+
+    The whole point of the change: without it the kernel would still be causal
+    and every set-equality check against a causal reference would pass while
+    the model quietly never saw the rest of the image.
+    """
+    from atom.models.deepseek_v4_vl import IMAGE_END, IMAGE_START
+
+    ids, vocab, _count_np, ptrs, run = _visibility_case(geometry)
+    out = run(write_v4_paged_prefill_indices)["extend_indices"].cpu().numpy()
+    indptr = ptrs["extend_indptr"].cpu().numpy()
+
+    start_idx = ids.index(vocab + IMAGE_START)
+    end_idx = ids.index(vocab + IMAGE_END)
+    for t in range(len(ids)):
+        rows = out[indptr[t] : indptr[t + 1]]
+        assert rows.min() >= 0 and rows.max() < len(ids)
+        if start_idx <= t < end_idx:
+            assert rows.max() == end_idx, f"token {t} cannot see its IMAGE_END"
+            assert rows.min() <= start_idx, f"token {t} cannot see its IMAGE_START"
+        elif t < start_idx or t > end_idx:
+            # Outside any span the window stays strictly causal.
+            assert rows.max() == t, f"text token {t} reads the future"


### PR DESCRIPTION
Adds the vision path for DeepSeek-V4 checkpoints that ship a ViT + aligner. The tower is a pure-torch port of the checkpoint's reference `inference/vision.py`; vision is built conditionally on `vision_n_layers > 0`, mirroring the reference `Transformer.__init__`.

Two things make this model differ from a plain embedding substitution:

- MoE routing: image tokens select experts with a second per-layer bias (`gate.bias_vl`). `select_experts` only takes a `[E]` vector, so a Triton kernel does the per-token choice.
- Attention: tokens inside `[IMAGE_START, IMAGE_END]` attend both ways. The prefill kernel is index-driven with no causal mask, so this is a per-token `(extend_start, extend_count)` widening of the index range, not a kernel change. Text forwards pass neither and stay bit-identical.

Multimodal code also moves to its own `atom/multimodal/` package, with the per-model builders under `models/` and a Protocol for the builder contract.

Not supported: MTP/DSpark drafting, PCP, TBO, chunked multimodal prefill, TP-sharded ViT.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
