### PR TITLE
[CI] Add opt-in paired performance check for pull requests (ci:perf)

### DIFF
--- a/.github/scripts/perf_check_half.sh
+++ b/.github/scripts/perf_check_half.sh
@@ -34,6 +34,15 @@ esac
 OUT_DIR="perf-pair/${HALF}"
 mkdir -p "$OUT_DIR"
 
+echo "========== ${HALF}: reclaiming workspace ownership =========="
+# The container runs as root against a bind-mounted workspace, so anything it
+# writes (__pycache__, build output) ends up owned by root. The checkout and
+# clean below run as the runner user and fail with EACCES on those files, as
+# does the next job's actions/checkout. Hand them back before touching the
+# tree; the container is already up, so this costs nothing.
+docker exec "$CONTAINER" bash -lc \
+  "chown -R $(id -u):$(id -g) /workspace" || true
+
 echo "========== ${HALF}: checking out ${COMMIT} =========="
 # Discard whatever the previous half left behind before moving: a dirty tree
 # makes the checkout fail, and a half-applied one would measure neither commit.

--- a/.github/scripts/perf_check_half.sh
+++ b/.github/scripts/perf_check_half.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Run one half of the PR perf check pairing.
 #
-#   perf_check_half.sh <commit-sha> <base|head>
+#   perf_check_half.sh <commit-sha> <warmup|base|head|base2>
 #
 # The container is already running and has the workspace bind-mounted at
 # /workspace, so checking out a commit on the host is immediately visible
@@ -20,19 +20,39 @@
 set -euo pipefail
 
 COMMIT="${1:?commit sha required}"
-HALF="${2:?half must be 'base' or 'head'}"
+HALF="${2:?half must be one of warmup|base|head|base2}"
 
+# warmup  discarded; exists only to fill the JIT/autotune caches that persist
+#         inside the shared container. Without it the first measured half pays
+#         for populating them and the second reads 6-9% faster on identical
+#         code -- larger than the regression threshold, and in the direction
+#         that hides regressions rather than inventing them.
+# base2   a second measurement of the base commit, after head. Its distance
+#         from the first is the drift the pairing accumulated; without it a
+#         head-vs-base delta cannot be told apart from time passing.
 case "$HALF" in
-  base|head) ;;
-  *) echo "ERROR: half must be 'base' or 'head', got '$HALF'" >&2; exit 2 ;;
+  warmup|base|head|base2) ;;
+  *) echo "ERROR: half must be warmup|base|head|base2, got '$HALF'" >&2; exit 2 ;;
 esac
 
 : "${CONTAINER:?CONTAINER must be set}"
 : "${MODEL_PATH:?MODEL_PATH must be set}"
 : "${RESULT_FILENAME:?RESULT_FILENAME must be set}"
+# atom_test.sh reads CONC for every phase; the warmup additionally derives its
+# shortened prompt count from it. Checked here so a missing value fails with a
+# name rather than "unbound variable" from wherever it is first dereferenced.
+: "${CONC:?CONC must be set}"
 
 OUT_DIR="perf-pair/${HALF}"
 mkdir -p "$OUT_DIR"
+
+if [ "$HALF" = "warmup" ]; then
+  # A tenth of the usual prompt count. atom_test.sh already honours this, and
+  # the caches are filled by compiling and tuning kernels, not by request
+  # volume -- whether that holds is exactly what this run is measuring.
+  export NUM_PROMPTS_OVERRIDE="${WARMUP_PROMPTS:-$CONC}"
+  echo "warmup: NUM_PROMPTS_OVERRIDE=${NUM_PROMPTS_OVERRIDE} (results discarded)"
+fi
 
 echo "========== ${HALF}: reclaiming workspace ownership =========="
 # The container runs as root against a bind-mounted workspace, so anything it
@@ -77,6 +97,14 @@ echo "========== ${HALF}: stopping server =========="
 # the GPUs to actually free, and starting the next server against a partially
 # released device measures the teardown, not the commit.
 docker exec "$CONTAINER" bash -lc '.github/scripts/atom_test.sh stop'
+
+if [ "$HALF" = "warmup" ]; then
+  # Deliberately not collected: a warmup result that reached the judge would be
+  # indistinguishable from a measurement.
+  rm -f "${RESULT_FILENAME}"*.json
+  echo "warmup: results discarded"
+  exit 0
+fi
 
 echo "========== ${HALF}: collecting results =========="
 # Copy out before the next checkout wipes the tree. Nothing is judged here --

--- a/.github/scripts/perf_check_half.sh
+++ b/.github/scripts/perf_check_half.sh
@@ -42,6 +42,9 @@ esac
 # shortened prompt count from it. Checked here so a missing value fails with a
 # name rather than "unbound variable" from wherever it is first dereferenced.
 : "${CONC:?CONC must be set}"
+: "${ISL:?ISL must be set}"
+: "${OSL:?OSL must be set}"
+: "${RANDOM_RANGE_RATIO:?RANDOM_RANGE_RATIO must be set}"
 
 OUT_DIR="perf-pair/${HALF}"
 mkdir -p "$OUT_DIR"
@@ -85,10 +88,22 @@ echo ".github/scripts/atom_test.sh launch ${model_path} ${ARGS:-}" \
   | docker exec -i "$CONTAINER" bash -l
 
 echo "========== ${HALF}: running benchmark =========="
+# ISL/OSL/CONC/RANDOM_RANGE_RATIO are read by atom_test.sh itself, under
+# `set -u`, so a missing one aborts the benchmark after the model has already
+# loaded. In CI the container is started with them injected (via
+# atom-bench-container's container-env), which makes passing them here look
+# redundant -- until the container is started any other way and the run fails
+# with "ISL: unbound variable". Passing them explicitly removes the dependency
+# on how the container was created.
 docker exec \
   -e RESULT_FILENAME="${RESULT_FILENAME}" \
   -e SERVER_ARGS="${ARGS:-}" \
   -e BENCH_EXTRA_ARGS="${BENCH_EXTRA_ARGS:-}" \
+  -e ISL="${ISL}" \
+  -e OSL="${OSL}" \
+  -e CONC="${CONC}" \
+  -e RANDOM_RANGE_RATIO="${RANDOM_RANGE_RATIO}" \
+  -e NUM_PROMPTS_OVERRIDE="${NUM_PROMPTS_OVERRIDE:-}" \
   -e MP="$model_path" \
   "$CONTAINER" bash -lc '.github/scripts/atom_test.sh benchmark "$MP"'
 

--- a/.github/scripts/perf_check_half.sh
+++ b/.github/scripts/perf_check_half.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Run one half of the PR perf check pairing.
+#
+#   perf_check_half.sh <commit-sha> <base|head>
+#
+# The container is already running and has the workspace bind-mounted at
+# /workspace, so checking out a commit on the host is immediately visible
+# inside it. That is the whole reason both halves can share one container: the
+# pairing then holds machine, image and container instance fixed, and the only
+# thing that differs between the two measurements is the commit.
+#
+# Everything heavy is delegated to atom_test.sh, the same entry point the
+# nightly benchmark uses. Reimplementing launch/benchmark here would fork the
+# definition of "run a benchmark" and drift silently the first time upstream
+# tunes it.
+#
+# Expects from the caller's environment: CONTAINER, MODEL_PATH, ARGS,
+# RESULT_FILENAME, plus whatever atom_test.sh itself reads.
+
+set -euo pipefail
+
+COMMIT="${1:?commit sha required}"
+HALF="${2:?half must be 'base' or 'head'}"
+
+case "$HALF" in
+  base|head) ;;
+  *) echo "ERROR: half must be 'base' or 'head', got '$HALF'" >&2; exit 2 ;;
+esac
+
+: "${CONTAINER:?CONTAINER must be set}"
+: "${MODEL_PATH:?MODEL_PATH must be set}"
+: "${RESULT_FILENAME:?RESULT_FILENAME must be set}"
+
+OUT_DIR="perf-pair/${HALF}"
+mkdir -p "$OUT_DIR"
+
+echo "========== ${HALF}: checking out ${COMMIT} =========="
+# Discard whatever the previous half left behind before moving: a dirty tree
+# makes the checkout fail, and a half-applied one would measure neither commit.
+git checkout --force --detach "$COMMIT"
+git clean -fdx --exclude=perf-pair --exclude=.git
+git --no-pager log -1 --format='%H %s'
+
+if [ -n "${MODEL_HOST_ROOT:-}" ]; then
+  model_path="/models/${MODEL_PATH}"
+else
+  model_path="${MODEL_PATH}"
+fi
+
+echo "========== ${HALF}: launching server =========="
+# Piped through stdin so the container's bash parses the quoting in ARGS
+# exactly once. Substituting ARGS into a `bash -lc "..."` string instead
+# collides single-quoted JSON values with the outer quotes and strips them
+# (argparse then rejects the value). Mirrors benchmark-tmpl.yml.
+echo ".github/scripts/atom_test.sh launch ${model_path} ${ARGS:-}" \
+  | docker exec -i "$CONTAINER" bash -l
+
+echo "========== ${HALF}: running benchmark =========="
+docker exec \
+  -e RESULT_FILENAME="${RESULT_FILENAME}" \
+  -e SERVER_ARGS="${ARGS:-}" \
+  -e BENCH_EXTRA_ARGS="${BENCH_EXTRA_ARGS:-}" \
+  -e MP="$model_path" \
+  "$CONTAINER" bash -lc '.github/scripts/atom_test.sh benchmark "$MP"'
+
+echo "========== ${HALF}: stopping server =========="
+# Must complete before the next half checks out: atom_test.sh stop waits for
+# the GPUs to actually free, and starting the next server against a partially
+# released device measures the teardown, not the commit.
+docker exec "$CONTAINER" bash -lc '.github/scripts/atom_test.sh stop'
+
+echo "========== ${HALF}: collecting results =========="
+# Copy out before the next checkout wipes the tree. Nothing is judged here --
+# the pairing only has to produce two comparable sets of result JSON.
+found=0
+while IFS= read -r -d '' f; do
+  cp "$f" "$OUT_DIR/"
+  found=$((found + 1))
+done < <(find . -maxdepth 2 -name "${RESULT_FILENAME}*.json" -not -path './perf-pair/*' -print0)
+
+if [ "$found" -eq 0 ]; then
+  # Leave the directory empty rather than inventing a result. A missing half
+  # makes the pair unjudgeable, which the judge reports as insufficient
+  # coverage -- the one thing it must never do is read as a pass.
+  echo "::warning::${HALF}: no result JSON matching ${RESULT_FILENAME}*.json"
+else
+  echo "${HALF}: collected ${found} result file(s)"
+fi

--- a/.github/scripts/perf_check_half.sh
+++ b/.github/scripts/perf_check_half.sh
@@ -57,7 +57,7 @@ if [ "$HALF" = "warmup" ]; then
   # at c=64/128/256 across three machines. Launch and model load dominate a
   # phase (~10.4 of 17.6 min at c=64), so matching the measurement costs about
   # 14% of job wall clock rather than a whole extra phase.
-  export NUM_PROMPTS_OVERRIDE="${WARMUP_PROMPTS:-$(( CONC * 10 ))}"
+  export NUM_PROMPTS_OVERRIDE="${WARMUP_PROMPTS:-$(( CONC * ${WARMUP_MULT:-10} ))}"
   echo "warmup: NUM_PROMPTS_OVERRIDE=${NUM_PROMPTS_OVERRIDE} (results discarded)"
 fi
 

--- a/.github/scripts/perf_check_half.sh
+++ b/.github/scripts/perf_check_half.sh
@@ -50,10 +50,14 @@ OUT_DIR="perf-pair/${HALF}"
 mkdir -p "$OUT_DIR"
 
 if [ "$HALF" = "warmup" ]; then
-  # A tenth of the usual prompt count. atom_test.sh already honours this, and
-  # the caches are filled by compiling and tuning kernels, not by request
-  # volume -- whether that holds is exactly what this run is measuring.
-  export NUM_PROMPTS_OVERRIDE="${WARMUP_PROMPTS:-$CONC}"
+  # Same prompt count as the measurement. A tenth of it was tried first, on
+  # the theory that the caches are filled by compiling and tuning kernels
+  # rather than by request volume. That holds on MI308 (1.35% residual) and
+  # does not on MI355X, where run 34233036220 still showed +4.19/+5.65/+3.10%
+  # at c=64/128/256 across three machines. Launch and model load dominate a
+  # phase (~10.4 of 17.6 min at c=64), so matching the measurement costs about
+  # 14% of job wall clock rather than a whole extra phase.
+  export NUM_PROMPTS_OVERRIDE="${WARMUP_PROMPTS:-$(( CONC * 10 ))}"
   echo "warmup: NUM_PROMPTS_OVERRIDE=${NUM_PROMPTS_OVERRIDE} (results discarded)"
 fi
 

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -265,14 +265,8 @@ def judge_family(members, history_cv):
         "median_tpot_pct": statistics.median(tpots) if tpots else None,
         "n_down": sum(1 for t in tputs if t <= DOWN_EPS_PCT),
         "n_total": len(tputs),
-        "median_drift_pct": (
-            statistics.median(drifts)
-            if (
-                drifts := [
-                    m["drift_pct"] for m in judging if m["drift_pct"] is not None
-                ]
-            )
-            else None
+        "median_drift_pct": _median_or_none(
+            [m["drift_pct"] for m in judging if m["drift_pct"] is not None]
         ),
         "nonmonotonic": _nonmonotonic(judging),
         "escalations": _single_escalations(judging, history_cv),
@@ -312,6 +306,16 @@ def judge_family(members, history_cv):
     )
     result["status"] = "triggered" if triggered else "clean"
     return result
+
+
+def _median_or_none(values):
+    """Median, or None for an empty sample.
+
+    Spelled out rather than inlined with a walrus so the module keeps parsing
+    on older interpreters: CI runs 3.12, but this also has to run wherever
+    someone points it at a pair of result directories.
+    """
+    return statistics.median(values) if values else None
 
 
 def _nonmonotonic(judging):
@@ -445,16 +449,12 @@ def judge(pairs, history_cv, expected_entries=None):
         "n_missing": n_missing,
         "n_unclear": len(unclear),
         "n_drifted": len(drifted),
-        "median_drift_pct": (
-            statistics.median(d)
-            if (
-                d := [
-                    f["median_drift_pct"]
-                    for f in results
-                    if f.get("median_drift_pct") is not None
-                ]
-            )
-            else None
+        "median_drift_pct": _median_or_none(
+            [
+                f["median_drift_pct"]
+                for f in results
+                if f.get("median_drift_pct") is not None
+            ]
         ),
         "expected_entries": expected_entries,
         "scope": _scope(triggered, judged),
@@ -536,13 +536,15 @@ def _entry_rows(family):
     rows = []
     first = True
     for member in family["judging"] + family["reference"]:
-        role = "judge" if member["conc"] >= JUDGE_MIN_CONC else "ref"
-        judged = role == "judge"
+        judged = member["conc"] >= JUDGE_MIN_CONC
+        # The marker rides with the number rather than occupying its own
+        # column, and says what it does rather than naming a category: a reader
+        # should not have to reach the legend to learn that a row does not count.
+        label = f"{member['conc']}" if judged else f"{member['conc']} (not judged)"
         rows.append(
-            "| {entry} | {c} | {role} | {tput} | {ttft} | {tpot} | {drift} |".format(
+            "| {entry} | {c} | {tput} | {ttft} | {tpot} | {drift} |".format(
                 entry=family["model"] if first else "",
-                c=member["conc"],
-                role=role,
+                c=label,
                 tput=_pct(member["tput_pct"], bold=tripped and judged),
                 ttft=_pct(member["ttft_pct"]),
                 tpot=_pct(member["tpot_pct"]),
@@ -552,10 +554,10 @@ def _entry_rows(family):
         first = False
 
     if family["status"] == "insufficient":
-        rows.append("| | **median** | judge | insufficient | | | |")
+        rows.append("| | **median of judged** | insufficient | | | |")
     else:
         rows.append(
-            "| | **median** | judge | {tput} | {ttft} | {tpot} | {drift} |".format(
+            "| | **median of judged** | {tput} | {ttft} | {tpot} | {drift} |".format(
                 tput=_pct(family["median_tput_pct"], bold=tripped),
                 ttft="-",
                 tpot=_pct(family["median_tpot_pct"], bold=tripped),
@@ -572,8 +574,8 @@ def render(report, context):
         lines += [context, ""]
 
     lines += [
-        "| Entry | c | role | Tput | TTFT | TPOT | Drift |",
-        "|---|---|---|---|---|---|---|",
+        "| Model | Concurrency | Total Tput | TTFT | TPOT | Drift |",
+        "|---|---|---|---|---|---|",
     ]
     for family in report["families"]:
         lines += _entry_rows(family)
@@ -581,11 +583,13 @@ def render(report, context):
     lines += [
         "",
         (
-            f"`judge` = levels the verdict is drawn from (c >= {JUDGE_MIN_CONC}); "
-            f"`ref` = measured and shown but never judged, because low "
-            f"concurrency both manufactures false positives and dilutes real "
-            f"ones. `Drift` is how far the base commit moved between its two "
-            f"readings -- the floor on what this comparison can resolve."
+            f"**Concurrency** is how many requests are in flight at once. Only "
+            f"levels at or above {JUDGE_MIN_CONC} decide the verdict. The rows "
+            f"marked *(not judged)* were measured and are shown, but excluded "
+            f"from every calculation: at low concurrency the numbers swing "
+            f"enough to both invent regressions and hide real ones. They are "
+            f"here because dropping them entirely would leave no way to tell a "
+            f"small-batch problem from ordinary low-concurrency noise."
         ),
         "",
     ]
@@ -608,7 +612,7 @@ def render(report, context):
 
     if report["verdict"] == "inconclusive":
         lines.append(
-            "No entry reported enough judging levels. "
+            "No model reported enough judged levels. "
             "This is **not** a pass -- treat it as no signal."
         )
     elif report["verdict"] in ("clean", "partial", "unclear", "untrustworthy"):
@@ -685,10 +689,10 @@ def render(report, context):
     gaps = []
     if report["n_insufficient"]:
         gaps.append(
-            f"{report['n_insufficient']} entry(ies) reported too few judging levels"
+            f"{report['n_insufficient']} model(s) reported too few judged levels"
         )
     if report.get("n_missing"):
-        gaps.append(f"{report['n_missing']} entry(ies) reported nothing at all")
+        gaps.append(f"{report['n_missing']} model(s) reported nothing at all")
     if gaps:
         lines += ["", "Coverage gaps: " + "; ".join(gaps) + "."]
 

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -506,29 +506,11 @@ def _fmt(value, suffix="%"):
     return "n/a" if value is None else f"{value:+.1f}{suffix}"
 
 
-def _delta_table(report, members_key, concs, extra_cols=()):
-    """One row per entry over a fixed set of concurrency columns.
-
-    ``extra_cols`` appends per-family summary columns as (title, fn) pairs.
-    Cells belonging to a tripped family are emphasised so the eye lands on the
-    row that produced the verdict.
-    """
-    titles = [f"c={c}" for c in concs] + [t for t, _ in extra_cols]
-    rows = [
-        "| Entry | " + " | ".join(titles) + " |",
-        "|" + "---|" * (len(titles) + 1),
-    ]
-    for family in report["families"]:
-        tripped = family["status"] == "triggered"
-        by_conc = {m["conc"]: m["tput_pct"] for m in family[members_key]}
-        cells = []
-        for conc in concs:
-            value = by_conc.get(conc)
-            cell = "-" if value is None else f"{value:+.1f}%"
-            cells.append(f"**{cell}**" if tripped and value is not None else cell)
-        cells += [fn(family) for _, fn in extra_cols]
-        rows.append(f"| {family['model']} | " + " | ".join(cells) + " |")
-    return rows
+def _pct(value, bold=False):
+    if value is None:
+        return "-"
+    text = f"{value:+.1f}%"
+    return f"**{text}**" if bold else text
 
 
 def _median_cell(family):
@@ -538,43 +520,75 @@ def _median_cell(family):
     return f"**{text}**" if family["status"] == "triggered" else text
 
 
+def _entry_rows(family):
+    """One row per concurrency level, then the family's median.
+
+    Throughput, TTFT and TPOT are the three independent measurements here --
+    output throughput is total throughput divided by a constant (the prompt
+    length ratio, fixed by --ignore-eos), and ITL and E2EL are recoverable from
+    TTFT and TPOT. Listing those too would spend width without adding a fact.
+
+    Judging and reference levels share the table and are labelled, so the shape
+    stays visible: judging levels moving with the reference ones is a broad
+    change, reference levels moving alone is a small-batch path or noise.
+    """
+    tripped = family["status"] == "triggered"
+    rows = []
+    first = True
+    for member in family["judging"] + family["reference"]:
+        role = "judge" if member["conc"] >= JUDGE_MIN_CONC else "ref"
+        judged = role == "judge"
+        rows.append(
+            "| {entry} | {c} | {role} | {tput} | {ttft} | {tpot} | {drift} |".format(
+                entry=family["model"] if first else "",
+                c=member["conc"],
+                role=role,
+                tput=_pct(member["tput_pct"], bold=tripped and judged),
+                ttft=_pct(member["ttft_pct"]),
+                tpot=_pct(member["tpot_pct"]),
+                drift=_pct(member.get("drift_pct")),
+            )
+        )
+        first = False
+
+    if family["status"] == "insufficient":
+        rows.append("| | **median** | judge | insufficient | | | |")
+    else:
+        rows.append(
+            "| | **median** | judge | {tput} | {ttft} | {tpot} | {drift} |".format(
+                tput=_pct(family["median_tput_pct"], bold=tripped),
+                ttft="-",
+                tpot=_pct(family["median_tpot_pct"], bold=tripped),
+                drift=_pct(family.get("median_drift_pct")),
+            )
+        )
+    return rows
+
+
 def render(report, context):
-    """Render the PR comment body (concise; per-config detail lives in summary)."""
+    """Render the PR comment body."""
     lines = [_HEADLINE[report["verdict"]], ""]
     if context:
         lines += [context, ""]
 
-    judge_concs = sorted({m["conc"] for f in report["families"] for m in f["judging"]})
-    ref_concs = sorted({m["conc"] for f in report["families"] for m in f["reference"]})
+    lines += [
+        "| Entry | c | role | Tput | TTFT | TPOT | Drift |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for family in report["families"]:
+        lines += _entry_rows(family)
 
-    # --- judging levels (these, and only these, produce the verdict) --------
-    lines += [f"**Judging levels** (c >= {JUDGE_MIN_CONC})", ""]
-    lines += _delta_table(
-        report,
-        "judging",
-        judge_concs,
-        extra_cols=(
-            ("Median", _median_cell),
-            ("TPOT", lambda f: _fmt(f["median_tpot_pct"])),
-            ("Drift", lambda f: _fmt(f.get("median_drift_pct"))),
+    lines += [
+        "",
+        (
+            f"`judge` = levels the verdict is drawn from (c >= {JUDGE_MIN_CONC}); "
+            f"`ref` = measured and shown but never judged, because low "
+            f"concurrency both manufactures false positives and dilutes real "
+            f"ones. `Drift` is how far the base commit moved between its two "
+            f"readings -- the floor on what this comparison can resolve."
         ),
-    )
-
-    # --- reference levels (measured, shown, never judged) -------------------
-    if ref_concs:
-        lines += [
-            "",
-            (
-                f"**Reference levels** (c < {JUDGE_MIN_CONC}, not judged) -- shown "
-                f"so the shape is visible: judging levels moving together with "
-                f"these is a broad regression; these moving alone is a small-batch "
-                f"path issue or low-concurrency noise."
-            ),
-            "",
-        ]
-        lines += _delta_table(report, "reference", ref_concs)
-
-    lines.append("")
+        "",
+    ]
 
     # --- shape flags -------------------------------------------------------
     for family in report["families"]:
@@ -609,9 +623,9 @@ def render(report, context):
             lines.append(
                 f"The base commit was measured twice, before and after head, and "
                 f"the two readings differ by {_fmt(report['median_drift_pct'])} -- "
-                f"more than the {report['thresholds']['family_median_pct']}% the "
-                f"criterion is asked to resolve. Whatever moved between them would "
-                f"also have moved under head, so a delta this size cannot be "
+                f"more than the {thresholds['family_median_pct']}% the criterion "
+                f"is asked to resolve. Whatever moved between them would also "
+                f"have moved under head, so a delta this size cannot be "
                 f"attributed to the change."
             )
         if report["verdict"] == "unclear":

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -60,7 +60,13 @@ FAMILY_MEDIAN_PCT = -3.0  # family median throughput delta that trips the gate
 DOWN_EPS_PCT = -2.0  # a level counts as "down" past this
 TPOT_MIRROR_RATIO = 0.6  # |median TPOT delta / median tput delta| for mirroring
 NONMONOTONIC_MARGIN_PCT = 3.0  # interior level this far outside its neighbours
-MEASURED_RESIDUAL_BIAS_PCT = 1.35  # A/A residual after the warmup; see below
+# A/A residual after the warmup, measured on the platform this runs on.
+# MI308 gave 1.35% with a 1x-concurrency warmup; MI355X gave 4.19% under
+# the same warmup (run 34233036220: +4.19/+5.65/+3.10 at c=64/128/256, on
+# three separate machines, TPOT mirroring each one). The warmup now runs
+# the same prompt count as the measurement; update this to whatever that
+# leaves behind.
+MEASURED_RESIDUAL_BIAS_PCT = 4.19
 
 # --- Baseline sanity (crimson only) ----------------------------------------
 BASELINE_SANITY_PCT = -25.0  # base this far under main's recent median
@@ -809,16 +815,39 @@ def render(report, context):
     for family in report["families"]:
         lines += _entry_rows(family)
 
+    has_unjudged = any(
+        m["conc"] < JUDGE_MIN_CONC for f in report["families"] for m in f["members"]
+    )
+    legend = (
+        f"**Concurrency** is how many requests are in flight at once. Only "
+        f"levels at or above {JUDGE_MIN_CONC} decide the verdict."
+    )
+    # Only describe the marked rows when the run actually produced some.
+    # Explaining a marker that appears nowhere on the page sends the reader
+    # looking for something that is not there.
+    if has_unjudged:
+        legend += (
+            " The rows marked *(not judged)* were measured and are shown, but "
+            "excluded from every calculation: at low concurrency the numbers "
+            "swing enough to both invent regressions and hide real ones. They "
+            "are here because dropping them entirely would leave no way to "
+            "tell a small-batch problem from ordinary low-concurrency noise."
+        )
     lines += [
         "",
+        legend,
+        "",
+        # The paired measurement carries a systematic bias toward whichever
+        # half ran second, and it is large enough that a reader who takes a
+        # small positive number at face value will conclude the PR helped when
+        # nothing changed. Say so next to the table rather than only in the
+        # step summary, because the comment is what gets read.
         (
-            f"**Concurrency** is how many requests are in flight at once. Only "
-            f"levels at or above {JUDGE_MIN_CONC} decide the verdict. The rows "
-            f"marked *(not judged)* were measured and are shown, but excluded "
-            f"from every calculation: at low concurrency the numbers swing "
-            f"enough to both invent regressions and hide real ones. They are "
-            f"here because dropping them entirely would leave no way to tell a "
-            f"small-batch problem from ordinary low-concurrency noise."
+            f"> A residual bias of about {MEASURED_RESIDUAL_BIAS_PCT}% favours "
+            f"head even when both halves run identical code, so small positive "
+            f"numbers here mean *no change*, not an improvement. A drop trips "
+            f"at roughly {FAMILY_MEDIAN_PCT - MEASURED_RESIDUAL_BIAS_PCT:.2f}% "
+            f"rather than {FAMILY_MEDIAN_PCT}%."
         ),
         "",
     ]

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -34,12 +34,12 @@ levels is reported as ``insufficient``; if no family survives, the whole run is
 from __future__ import annotations
 
 import argparse
+import collections
 import json
 import re
 import statistics
 import sys
 import urllib.request
-from collections import defaultdict
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -67,6 +67,27 @@ BASELINE_SANITY_PCT = -25.0  # base this far under main's recent median
 BASELINE_SANITY_SIGMA = 2.5  # ... and clear of that configuration's own noise
 BASELINE_SANITY_MIN_LEVELS = 2  # ... on at least this many judged levels
 BASELINE_SANITY_MIN_POINTS = 6  # ... judged against at least this much history
+
+# --- Main-side drift (context, never a verdict on the PR) -------------------
+# Ported from the nightly monitor's trend criterion, with its constants intact.
+# A paired comparison cannot see a level that has been sliding for weeks: base
+# and head both sit on top of it, so the delta is honest and the absolute
+# number is not. This reads the same dashboard file already fetched for the
+# noise band and says so separately.
+#
+# Judged per family -- one model at one input/output shape, across its
+# concurrency levels -- because a single configuration's slope carries no
+# information. Measured across 414 configurations, the 14-day change is
+# symmetric: 18 below -10% and 22 above +10%. Amplitude alone cannot separate
+# signal from noise. Several independent levels sliding together can.
+DRIFT_MIN_CONC = 64  # small concurrency both invents and dilutes drift
+DRIFT_HORIZONS = (7, 14)  # days
+DRIFT_FAM_MIN_CONFIGS = 3  # levels needed before a family is judged
+DRIFT_MEDIAN_TH = -4.0  # family median change that counts as drift
+DRIFT_MIN_DOWN = 3  # ... on at least this many levels
+DRIFT_DOWN_EPS = -2.0  # a level counts as "down" past this
+DRIFT_TPOT_MIRROR = 0.6  # |TPOT change / throughput change| confirming it
+DRIFT_SMOOTH_K = 3  # points averaged at each end, to flatten run-to-run jitter
 
 # A paired comparison answers "did this change make it worse" and is blind to
 # "main was already broken": if base and head are both 20% down, the delta is
@@ -145,8 +166,12 @@ def _parse_data_js(text):
         return None
 
 
-def load_history_cv(source=None):
-    """Return {(model, isl_osl, conc): {"cv", "median", "n"}} from history.
+def load_history(source=None):
+    """Return (series, stats) from the dashboard history file.
+
+    ``series`` maps each configuration to its points in time, which the drift
+    criterion needs; ``stats`` is the per-configuration summary the noise band
+    and the baseline check use. Both come from one parse of one file.
 
     ``source`` may be a local path or None (fetch the public dashboard). Any
     failure yields an empty mapping -- the sigma gate is optional by design and
@@ -167,19 +192,24 @@ def load_history_cv(source=None):
             with urllib.request.urlopen(req, timeout=60) as resp:
                 text = resp.read().decode("utf-8", errors="replace")
     except (OSError, urllib.error.URLError):
-        return {}
+        return {}, {}
 
     data = _parse_data_js(text)
     if not data:
-        return {}
+        return {}, {}
 
     runs = []
     for entry in data.get("entries", {}).values():
         runs.extend(entry)
 
     seen_run_ids = set()
-    series = defaultdict(list)
-    name_re = re.compile(r"^(ATOM[^:]*)::(.+?)\s+(\d+/\d+)\s+c=(\d+)\s+Total Tput")
+    series = collections.defaultdict(list)
+    # Throughput and TPOT both, keyed together: the drift criterion confirms a
+    # slide by requiring TPOT to move the other way by a comparable amount,
+    # which separates a real slowdown from measurement wobble.
+    name_re = re.compile(
+        r"^(ATOM[^:]*)::(.+?)\s+(\d+/\d+)\s+c=(\d+)\s+(Total Tput|TPOT)"
+    )
 
     for run in sorted(runs, key=lambda r: r.get("date", 0)):
         benches = run.get("benches") or []
@@ -192,18 +222,25 @@ def load_history_cv(source=None):
             continue
         if run_id:
             seen_run_ids.add(run_id)
+        per_run = {}
         for bench in benches:
-            if bench.get("unit") != "tok/s":
+            if bench.get("unit") not in ("tok/s", "ms"):
                 continue
             match = name_re.match(bench.get("name", ""))
             if not match:
                 continue
             key = (match.group(2), match.group(3), int(match.group(4)))
-            series[key].append(bench.get("value"))
+            field = "tput" if match.group(5) == "Total Tput" else "tpot"
+            per_run.setdefault(key, {"date": run.get("date", 0)})[field] = bench.get(
+                "value"
+            )
+        for key, point in per_run.items():
+            if point.get("tput") is not None:
+                series[key].append(point)
 
     stats = {}
-    for key, values in series.items():
-        values = [v for v in values if isinstance(v, (int, float))]
+    for key, points in series.items():
+        values = [p["tput"] for p in points if p.get("tput") is not None]
         if len(values) < BASELINE_SANITY_MIN_POINTS:
             continue
         # The last few runs, not the whole window: a level that shifted weeks
@@ -217,7 +254,98 @@ def load_history_cv(source=None):
                 "median": median,
                 "n": len(recent),
             }
-    return stats
+    ordered = {
+        key: sorted(points, key=lambda p: p["date"]) for key, points in series.items()
+    }
+    return ordered, stats
+
+
+def _drift_lag(points, days, field):
+    """Change from `days` ago to now, each end averaged over DRIFT_SMOOTH_K
+    points so a single jumpy run does not set the slope. None when either end
+    is short of history."""
+    if not points:
+        return None
+    cutoff = points[-1]["date"] - days * 86400 * 1000
+    now = [p[field] for p in reversed(points) if p.get(field) is not None]
+    then = [
+        p[field] for p in points if p["date"] <= cutoff and p.get(field) is not None
+    ]
+    if len(now) < DRIFT_SMOOTH_K or len(then) < DRIFT_SMOOTH_K:
+        return None
+    base = statistics.mean(then[-DRIFT_SMOOTH_K:])
+    if not base:
+        return None
+    return (statistics.mean(now[:DRIFT_SMOOTH_K]) / base - 1) * 100
+
+
+def main_drift(series, models):
+    """Families on main that have been sliding, restricted to `models`.
+
+    Context for reading the paired result, never a judgement on the PR: base
+    and head both sit on top of whatever main is doing, so a slide leaves the
+    delta honest and the absolute number wrong. A reviewer told only "no
+    change" would take that as "fine".
+
+    Reports the worst horizon per family. Scoped to the models this run
+    measured -- listing every drifting family in the repository would bury the
+    one the reader is looking at.
+    """
+    families = collections.defaultdict(list)
+    for (model, isl_osl, conc), points in series.items():
+        if conc < DRIFT_MIN_CONC or model not in models:
+            continue
+        if len(points) < 2 * DRIFT_SMOOTH_K:
+            continue
+        families[(model, isl_osl)].append(sorted(points, key=lambda p: p["date"]))
+
+    found = []
+    for (model, isl_osl), members in families.items():
+        if len(members) < DRIFT_FAM_MIN_CONFIGS:
+            continue
+        worst = None
+        for horizon in DRIFT_HORIZONS:
+            tputs = [
+                d
+                for d in (_drift_lag(m, horizon, "tput") for m in members)
+                if d is not None
+            ]
+            tpots = [
+                d
+                for d in (_drift_lag(m, horizon, "tpot") for m in members)
+                if d is not None
+            ]
+            if len(tputs) < DRIFT_FAM_MIN_CONFIGS:
+                continue
+            median = statistics.median(tputs)
+            n_down = sum(1 for d in tputs if d <= DRIFT_DOWN_EPS)
+            median_tpot = statistics.median(tpots) if tpots else None
+            # Mirror confirmation: throughput down while TPOT goes up, by a
+            # comparable amount. Measurement wobble does not move the two in
+            # lockstep.
+            mirrored = (
+                median_tpot is not None
+                and median < 0
+                and median_tpot > 0
+                and abs(median_tpot / median) >= DRIFT_TPOT_MIRROR
+            )
+            tripped = (
+                median <= DRIFT_MEDIAN_TH and n_down >= DRIFT_MIN_DOWN and mirrored
+            )
+            if tripped and (worst is None or median < worst["median_pct"]):
+                worst = {
+                    "model": model,
+                    "isl_osl": isl_osl,
+                    "horizon_days": horizon,
+                    "median_pct": median,
+                    "median_tpot_pct": median_tpot,
+                    "n_down": n_down,
+                    "n_total": len(tputs),
+                }
+        if worst:
+            found.append(worst)
+    found.sort(key=lambda f: f["median_pct"])
+    return found
 
 
 # --------------------------------------------------------------------------
@@ -473,9 +601,9 @@ def _single_escalations(members, history_cv):
     return flags
 
 
-def judge(pairs, history_cv, expected_entries=None):
+def judge(pairs, history_cv, expected_entries=None, drift=None):
     """Two-layer verdict: per model entry, then across entries."""
-    families = defaultdict(list)
+    families = collections.defaultdict(list)
     for pair in pairs:
         families[(pair["backend"], pair["model"], pair["isl_osl"])].append(pair)
 
@@ -543,6 +671,9 @@ def judge(pairs, history_cv, expected_entries=None):
         "n_unclear": len(unclear),
         "n_drifted": len(drifted),
         "n_bad_baseline": len(bad_baseline),
+        # Context, deliberately outside the verdict: main sliding is not
+        # something this PR did, and folding it in would blame the author.
+        "main_drift": drift or [],
         "median_drift_pct": _median_or_none(
             [
                 f["median_drift_pct"]
@@ -718,6 +849,40 @@ def render(report, context):
                 "or the base half was contaminated and every number here is "
                 "measured against a bad one. Both need looking at before the PR "
                 "is judged on this."
+            ),
+            "",
+        ]
+
+    # --- main-side context, kept apart from the verdict --------------------
+    if report.get("main_drift"):
+        lines += [
+            "---",
+            "",
+            (
+                "**Main-side context — not caused by this PR.** The baseline "
+                "above was measured on main, and these models have been sliding "
+                "there. A paired comparison sits on top of that: the delta is "
+                "honest and the absolute level is not."
+            ),
+            "",
+            "| Model | Input/output | Window | Throughput | TPOT | Levels down |",
+            "|---|---|---|---|---|---|",
+        ]
+        for d in report["main_drift"]:
+            lines.append(
+                f"| {d['model']} | {d['isl_osl']} | {d['horizon_days']}d "
+                f"| {d['median_pct']:+.1f}% | {_fmt(d['median_tpot_pct'])} "
+                f"| {d['n_down']}/{d['n_total']} |"
+            )
+        lines += [
+            "",
+            (
+                "Read from the nightly history on the dashboard, over the "
+                "concurrency levels this check judges. Reported when several "
+                "levels of one model slide together and TPOT mirrors the move "
+                "-- a single level's slope carries no information, and across "
+                "414 configurations the 14-day change is symmetric enough that "
+                "amplitude alone cannot separate signal from noise."
             ),
             "",
         ]
@@ -936,8 +1101,13 @@ def main():
 
     # Only a path enables history. Reaching for the network because no flag was
     # given would put an outbound request behind an omission.
-    history_cv = load_history_cv(args.history) if args.history else {}
-    report = judge(pairs, history_cv, expected_entries=args.expect_entries)
+    if args.history:
+        history_series, history_cv = load_history(args.history)
+    else:
+        history_series, history_cv = {}, {}
+    models = {p["model"] for p in pairs}
+    drift = main_drift(history_series, models) if history_series else []
+    report = judge(pairs, history_cv, expected_entries=args.expect_entries, drift=drift)
     report["context"] = args.context
     report["n_pairs"] = len(pairs)
     report["history_configs"] = len(history_cv)

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -611,11 +611,11 @@ def _single_escalations(members, history_cv):
 
         reasons = []
         if delta <= DRAMATIC_PCT:
-            reasons.append(f"drop {delta:.1f}% exceeds {DRAMATIC_PCT:.0f}%")
+            reasons.append(f"past the {DRAMATIC_PCT:.0f}% mark")
         # Only judging levels reach this function, so there is no low-c caveat
         # left to apply -- every level here is one the verdict already trusts.
         if delta <= SINGLE_STANDS_ALONE_PCT:
-            reasons.append(f"c={member['conc']} dropped {delta:.1f}% on its own")
+            reasons.append("this level alone would qualify")
 
         hist = history_cv.get((member["model"], member["isl_osl"], member["conc"]))
         if hist and hist["cv"]:
@@ -786,7 +786,7 @@ def _median_cell(family):
     return f"**{text}**" if family["status"] == "triggered" else text
 
 
-def _entry_rows(family):
+def _entry_rows(family, show_drift=False):
     """One row per concurrency level, then the family's median.
 
     Throughput, TTFT and TPOT are the three independent measurements here --
@@ -806,28 +806,37 @@ def _entry_rows(family):
         # The marker rides with the number rather than occupying its own
         # column, and says what it does rather than naming a category: a reader
         # should not have to reach the legend to learn that a row does not count.
-        label = f"{member['conc']}" if judged else f"{member['conc']} (not judged)"
+        label = f"{member['conc']}" if judged else f"*{member['conc']}*"
         rows.append(
-            "| {entry} | {c} | {tput} | {ttft} | {tpot} | {drift} |".format(
+            "| {entry} | {c} | {tput} | {ttft} | {tpot} |{drift}".format(
                 entry=family["model"] if first else "",
                 c=label,
                 tput=_pct(member["tput_pct"], bold=tripped and judged),
                 ttft=_pct(member["ttft_pct"]),
                 tpot=_pct(member["tpot_pct"]),
-                drift=_pct(member.get("drift_pct")),
+                drift=(
+                    " {} |".format(_pct(member.get("drift_pct"))) if show_drift else ""
+                ),
             )
         )
         first = False
 
     if family["status"] == "insufficient":
-        rows.append("| | **median of judged** | insufficient | | | |")
+        rows.append(
+            "| | **median of judged** | insufficient | | |"
+            + (" |" if show_drift else "")
+        )
     else:
         rows.append(
-            "| | **median of judged** | {tput} | {ttft} | {tpot} | {drift} |".format(
+            "| | **median of judged** | {tput} | {ttft} | {tpot} |{drift}".format(
                 tput=_pct(family["median_tput_pct"], bold=tripped),
                 ttft="-",
                 tpot=_pct(family["median_tpot_pct"], bold=tripped),
-                drift=_pct(family.get("median_drift_pct")),
+                drift=(
+                    " {} |".format(_pct(family.get("median_drift_pct")))
+                    if show_drift
+                    else ""
+                ),
             )
         )
     return rows
@@ -839,31 +848,28 @@ def render(report, context):
     if context:
         lines += [context, ""]
 
+    # Drift only exists when the base was measured twice. Printing a column of
+    # dashes reads as missing data rather than as a phase that did not run.
+    show_drift = any(
+        m.get("drift_pct") is not None for f in report["families"] for m in f["members"]
+    )
     lines += [
-        "| Model | Concurrency | Total Tput | TTFT | TPOT | Drift |",
-        "|---|---|---|---|---|---|",
+        "| Model | Concurrency | Total Tput | TTFT | TPOT |"
+        + (" Drift |" if show_drift else ""),
+        "|---|---|---|---|---|" + ("---|" if show_drift else ""),
     ]
     for family in report["families"]:
-        lines += _entry_rows(family)
+        lines += _entry_rows(family, show_drift)
 
     has_unjudged = any(
         m["conc"] < JUDGE_MIN_CONC for f in report["families"] for m in f["members"]
     )
-    legend = (
-        f"**Concurrency** is how many requests are in flight at once. Only "
-        f"levels at or above {JUDGE_MIN_CONC} decide the verdict."
-    )
+    legend = f"Italic levels are measured but not judged (c < {JUDGE_MIN_CONC})."
     # Only describe the marked rows when the run actually produced some.
     # Explaining a marker that appears nowhere on the page sends the reader
     # looking for something that is not there.
-    if has_unjudged:
-        legend += (
-            " The rows marked *(not judged)* were measured and are shown, but "
-            "excluded from every calculation: at low concurrency the numbers "
-            "swing enough to both invent regressions and hide real ones. They "
-            "are here because dropping them entirely would leave no way to "
-            "tell a small-batch problem from ordinary low-concurrency noise."
-        )
+    if not has_unjudged:
+        legend = ""
     lines += [
         "",
         legend,
@@ -874,12 +880,9 @@ def render(report, context):
         # nothing changed. Say so next to the table rather than only in the
         # step summary, because the comment is what gets read.
         (
-            f"> Measured on identical code, the paired delta comes out at "
-            f"{MEASURED_RESIDUAL_BIAS_PCT}% with individual levels landing up "
-            f"to {RESIDUAL_SPREAD_PCT} points either side. Read a single level "
-            f"as carrying about that much slack, and treat anything inside it "
-            f"as no change. The verdict uses the family median across levels "
-            f"for the same reason."
+            f"> Identical code measures {MEASURED_RESIDUAL_BIAS_PCT}%, individual "
+            f"levels within {RESIDUAL_SPREAD_PCT} points of that. The verdict "
+            f"takes the family median for that reason."
         ),
         "",
     ]
@@ -950,36 +953,38 @@ def render(report, context):
             "",
         ]
 
+    # Held back and appended below the verdict. It is context, and printing
+    # it between the table and the reason for the verdict puts other
+    # models' problems ahead of this PR's on the way down the page.
+    # A "---" directly under a line of text is a setext heading in Markdown,
+    # not a rule: the sentence above it renders as a full-width H2. The blank
+    # line is load-bearing.
+    drift_lines = [""]
     # --- main-side context, kept apart from the verdict --------------------
     if report.get("main_drift"):
-        lines += [
+        drift_lines += [
             "---",
             "",
             (
-                "**Main-side context — not caused by this PR.** The baseline "
-                "above was measured on main, and these models have been sliding "
-                "there. A paired comparison sits on top of that: the delta is "
-                "honest and the absolute level is not."
+                "**Main-side context — not caused by this PR.** These models "
+                "are sliding on main; the delta above is honest, the absolute "
+                "level is not."
             ),
             "",
             "| Model | Input/output | Window | Throughput | TPOT | Levels down |",
             "|---|---|---|---|---|---|",
         ]
         for d in report["main_drift"]:
-            lines.append(
+            drift_lines.append(
                 f"| {d['model']} | {d['isl_osl']} | {d['horizon_days']}d "
                 f"| {d['median_pct']:+.1f}% | {_fmt(d['median_tpot_pct'])} "
                 f"| {d['n_down']}/{d['n_total']} |"
             )
-        lines += [
+        drift_lines += [
             "",
             (
-                "Read from the nightly history on the dashboard, over the "
-                "concurrency levels this check judges. Reported when several "
-                "levels of one model slide together and TPOT mirrors the move "
-                "-- a single level's slope carries no information, and across "
-                "414 configurations the 14-day change is symmetric enough that "
-                "amplitude alone cannot separate signal from noise."
+                "From nightly history: several levels of one model sliding "
+                "together, TPOT mirroring."
             ),
             "",
         ]
@@ -1071,10 +1076,20 @@ def render(report, context):
                 f"TPOT {_fmt(family['median_tpot_pct'])}"
                 + (f" (confirmed by {via}, ratio {ratio:.2f})" if ratio and via else "")
             )
-            for flag in family["escalations"]:
+            # One line per level repeating the same two reasons reads as
+            # padding. Keep the part that differs -- how far outside that
+            # level's own history it sits -- and state the shared reason once.
+            sigmas = [
+                (f["conc"], w)
+                for f in family["escalations"]
+                for w in f["why"]
+                if "sigma" in w
+            ]
+            if sigmas:
                 lines.append(
-                    f"  - c={flag['conc']} {flag['pct']:+.1f}%: "
-                    + "; ".join(flag["why"])
+                    "  - "
+                    + ", ".join(f"c={c} at {w.split(' the')[0]}" for c, w in sigmas)
+                    + " of that level's own history"
                 )
         if report["scope"]:
             lines += ["", _SCOPE_NOTE[report["scope"]]]
@@ -1110,14 +1125,8 @@ def render(report, context):
     if gaps:
         lines += ["", "Coverage gaps: " + "; ".join(gaps) + "."]
 
-    lines += [
-        "",
-        (
-            "This check does not block merge. It reports a measured delta "
-            "between the merge-base and the head commit; deciding whether it is "
-            "an acceptable trade-off is the reviewer's call."
-        ),
-    ]
+    lines += drift_lines
+    lines += ["", "Advisory. This check does not block merge."]
     return "\n".join(lines)
 
 
@@ -1152,7 +1161,7 @@ def render_summary(report, context):
     for family in report["families"]:
         for member in family["members"]:
             judged = member["conc"] >= JUDGE_MIN_CONC
-            conc = f"{member['conc']}" if judged else f"{member['conc']} (not judged)"
+            conc = f"{member['conc']}" if judged else f"*{member['conc']}*"
             row = [
                 family["model"],
                 member["isl_osl"],
@@ -1182,20 +1191,11 @@ def render_summary(report, context):
             else ")"
         ),
         "",
-        (
-            "Rows marked *(not judged)* were measured and are shown, but "
-            f"excluded from every calculation: below {JUDGE_MIN_CONC} requests "
-            "in flight the numbers swing enough to both invent regressions and "
-            "hide real ones."
-        ),
+        (f"Italic levels are measured but not judged " f"(c < {JUDGE_MIN_CONC})."),
         "",
         (
-            f"> Measured on identical code, the paired delta comes out at "
-            f"{MEASURED_RESIDUAL_BIAS_PCT}% with individual levels landing up "
-            f"to {RESIDUAL_SPREAD_PCT} points either side. The warmup removed "
-            f"the systematic part; what is left is spread, which is why the "
-            f"verdict is taken on the family median across levels rather than "
-            f"on any single one."
+            f"> Identical code measures {MEASURED_RESIDUAL_BIAS_PCT}%, individual "
+            f"levels within {RESIDUAL_SPREAD_PCT} points of that."
         ),
     ]
     return "\n".join(lines)

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -1,0 +1,720 @@
+#! /usr/bin/env python3
+"""Judge a paired base/head benchmark comparison for a pull request.
+
+Consumes the two result directories produced by the paired A/B step of the PR
+perf check (same job, same machine, same container image, same aiter wheel) and
+decides whether the head commit regressed.
+
+Usage:
+    python perf_judge.py --base-dir <dir> --head-dir <dir> \\
+        [--history data.js] [--output-json verdict.json] \\
+        [--comment-file comment.md] > "$GITHUB_STEP_SUMMARY"
+
+Design notes
+------------
+The primary criterion is *family linkage*, not a per-configuration threshold.
+A "family" here is one model entry (backend + display model + isl/osl); its
+members are the concurrency levels. Independent concurrency levels drifting in
+the same direction at the same time is far less likely than any single level
+moving, so linkage is the most noise-resistant signal available -- and, unlike a
+sigma gate, it needs no estimate of the noise band.
+
+The sigma gate is auxiliary only. Estimating sigma requires several historical
+points on the *same* container image, and those barely exist: across 52
+deduplicated perf runs on the public dashboard, 30 of 39 images were benchmarked
+exactly once and only 3 reached 3 runs. What history can offer is a cross-image
+estimate, which is inflated by image-to-image level shifts and therefore
+conservative (a loose gate that under-reports rather than over-reports).
+
+Incomplete data never produces a pass. A family that lost too many concurrency
+levels is reported as ``insufficient``; if no family survives, the whole run is
+``inconclusive``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from summarize import (  # the sys.path shim above must run first
+    _backend_name,
+    _config_key,
+    _display_model,
+    _pct_change,
+    load_results,
+)
+
+# --- Family linkage (primary criterion; independent of sigma) ---------------
+JUDGE_MIN_CONC = 64  # below this, a level is reference-only and never judged
+FAMILY_MIN_CONFIGS = 3  # judging levels needed before a family is judged
+FAMILY_MIN_DOWN = 3  # of those, how many must be down
+FAMILY_MEDIAN_PCT = -3.0  # family median throughput delta that trips the gate
+DOWN_EPS_PCT = -2.0  # a level counts as "down" past this
+TPOT_MIRROR_RATIO = 0.6  # |median TPOT delta / median tput delta| for mirroring
+NONMONOTONIC_MARGIN_PCT = 3.0  # interior level this far outside its neighbours
+
+# Low concurrency levels are excluded from the verdict but still measured and
+# still shown. They pollute a verdict in both directions: they manufacture false
+# positives (an entry whose large-concurrency levels sat at their historical
+# peak was flagged at -4.2% purely on c4..c32) and they dilute real ones (an
+# all-levels median of -7.1% was -12.0% when restricted to large concurrency).
+# Dropping them from the *display* as well, however, removes the very evidence a
+# reader needs to tell "small-batch path problem" from "small-c noise" -- so
+# they are reported alongside, labelled, and excluded from every computation.
+
+# FAMILY_MEDIAN_PCT is PROVISIONAL. It was derived by tightening the -4.0 used
+# for nightly time-series monitoring by one notch, on the reasoning that a
+# paired same-machine measurement is quieter than a cross-run comparison. It is
+# not backed by a measurement yet. Calibrate it against an A/A run (same commit,
+# same wheel, repeated) before treating a trip as authoritative.
+
+# --- Single-configuration escalation (auxiliary; uses history sigma) --------
+SINGLE_DROP_PCT = -8.0  # a lone level this far down is worth surfacing
+SIGMA_MULT = 2.5  # ... if it also clears this many historical sigmas
+SINGLE_STANDS_ALONE_PCT = -10.0  # a drop this large needs no corroboration
+DRAMATIC_PCT = -25.0  # too large to be ordinary variance at any concurrency
+
+# Metric keys in the benchmark result JSON.
+TPUT_KEY = "total_token_throughput"
+TPOT_KEY = "mean_tpot_ms"
+TTFT_KEY = "mean_ttft_ms"
+
+DASHBOARD_DATA_JS = "https://rocm.github.io/ATOM/benchmark-dashboard/data.js"
+
+
+# --------------------------------------------------------------------------
+# Historical noise band
+# --------------------------------------------------------------------------
+def _parse_data_js(text):
+    """Extract the BENCHMARK_DATA object from a data.js payload."""
+    start = text.find("{")
+    if start < 0:
+        return None
+    try:
+        return json.loads(text[start:].rstrip().rstrip(";"))
+    except json.JSONDecodeError:
+        return None
+
+
+def load_history_cv(source=None):
+    """Return {(model, isl_osl, conc): coefficient_of_variation} from history.
+
+    ``source`` may be a local path or None (fetch the public dashboard). Any
+    failure yields an empty mapping -- the sigma gate is optional by design and
+    must never block a verdict.
+
+    Points are deduplicated by Actions run id first: the dashboard republishes a
+    single run against several commits (9% of perf points in the sampled
+    window), and duplicates have zero spread, so leaving them in biases the
+    estimate toward "suspiciously stable".
+    """
+    try:
+        if source:
+            text = Path(source).read_text(encoding="utf-8")
+        else:
+            req = urllib.request.Request(
+                DASHBOARD_DATA_JS, headers={"User-Agent": "atom-perf-judge"}
+            )
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                text = resp.read().decode("utf-8", errors="replace")
+    except (OSError, urllib.error.URLError):
+        return {}
+
+    data = _parse_data_js(text)
+    if not data:
+        return {}
+
+    runs = []
+    for entry in data.get("entries", {}).values():
+        runs.extend(entry)
+
+    seen_run_ids = set()
+    series = defaultdict(list)
+    name_re = re.compile(r"^(ATOM[^:]*)::(.+?)\s+(\d+/\d+)\s+c=(\d+)\s+Total Tput")
+
+    for run in sorted(runs, key=lambda r: r.get("date", 0)):
+        benches = run.get("benches") or []
+        if not benches:
+            continue
+        extra = benches[0].get("extra") or ""
+        run_id_match = re.search(r"actions/runs/(\d+)", extra)
+        run_id = run_id_match.group(1) if run_id_match else None
+        if run_id and run_id in seen_run_ids:
+            continue
+        if run_id:
+            seen_run_ids.add(run_id)
+        for bench in benches:
+            if bench.get("unit") != "tok/s":
+                continue
+            match = name_re.match(bench.get("name", ""))
+            if not match:
+                continue
+            key = (match.group(2), match.group(3), int(match.group(4)))
+            series[key].append(bench.get("value"))
+
+    cv = {}
+    for key, values in series.items():
+        values = [v for v in values if isinstance(v, (int, float))]
+        if len(values) < 6:
+            continue
+        median = statistics.median(values)
+        if median:
+            cv[key] = statistics.pstdev(values) / median
+    return cv
+
+
+# --------------------------------------------------------------------------
+# Pairing
+# --------------------------------------------------------------------------
+def pair_results(base_results, head_results):
+    """Match head measurements to base measurements by configuration key."""
+    base_map = {_config_key(d): d for d in base_results}
+    pairs = []
+    for head in head_results:
+        key = _config_key(head)
+        base = base_map.get(key)
+        if base is None:
+            continue
+        base_tput = base.get(TPUT_KEY)
+        head_tput = head.get(TPUT_KEY)
+        if not base_tput or not head_tput:
+            continue
+        pairs.append(
+            {
+                "backend": _backend_name(head),
+                "model": _display_model(head),
+                "isl_osl": f"{head.get('random_input_len', 0)}/"
+                f"{head.get('random_output_len', 0)}",
+                "conc": int(head.get("max_concurrency", 0)),
+                "base_tput": base_tput,
+                "head_tput": head_tput,
+                "tput_pct": _pct_change(head_tput, base_tput),
+                "tpot_pct": _delta_or_none(base, head, TPOT_KEY),
+                "ttft_pct": _delta_or_none(base, head, TTFT_KEY),
+            }
+        )
+    return pairs
+
+
+def _delta_or_none(base, head, key):
+    base_value, head_value = base.get(key), head.get(key)
+    if not base_value or not head_value:
+        return None
+    return _pct_change(head_value, base_value)
+
+
+# --------------------------------------------------------------------------
+# Judgment
+# --------------------------------------------------------------------------
+def judge_family(members, history_cv):
+    """Judge one model entry from its concurrency levels.
+
+    Returns a dict with ``status`` in {triggered, clean, insufficient} plus the
+    evidence behind that call.
+    """
+    members = sorted(members, key=lambda m: m["conc"])
+    judging = [m for m in members if m["conc"] >= JUDGE_MIN_CONC]
+    reference = [m for m in members if m["conc"] < JUDGE_MIN_CONC]
+
+    tputs = [m["tput_pct"] for m in judging]
+    tpots = [m["tpot_pct"] for m in judging if m["tpot_pct"] is not None]
+
+    result = {
+        "backend": members[0]["backend"],
+        "model": members[0]["model"],
+        "isl_osl": members[0]["isl_osl"],
+        "members": members,
+        "judging": judging,
+        "reference": reference,
+        "median_tput_pct": statistics.median(tputs) if tputs else None,
+        "median_tpot_pct": statistics.median(tpots) if tpots else None,
+        "n_down": sum(1 for t in tputs if t <= DOWN_EPS_PCT),
+        "n_total": len(tputs),
+        "nonmonotonic": _nonmonotonic(judging),
+        "escalations": _single_escalations(judging, history_cv),
+    }
+
+    if len(tputs) < FAMILY_MIN_CONFIGS:
+        result["status"] = "insufficient"
+        result["reason"] = (
+            f"only {len(tputs)} of {FAMILY_MIN_CONFIGS} required judging levels "
+            f"(c >= {JUDGE_MIN_CONC}) reported"
+        )
+        return result
+
+    median_tput = result["median_tput_pct"]
+    median_tpot = result["median_tpot_pct"]
+
+    # Mirroring: throughput down while TPOT goes up, by a comparable magnitude.
+    # It separates a real slowdown from measurement wobble, which does not make
+    # the two metrics move in lockstep.
+    mirror = (
+        median_tpot is not None
+        and median_tput < 0
+        and median_tpot > 0
+        and abs(median_tpot / median_tput) >= TPOT_MIRROR_RATIO
+    )
+    result["mirror"] = mirror
+    result["mirror_ratio"] = (
+        abs(median_tpot / median_tput)
+        if (median_tpot is not None and median_tput)
+        else None
+    )
+
+    triggered = (
+        median_tput <= FAMILY_MEDIAN_PCT
+        and result["n_down"] >= FAMILY_MIN_DOWN
+        and mirror
+    )
+    result["status"] = "triggered" if triggered else "clean"
+    return result
+
+
+def _nonmonotonic(judging):
+    """Flag an interior level that sits well outside its immediate neighbours.
+
+    A median cannot express this shape at all: c=64 -8.6%, c=128 -0.3%,
+    c=256 -7.8% medians to -7.8% and reads as a clean two-sided drop, while the
+    actual signal is that one level behaves nothing like the ones around it --
+    often a kernel-selection fork. Worth surfacing verbatim rather than
+    summarising away.
+    """
+    if len(judging) < 3:
+        return None
+    outliers = []
+    for i in range(1, len(judging) - 1):
+        value = judging[i]["tput_pct"]
+        lo = min(judging[i - 1]["tput_pct"], judging[i + 1]["tput_pct"])
+        hi = max(judging[i - 1]["tput_pct"], judging[i + 1]["tput_pct"])
+        if value > hi + NONMONOTONIC_MARGIN_PCT or value < lo - NONMONOTONIC_MARGIN_PCT:
+            outliers.append(
+                {
+                    "conc": judging[i]["conc"],
+                    "pct": value,
+                    "neighbours": [judging[i - 1]["conc"], judging[i + 1]["conc"]],
+                    "neighbour_pcts": [
+                        judging[i - 1]["tput_pct"],
+                        judging[i + 1]["tput_pct"],
+                    ],
+                }
+            )
+    return outliers or None
+
+
+def _single_escalations(members, history_cv):
+    """Auxiliary per-level flags. Never on their own a family verdict."""
+    flags = []
+    for member in members:
+        delta = member["tput_pct"]
+        if delta > SINGLE_DROP_PCT:
+            continue
+
+        reasons = []
+        if delta <= DRAMATIC_PCT:
+            reasons.append(f"drop {delta:.1f}% exceeds {DRAMATIC_PCT:.0f}%")
+        # Only judging levels reach this function, so there is no low-c caveat
+        # left to apply -- every level here is one the verdict already trusts.
+        if delta <= SINGLE_STANDS_ALONE_PCT:
+            reasons.append(f"c={member['conc']} dropped {delta:.1f}% on its own")
+
+        cv = history_cv.get((member["model"], member["isl_osl"], member["conc"]))
+        if cv:
+            sigma_pct = cv * 100.0
+            if abs(delta) > SIGMA_MULT * sigma_pct:
+                reasons.append(
+                    f"{abs(delta) / sigma_pct:.1f}x the historical sigma "
+                    f"({sigma_pct:.2f}%)"
+                )
+            else:
+                # Inside the (conservative, cross-image) noise band: record the
+                # miss so the summary can say why nothing was escalated.
+                reasons.append(
+                    f"within {SIGMA_MULT}x historical sigma "
+                    f"({sigma_pct:.2f}%) -- not escalated"
+                )
+
+        if reasons and not any("not escalated" in r for r in reasons):
+            flags.append({"conc": member["conc"], "pct": delta, "why": reasons})
+    return flags
+
+
+def judge(pairs, history_cv, expected_entries=None):
+    """Two-layer verdict: per model entry, then across entries."""
+    families = defaultdict(list)
+    for pair in pairs:
+        families[(pair["backend"], pair["model"], pair["isl_osl"])].append(pair)
+
+    results = [judge_family(members, history_cv) for members in families.values()]
+    results.sort(
+        key=lambda r: (
+            {"triggered": 0, "insufficient": 1, "clean": 2}[r["status"]],
+            r["median_tput_pct"] if r["median_tput_pct"] is not None else 0,
+        )
+    )
+
+    triggered = [r for r in results if r["status"] == "triggered"]
+    judged = [r for r in results if r["status"] in ("triggered", "clean")]
+
+    # Entries that were expected but produced no usable pair at all (the whole
+    # job died) never reach ``results``, so they have to be counted separately.
+    n_missing = max(0, (expected_entries or 0) - len(results))
+    incomplete = (len(results) - len(judged)) + n_missing
+
+    # A positive finding stands on its own -- missing coverage elsewhere does
+    # not weaken it. But the absence of a finding is only as good as the
+    # coverage behind it, so anything short of full coverage downgrades to
+    # ``partial``: no regression *in what could be measured*, which is a
+    # different claim from "no regression".
+    # A non-monotonic family is one the criterion cannot describe: the median
+    # and the down-count both assume the levels behave alike, and here they do
+    # not. Reporting "clean" would be a claim the method does not support, so
+    # such a run is handed to the reader instead of summarised away.
+    unclear = [f for f in results if f.get("nonmonotonic")]
+
+    if triggered:
+        verdict = "regression"
+    elif not judged:
+        verdict = "inconclusive"
+    elif unclear:
+        verdict = "unclear"
+    elif incomplete:
+        verdict = "partial"
+    else:
+        verdict = "clean"
+
+    return {
+        "verdict": verdict,
+        "n_triggered": len(triggered),
+        "n_judged": len(judged),
+        "n_insufficient": len(results) - len(judged),
+        "n_missing": n_missing,
+        "n_unclear": len(unclear),
+        "expected_entries": expected_entries,
+        "scope": _scope(triggered, judged),
+        "families": results,
+        "thresholds": {
+            "family_median_pct": FAMILY_MEDIAN_PCT,
+            "family_min_down": FAMILY_MIN_DOWN,
+            "family_min_configs": FAMILY_MIN_CONFIGS,
+            "tpot_mirror_ratio": TPOT_MIRROR_RATIO,
+            "family_median_pct_is_provisional": True,
+        },
+    }
+
+
+def _scope(triggered, judged):
+    """Second layer: how wide is the blast radius."""
+    if not triggered:
+        return None
+    if len(triggered) == len(judged) and len(judged) > 1:
+        return "all_entries"
+    if len(triggered) == 1:
+        return "single_entry"
+    return "several_entries"
+
+
+# --------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------
+_HEADLINE = {
+    "clean": "### No significant performance change",
+    "partial": "### No regression found, but coverage was incomplete",
+    "unclear": "### Needs a look -- levels moved, but not in a shape the criterion can judge",
+    "regression": "### Performance regression detected",
+    "inconclusive": "### Inconclusive -- not enough data",
+}
+
+_SCOPE_NOTE = {
+    "all_entries": (
+        "Every judged entry moved, which points at a shared path "
+        "(kernel / attention / scheduler) rather than one model."
+    ),
+    "single_entry": "Only one entry moved, which points at a model-specific path.",
+    "several_entries": "Several but not all entries moved.",
+}
+
+
+def _fmt(value, suffix="%"):
+    return "n/a" if value is None else f"{value:+.1f}{suffix}"
+
+
+def _delta_table(report, members_key, concs, extra_cols=()):
+    """One row per entry over a fixed set of concurrency columns.
+
+    ``extra_cols`` appends per-family summary columns as (title, fn) pairs.
+    Cells belonging to a tripped family are emphasised so the eye lands on the
+    row that produced the verdict.
+    """
+    titles = [f"c={c}" for c in concs] + [t for t, _ in extra_cols]
+    rows = [
+        "| Entry | " + " | ".join(titles) + " |",
+        "|" + "---|" * (len(titles) + 1),
+    ]
+    for family in report["families"]:
+        tripped = family["status"] == "triggered"
+        by_conc = {m["conc"]: m["tput_pct"] for m in family[members_key]}
+        cells = []
+        for conc in concs:
+            value = by_conc.get(conc)
+            cell = "-" if value is None else f"{value:+.1f}%"
+            cells.append(f"**{cell}**" if tripped and value is not None else cell)
+        cells += [fn(family) for _, fn in extra_cols]
+        rows.append(f"| {family['model']} | " + " | ".join(cells) + " |")
+    return rows
+
+
+def _median_cell(family):
+    if family["status"] == "insufficient":
+        return "insufficient"
+    text = _fmt(family["median_tput_pct"])
+    return f"**{text}**" if family["status"] == "triggered" else text
+
+
+def render(report, context):
+    """Render the PR comment body (concise; per-config detail lives in summary)."""
+    lines = [_HEADLINE[report["verdict"]], ""]
+    if context:
+        lines += [context, ""]
+
+    judge_concs = sorted({m["conc"] for f in report["families"] for m in f["judging"]})
+    ref_concs = sorted({m["conc"] for f in report["families"] for m in f["reference"]})
+
+    # --- judging levels (these, and only these, produce the verdict) --------
+    lines += [f"**Judging levels** (c >= {JUDGE_MIN_CONC})", ""]
+    lines += _delta_table(
+        report,
+        "judging",
+        judge_concs,
+        extra_cols=(
+            ("Median", _median_cell),
+            ("TPOT", lambda f: _fmt(f["median_tpot_pct"])),
+        ),
+    )
+
+    # --- reference levels (measured, shown, never judged) -------------------
+    if ref_concs:
+        lines += [
+            "",
+            (
+                f"**Reference levels** (c < {JUDGE_MIN_CONC}, not judged) -- shown "
+                f"so the shape is visible: judging levels moving together with "
+                f"these is a broad regression; these moving alone is a small-batch "
+                f"path issue or low-concurrency noise."
+            ),
+            "",
+        ]
+        lines += _delta_table(report, "reference", ref_concs)
+
+    lines.append("")
+
+    # --- shape flags -------------------------------------------------------
+    for family in report["families"]:
+        for flag in family.get("nonmonotonic") or []:
+            lo, hi = flag["neighbour_pcts"]
+            a, b = flag["neighbours"]
+            lines += [
+                (
+                    f"**{family['model']}: c={flag['conc']} at {flag['pct']:+.1f}% "
+                    f"does not follow its neighbours** (c={a} {lo:+.1f}%, "
+                    f"c={b} {hi:+.1f}%). A median cannot express this shape; it "
+                    f"often indicates a kernel-selection fork rather than a "
+                    f"uniform slowdown."
+                ),
+                "",
+            ]
+
+    if report["verdict"] == "inconclusive":
+        lines.append(
+            "No entry reported enough judging levels. "
+            "This is **not** a pass -- treat it as no signal."
+        )
+    elif report["verdict"] in ("clean", "partial", "unclear"):
+        thresholds = report["thresholds"]
+        lines.append(
+            f"No judged entry tripped (family median <= "
+            f"{thresholds['family_median_pct']}% and >= "
+            f"{thresholds['family_min_down']} judging levels down and TPOT "
+            f"mirroring)."
+        )
+        if report["verdict"] == "unclear":
+            lines.append(
+                "The linkage criterion (median + count) assumes the judging "
+                "levels move alike. At least one entry above does not, so no "
+                "verdict is claimed either way -- read the per-level numbers."
+            )
+        if report["verdict"] == "partial":
+            lines.append(
+                f"**{report['n_judged']} of "
+                f"{report['expected_entries'] or 'an unknown number of'} entries "
+                f"were judged.** The rest did not report enough data, so this is "
+                f"not a clean bill of health -- only the absence of a finding in "
+                f"the part that was measured."
+            )
+    else:
+        for family in report["families"]:
+            if family["status"] != "triggered":
+                continue
+            ratio = family.get("mirror_ratio")
+            lines.append(
+                f"- **{family['model']}**: {family['n_down']}/{family['n_total']} "
+                f"judging levels down, median {_fmt(family['median_tput_pct'])}, "
+                f"TPOT {_fmt(family['median_tpot_pct'])}"
+                + (f" (mirror ratio {ratio:.2f})" if ratio else "")
+            )
+            for flag in family["escalations"]:
+                lines.append(
+                    f"  - c={flag['conc']} {flag['pct']:+.1f}%: "
+                    + "; ".join(flag["why"])
+                )
+        if report["scope"]:
+            lines += ["", _SCOPE_NOTE[report["scope"]]]
+
+    # An entry that could not be judged may still have reported levels that
+    # dropped hard. Burying that under "no regression found" is the same
+    # failure as passing on incomplete data, one step removed -- so say it.
+    for family in report["families"]:
+        if family["status"] != "insufficient":
+            continue
+        bad = [m for m in family["judging"] if m["tput_pct"] <= DOWN_EPS_PCT]
+        if not bad:
+            continue
+        levels = ", ".join(f"c={m['conc']} {m['tput_pct']:+.1f}%" for m in bad)
+        lines += [
+            "",
+            (
+                f"**{family['model']} could not be judged, but the judging "
+                f"level(s) that did report were down: {levels}.** Too few levels "
+                f"arrived to apply the linkage criterion -- this is missing "
+                f"evidence, not evidence of absence. Re-run before reading the "
+                f"result as a pass."
+            ),
+        ]
+
+    gaps = []
+    if report["n_insufficient"]:
+        gaps.append(
+            f"{report['n_insufficient']} entry(ies) reported too few judging levels"
+        )
+    if report.get("n_missing"):
+        gaps.append(f"{report['n_missing']} entry(ies) reported nothing at all")
+    if gaps:
+        lines += ["", "Coverage gaps: " + "; ".join(gaps) + "."]
+
+    lines += [
+        "",
+        (
+            "This check does not block merge. It reports a measured delta "
+            "between the merge-base and the head commit; deciding whether it is "
+            "an acceptable trade-off is the reviewer's call."
+        ),
+    ]
+    return "\n".join(lines)
+
+
+def render_summary(report, context):
+    """Render the full step-summary table, one row per configuration."""
+    lines = ["## PR performance check", ""]
+    if context:
+        lines += [context, ""]
+    lines += [
+        "| Entry | isl/osl | conc | role | base | head | tput | TPOT | TTFT |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for family in report["families"]:
+        for member in family["members"]:
+            role = "judging" if member["conc"] >= JUDGE_MIN_CONC else "reference"
+            lines.append(
+                f"| {family['model']} | {member['isl_osl']} | {member['conc']} "
+                f"| {role} "
+                f"| {member['base_tput']:.1f} | {member['head_tput']:.1f} "
+                f"| {member['tput_pct']:+.2f}% | {_fmt(member['tpot_pct'])} "
+                f"| {_fmt(member['ttft_pct'])} |"
+            )
+    lines += [
+        "",
+        f"Verdict: **{report['verdict']}** "
+        f"({report['n_triggered']} triggered / {report['n_judged']} judged / "
+        f"{report['n_insufficient']} insufficient / "
+        f"{report.get('n_missing', 0)} missing"
+        + (
+            f" / {report['expected_entries']} expected)"
+            if report.get("expected_entries")
+            else ")"
+        ),
+        "",
+        (
+            "> The family-median threshold is provisional and not yet calibrated "
+            "against a repeated same-commit (A/A) measurement."
+        ),
+    ]
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(
+        description="Judge a paired base/head PR benchmark comparison"
+    )
+    parser.add_argument("--base-dir", required=True)
+    parser.add_argument("--head-dir", required=True)
+    parser.add_argument(
+        "--history",
+        default=None,
+        help="Local data.js for the sigma gate; omit to fetch the dashboard",
+    )
+    parser.add_argument(
+        "--no-history",
+        action="store_true",
+        help="Skip the sigma gate entirely (family linkage still applies)",
+    )
+    parser.add_argument(
+        "--expect-entries",
+        type=int,
+        default=None,
+        help="How many model entries the matrix was supposed to produce. "
+        "Without it, an entry whose job died entirely is invisible and the "
+        "verdict can read as clean on partial coverage.",
+    )
+    parser.add_argument("--context", default="", help="Line of provenance text")
+    parser.add_argument("--output-json")
+    parser.add_argument("--comment-file")
+    args = parser.parse_args()
+
+    base_results = load_results(args.base_dir, recursive=True)
+    head_results = load_results(args.head_dir, recursive=True)
+    pairs = pair_results(base_results, head_results)
+
+    if not pairs:
+        print("No base/head pairs matched -- nothing to judge.", file=sys.stderr)
+
+    history_cv = {} if args.no_history else load_history_cv(args.history)
+    report = judge(pairs, history_cv, expected_entries=args.expect_entries)
+    report["context"] = args.context
+    report["n_pairs"] = len(pairs)
+    report["history_configs"] = len(history_cv)
+
+    print(render_summary(report, args.context))
+
+    if args.comment_file:
+        Path(args.comment_file).write_text(
+            render(report, args.context), encoding="utf-8"
+        )
+    if args.output_json:
+        Path(args.output_json).write_text(
+            json.dumps(report, indent=2, default=str), encoding="utf-8"
+        )
+
+    # Always exit 0: this check informs the reviewer, it does not gate the merge.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -855,7 +855,7 @@ def render(report, context):
     # in the per-level table. The breakdown is one click away and carries the
     # shape the criterion actually rests on.
     lines += [
-        "| Model | Levels down | Total Tput | TPOT | TTFT |",
+        "| Model | Levels slower | Total Tput | TPOT | TTFT |",
         "|---|---|---|---|---|",
     ]
     for family in report["families"]:
@@ -864,7 +864,7 @@ def render(report, context):
             lines.append("| {} | insufficient | | | |".format(family["model"]))
             continue
         lines.append(
-            "| {model} | {down}/{tot} | {tput} | {tpot} | {ttft} |".format(
+            "| {model} | {down} of {tot} | {tput} | {tpot} | {ttft} |".format(
                 model=(
                     "**{}**".format(family["model"]) if tripped else family["model"]
                 ),
@@ -989,7 +989,7 @@ def render(report, context):
             "<summary><b>Sliding on main — not this PR</b> "
             "({} {})</summary>".format(n, "family" if n == 1 else "families"),
             "",
-            "| Model | Input/output | Window | Throughput | TPOT | Levels down |",
+            "| Model | Input/output | Window | Throughput | TPOT | Levels slower |",
             "|---|---|---|---|---|---|",
         ]
         for d in report["main_drift"]:
@@ -1090,8 +1090,9 @@ def render(report, context):
                 else family.get("mirror_ratio")
             )
             lines.append(
-                f"- **{family['model']}**: {family['n_down']}/{family['n_total']} "
-                f"judging levels down, median {_fmt(family['median_tput_pct'])}, "
+                f"- **{family['model']}**: {family['n_down']} of "
+                f"{family['n_total']} levels slower, median "
+                f"{_fmt(family['median_tput_pct'])}, "
                 f"TPOT {_fmt(family['median_tpot_pct'])}"
                 + (f" (confirmed by {via}, ratio {ratio:.2f})" if ratio and via else "")
             )

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -87,6 +87,13 @@ BASELINE_SANITY_MIN_POINTS = 6  # ... judged against at least this much history
 # by the onset instead -- see _level_window.
 LEVEL_WINDOW = 3
 VAR_WINDOW = 8
+# The best main has sustained, over all recorded history rather than a window.
+# A windowed peak forgets: once the good runs roll out of it the baseline falls
+# with them, the shortfall shrinks, and a level that never recovered reads as
+# recovered. Upstream hit exactly that -- a family closed as healthy while
+# sitting 12.3% under its peak. Three-point rolling mean rather than a single
+# best run, so one lucky night cannot become the anchor.
+ANCHOR_ROLL = 3
 
 # --- Main-side drift (context, never a verdict on the PR) -------------------
 # Ported from the nightly monitor's trend criterion, with its constants intact.
@@ -274,10 +281,9 @@ def load_history(source=None):
             stats[key] = {
                 "cv": statistics.pstdev(var) / median,
                 "median": median,
-                # Best of the same window the level came from. The median says
-                # what main does now; the best says how good it has been, which
-                # is what a reader asks when the paired delta is near zero.
-                "peak": max(level),
+                # Deliberately not from the level window: this is the number
+                # that must not move as history rolls forward.
+                "peak": _anchor(values),
                 "n": len(level),
             }
     ordered = {
@@ -303,6 +309,22 @@ def _drift_lag(points, days, field):
     if not base:
         return None
     return (statistics.mean(now[:DRIFT_SMOOTH_K]) / base - 1) * 100
+
+
+def _anchor(values):
+    """The best level main has sustained, over everything on record.
+
+    Not a window and not a single run: the maximum of a three-point rolling
+    mean across the whole series. A window would let a drop age out of the
+    comparison, which turns a permanent regression into the new normal; a
+    single run would anchor on one good night.
+    """
+    if len(values) < ANCHOR_ROLL:
+        return max(values) if values else None
+    return max(
+        statistics.mean(values[i : i + ANCHOR_ROLL])
+        for i in range(len(values) - ANCHOR_ROLL + 1)
+    )
 
 
 def _level_window(points):
@@ -1163,7 +1185,7 @@ def render(report, context):
 
     if rows:
         drift_lines += [
-            "| Model | isl/osl | vs recent median | vs recent best | Main trend |",
+            "| Model | isl/osl | vs main now | vs main peak | Main trend |",
             "|---|---|---|---|---|",
         ]
         for family in rows:
@@ -1199,13 +1221,14 @@ def render(report, context):
         drift_lines += [
             "",
             (
-                "Against main's recent nightly runs at the same "
-                "configuration -- the last 3, or everything since the step if "
-                "one is visible, so a median never straddles a level change. "
-                "The comparison crosses container images, where the spread is "
-                "11-21% against 0.6% within one image; read it for order of "
-                "magnitude. Trend is the nightly monitor's criterion, dated "
-                "from the data rather than from the window."
+                "*now* is main's current level -- the last 3 nightly runs, or "
+                "everything since the step when one is visible, so a median "
+                "never straddles a level change. *peak* is the best main has "
+                "sustained across all recorded history, which does not move as "
+                "history rolls forward: a drop that ages out of every window "
+                "still shows here. Both cross container images, where the "
+                "spread is 11-21% against 0.6% within one image; read them for "
+                "order of magnitude."
             ),
         ]
         measured = {(f["model"], f["isl_osl"]) for f in rows}

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -60,6 +60,15 @@ FAMILY_MEDIAN_PCT = -3.0  # family median throughput delta that trips the gate
 DOWN_EPS_PCT = -2.0  # a level counts as "down" past this
 TPOT_MIRROR_RATIO = 0.6  # |median TPOT delta / median tput delta| for mirroring
 NONMONOTONIC_MARGIN_PCT = 3.0  # interior level this far outside its neighbours
+DRIFT_TRUST_PCT = 3.0  # base repeated this far apart -> the pairing cannot resolve
+
+# The base commit is measured twice, before and after head. The distance
+# between those two readings is drift the pairing accumulated -- caches warming,
+# clocks settling, a neighbour arriving -- and it bounds what the comparison can
+# resolve. A head-vs-base delta smaller than the drift is not a measurement of
+# the change; it is a measurement of time passing. Where both readings exist the
+# baseline is their mean, which cancels drift to first order, and the residual
+# drift is reported so the reader can see how much was cancelled.
 
 # Low concurrency levels are excluded from the verdict but still measured and
 # still shown. They pollute a verdict in both directions: they manufacture false
@@ -174,9 +183,15 @@ def load_history_cv(source=None):
 # --------------------------------------------------------------------------
 # Pairing
 # --------------------------------------------------------------------------
-def pair_results(base_results, head_results):
-    """Match head measurements to base measurements by configuration key."""
+def pair_results(base_results, head_results, base2_results=None):
+    """Match head measurements to base measurements by configuration key.
+
+    ``base2_results`` is an optional second reading of the base commit taken
+    after head. When present the baseline is the mean of the two readings and
+    the drift between them is carried through for reporting.
+    """
     base_map = {_config_key(d): d for d in base_results}
+    base2_map = {_config_key(d): d for d in (base2_results or [])}
     pairs = []
     for head in head_results:
         key = _config_key(head)
@@ -187,6 +202,15 @@ def pair_results(base_results, head_results):
         head_tput = head.get(TPUT_KEY)
         if not base_tput or not head_tput:
             continue
+        base2 = base2_map.get(key)
+        base2_tput = base2.get(TPUT_KEY) if base2 else None
+        if base2_tput:
+            baseline = (base_tput + base2_tput) / 2
+            drift_pct = _pct_change(base2_tput, base_tput)
+        else:
+            baseline = base_tput
+            drift_pct = None
+
         pairs.append(
             {
                 "backend": _backend_name(head),
@@ -195,8 +219,11 @@ def pair_results(base_results, head_results):
                 f"{head.get('random_output_len', 0)}",
                 "conc": int(head.get("max_concurrency", 0)),
                 "base_tput": base_tput,
+                "base2_tput": base2_tput,
                 "head_tput": head_tput,
-                "tput_pct": _pct_change(head_tput, base_tput),
+                "baseline_tput": baseline,
+                "drift_pct": drift_pct,
+                "tput_pct": _pct_change(head_tput, baseline),
                 "tpot_pct": _delta_or_none(base, head, TPOT_KEY),
                 "ttft_pct": _delta_or_none(base, head, TTFT_KEY),
             }
@@ -238,6 +265,15 @@ def judge_family(members, history_cv):
         "median_tpot_pct": statistics.median(tpots) if tpots else None,
         "n_down": sum(1 for t in tputs if t <= DOWN_EPS_PCT),
         "n_total": len(tputs),
+        "median_drift_pct": (
+            statistics.median(drifts)
+            if (
+                drifts := [
+                    m["drift_pct"] for m in judging if m["drift_pct"] is not None
+                ]
+            )
+            else None
+        ),
         "nonmonotonic": _nonmonotonic(judging),
         "escalations": _single_escalations(judging, history_cv),
     }
@@ -379,10 +415,21 @@ def judge(pairs, history_cv, expected_entries=None):
     # such a run is handed to the reader instead of summarised away.
     unclear = [f for f in results if f.get("nonmonotonic")]
 
-    if triggered:
+    # Drift larger than the threshold the criterion is asked to resolve means
+    # the comparison cannot answer the question, whatever the deltas look like.
+    drifted = [
+        f
+        for f in results
+        if f.get("median_drift_pct") is not None
+        and abs(f["median_drift_pct"]) > DRIFT_TRUST_PCT
+    ]
+
+    if triggered and not drifted:
         verdict = "regression"
     elif not judged:
         verdict = "inconclusive"
+    elif drifted:
+        verdict = "untrustworthy"
     elif unclear:
         verdict = "unclear"
     elif incomplete:
@@ -397,6 +444,18 @@ def judge(pairs, history_cv, expected_entries=None):
         "n_insufficient": len(results) - len(judged),
         "n_missing": n_missing,
         "n_unclear": len(unclear),
+        "n_drifted": len(drifted),
+        "median_drift_pct": (
+            statistics.median(d)
+            if (
+                d := [
+                    f["median_drift_pct"]
+                    for f in results
+                    if f.get("median_drift_pct") is not None
+                ]
+            )
+            else None
+        ),
         "expected_entries": expected_entries,
         "scope": _scope(triggered, judged),
         "families": results,
@@ -428,6 +487,7 @@ _HEADLINE = {
     "clean": "### No significant performance change",
     "partial": "### No regression found, but coverage was incomplete",
     "unclear": "### Needs a look -- levels moved, but not in a shape the criterion can judge",
+    "untrustworthy": "### Cannot be trusted -- the base commit did not measure the same twice",
     "regression": "### Performance regression detected",
     "inconclusive": "### Inconclusive -- not enough data",
 }
@@ -496,6 +556,7 @@ def render(report, context):
         extra_cols=(
             ("Median", _median_cell),
             ("TPOT", lambda f: _fmt(f["median_tpot_pct"])),
+            ("Drift", lambda f: _fmt(f.get("median_drift_pct"))),
         ),
     )
 
@@ -536,7 +597,7 @@ def render(report, context):
             "No entry reported enough judging levels. "
             "This is **not** a pass -- treat it as no signal."
         )
-    elif report["verdict"] in ("clean", "partial", "unclear"):
+    elif report["verdict"] in ("clean", "partial", "unclear", "untrustworthy"):
         thresholds = report["thresholds"]
         lines.append(
             f"No judged entry tripped (family median <= "
@@ -544,6 +605,15 @@ def render(report, context):
             f"{thresholds['family_min_down']} judging levels down and TPOT "
             f"mirroring)."
         )
+        if report["verdict"] == "untrustworthy":
+            lines.append(
+                f"The base commit was measured twice, before and after head, and "
+                f"the two readings differ by {_fmt(report['median_drift_pct'])} -- "
+                f"more than the {report['thresholds']['family_median_pct']}% the "
+                f"criterion is asked to resolve. Whatever moved between them would "
+                f"also have moved under head, so a delta this size cannot be "
+                f"attributed to the change."
+            )
         if report["verdict"] == "unclear":
             lines.append(
                 "The linkage criterion (median + count) assumes the judging "
@@ -625,8 +695,8 @@ def render_summary(report, context):
     if context:
         lines += [context, ""]
     lines += [
-        "| Entry | isl/osl | conc | role | base | head | tput | TPOT | TTFT |",
-        "|---|---|---|---|---|---|---|---|---|",
+        "| Entry | isl/osl | conc | role | base | base2 | head | tput | drift | TPOT | TTFT |",
+        "|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for family in report["families"]:
         for member in family["members"]:
@@ -634,9 +704,11 @@ def render_summary(report, context):
             lines.append(
                 f"| {family['model']} | {member['isl_osl']} | {member['conc']} "
                 f"| {role} "
-                f"| {member['base_tput']:.1f} | {member['head_tput']:.1f} "
-                f"| {member['tput_pct']:+.2f}% | {_fmt(member['tpot_pct'])} "
-                f"| {_fmt(member['ttft_pct'])} |"
+                f"| {member['base_tput']:.1f} "
+                f"| {format(member['base2_tput'], '.1f') if member.get('base2_tput') else '-'} "
+                f"| {member['head_tput']:.1f} "
+                f"| {member['tput_pct']:+.2f}% | {_fmt(member.get('drift_pct'))} "
+                f"| {_fmt(member['tpot_pct'])} | {_fmt(member['ttft_pct'])} |"
             )
     lines += [
         "",
@@ -666,6 +738,12 @@ def main():
     parser.add_argument("--base-dir", required=True)
     parser.add_argument("--head-dir", required=True)
     parser.add_argument(
+        "--base2-dir",
+        default=None,
+        help="Second reading of the base commit, taken after head. Its distance "
+        "from the first bounds what the comparison can resolve.",
+    )
+    parser.add_argument(
         "--history",
         default=None,
         help="Local data.js for the sigma gate; omit to fetch the dashboard",
@@ -690,7 +768,10 @@ def main():
 
     base_results = load_results(args.base_dir, recursive=True)
     head_results = load_results(args.head_dir, recursive=True)
-    pairs = pair_results(base_results, head_results)
+    base2_results = (
+        load_results(args.base2_dir, recursive=True) if args.base2_dir else []
+    )
+    pairs = pair_results(base_results, head_results, base2_results)
 
     if not pairs:
         print("No base/head pairs matched -- nothing to judge.", file=sys.stderr)

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -60,13 +60,15 @@ FAMILY_MEDIAN_PCT = -3.0  # family median throughput delta that trips the gate
 DOWN_EPS_PCT = -2.0  # a level counts as "down" past this
 TPOT_MIRROR_RATIO = 0.6  # |median TPOT delta / median tput delta| for mirroring
 NONMONOTONIC_MARGIN_PCT = 3.0  # interior level this far outside its neighbours
-# A/A residual after the warmup, measured on the platform this runs on.
-# MI308 gave 1.35% with a 1x-concurrency warmup; MI355X gave 4.19% under
-# the same warmup (run 34233036220: +4.19/+5.65/+3.10 at c=64/128/256, on
-# three separate machines, TPOT mirroring each one). The warmup now runs
-# the same prompt count as the measurement; update this to whatever that
-# leaves behind.
-MEASURED_RESIDUAL_BIAS_PCT = 4.19
+# A/A residual after the warmup, measured on the platform this runs on. With
+# a 1x-concurrency warmup MI355X held a systematic +4.19% (run 34233036220:
+# +4.19/+5.65/+3.10 at c=64/128/256, TPOT mirroring each). Warming up with the
+# measurement's own prompt count removed it: run 34247362619 gave -0.39/+0.27/
+# +1.84, two of the three on the same machines as before. What is left is
+# spread rather than bias, so this is the median and RESIDUAL_SPREAD_PCT is
+# how far a single level wandered from it.
+MEASURED_RESIDUAL_BIAS_PCT = 0.27
+RESIDUAL_SPREAD_PCT = 1.8
 
 # --- Baseline sanity (crimson only) ----------------------------------------
 BASELINE_SANITY_PCT = -25.0  # base this far under main's recent median
@@ -843,11 +845,12 @@ def render(report, context):
         # nothing changed. Say so next to the table rather than only in the
         # step summary, because the comment is what gets read.
         (
-            f"> A residual bias of about {MEASURED_RESIDUAL_BIAS_PCT}% favours "
-            f"head even when both halves run identical code, so small positive "
-            f"numbers here mean *no change*, not an improvement. A drop trips "
-            f"at roughly {FAMILY_MEDIAN_PCT - MEASURED_RESIDUAL_BIAS_PCT:.2f}% "
-            f"rather than {FAMILY_MEDIAN_PCT}%."
+            f"> Measured on identical code, the paired delta comes out at "
+            f"{MEASURED_RESIDUAL_BIAS_PCT}% with individual levels landing up "
+            f"to {RESIDUAL_SPREAD_PCT} points either side. Read a single level "
+            f"as carrying about that much slack, and treat anything inside it "
+            f"as no change. The verdict uses the family median across levels "
+            f"for the same reason."
         ),
         "",
     ]
@@ -1104,12 +1107,12 @@ def render_summary(report, context):
         ),
         "",
         (
-            f"> Measured residual bias after the warmup is "
-            f"{MEASURED_RESIDUAL_BIAS_PCT}%, systematic and favouring head, so "
-            f"a drop trips at roughly "
-            f"{FAMILY_MEDIAN_PCT - MEASURED_RESIDUAL_BIAS_PCT:.2f}% rather than "
-            f"{FAMILY_MEDIAN_PCT}%. Fine for the regressions worth catching; not "
-            f"a resolution of {abs(FAMILY_MEDIAN_PCT)}%."
+            f"> Measured on identical code, the paired delta comes out at "
+            f"{MEASURED_RESIDUAL_BIAS_PCT}% with individual levels landing up "
+            f"to {RESIDUAL_SPREAD_PCT} points either side. The warmup removed "
+            f"the systematic part; what is left is spread, which is why the "
+            f"verdict is taken on the family median across levels rather than "
+            f"on any single one."
         ),
     ]
     return "\n".join(lines)

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -1007,26 +1007,54 @@ def render(report, context):
 
 
 def render_summary(report, context):
-    """Render the full step-summary table, one row per configuration."""
+    """Render the full step-summary table, one row per configuration.
+
+    Same vocabulary as the PR comment -- a reader moving between the two should
+    not have to learn two names for the same thing. Columns that carry nothing
+    on a given run (base2 when the flow measured the base once, drift when
+    there is no history) are left out rather than printed empty: a column of
+    dashes reads as missing data rather than as a phase that did not run.
+    """
+    members = [m for f in report["families"] for m in f["members"]]
+    show_base2 = any(m.get("base2_tput") for m in members)
+    show_drift = any(m.get("drift_pct") is not None for m in members)
+
+    header = ["Model", "isl/osl", "Concurrency", "base"]
+    if show_base2:
+        header.append("base2")
+    header += ["head", "Total Tput"]
+    if show_drift:
+        header.append("drift")
+    header += ["TPOT", "TTFT"]
+
     lines = ["## PR performance check", ""]
     if context:
         lines += [context, ""]
     lines += [
-        "| Entry | isl/osl | conc | role | base | base2 | head | tput | drift | TPOT | TTFT |",
-        "|---|---|---|---|---|---|---|---|---|---|---|",
+        "| " + " | ".join(header) + " |",
+        "|" + "---|" * len(header),
     ]
     for family in report["families"]:
         for member in family["members"]:
-            role = "judging" if member["conc"] >= JUDGE_MIN_CONC else "reference"
-            lines.append(
-                f"| {family['model']} | {member['isl_osl']} | {member['conc']} "
-                f"| {role} "
-                f"| {member['base_tput']:.1f} "
-                f"| {format(member['base2_tput'], '.1f') if member.get('base2_tput') else '-'} "
-                f"| {member['head_tput']:.1f} "
-                f"| {member['tput_pct']:+.2f}% | {_fmt(member.get('drift_pct'))} "
-                f"| {_fmt(member['tpot_pct'])} | {_fmt(member['ttft_pct'])} |"
-            )
+            judged = member["conc"] >= JUDGE_MIN_CONC
+            conc = f"{member['conc']}" if judged else f"{member['conc']} (not judged)"
+            row = [
+                family["model"],
+                member["isl_osl"],
+                conc,
+                f"{member['base_tput']:.1f}",
+            ]
+            if show_base2:
+                row.append(
+                    format(member["base2_tput"], ".1f")
+                    if member.get("base2_tput")
+                    else "-"
+                )
+            row += [f"{member['head_tput']:.1f}", f"{member['tput_pct']:+.2f}%"]
+            if show_drift:
+                row.append(_fmt(member.get("drift_pct")))
+            row += [_fmt(member["tpot_pct"]), _fmt(member["ttft_pct"])]
+            lines.append("| " + " | ".join(row) + " |")
     lines += [
         "",
         f"Verdict: **{report['verdict']}** "
@@ -1037,6 +1065,13 @@ def render_summary(report, context):
             f" / {report['expected_entries']} expected)"
             if report.get("expected_entries")
             else ")"
+        ),
+        "",
+        (
+            "Rows marked *(not judged)* were measured and are shown, but "
+            f"excluded from every calculation: below {JUDGE_MIN_CONC} requests "
+            "in flight the numbers swing enough to both invent regressions and "
+            "hide real ones."
         ),
         "",
         (

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -687,20 +687,35 @@ def _base_vs_main(judging, history):
     only large deviations carry meaning. `_baseline_sanity` is the gate; this
     is the reading.
     """
-    med, peak = [], []
+    per_conc = []
     for member in judging:
         hist = history.get((member["model"], member["isl_osl"], member["conc"]))
         if not hist or not hist.get("median"):
             continue
-        med.append((member["base_tput"] / hist["median"] - 1) * 100)
-        if hist.get("peak"):
-            peak.append((member["base_tput"] / hist["peak"] - 1) * 100)
-    if not med:
+        per_conc.append(
+            {
+                "conc": member["conc"],
+                "vs_median_pct": (member["base_tput"] / hist["median"] - 1) * 100,
+                "vs_peak_pct": (
+                    (member["base_tput"] / hist["peak"] - 1) * 100
+                    if hist.get("peak")
+                    else None
+                ),
+            }
+        )
+    if not per_conc:
         return None
+    per_conc.sort(key=lambda x: x["conc"])
     return {
-        "vs_median_pct": statistics.median(med),
-        "vs_peak_pct": _median_or_none(peak),
-        "n_levels": len(med),
+        # Kept for the ordering and for anything reading the JSON, but the
+        # report shows the levels: a median hides the split where one level is
+        # fine and another is far under, which is what says where to look.
+        "vs_median_pct": statistics.median(x["vs_median_pct"] for x in per_conc),
+        "vs_peak_pct": _median_or_none(
+            [x["vs_peak_pct"] for x in per_conc if x["vs_peak_pct"] is not None]
+        ),
+        "per_conc": per_conc,
+        "n_levels": len(per_conc),
     }
 
 
@@ -1185,8 +1200,8 @@ def render(report, context):
 
     if rows:
         drift_lines += [
-            "| Model | isl/osl | vs main now | vs main peak | Main trend |",
-            "|---|---|---|---|---|",
+            "| Model | isl/osl | c | vs main now | vs main peak | Main trend |",
+            "|---|---|---|---|---|---|",
         ]
         for family in rows:
             v = family["base_vs_main"]
@@ -1205,19 +1220,23 @@ def render(report, context):
                 )
             else:
                 trend = "steady"
-            drift_lines.append(
-                "| {} | {} | {:+.1f}% | {} | {} |".format(
-                    family["model"],
-                    family["isl_osl"],
-                    v["vs_median_pct"],
-                    (
-                        "{:+.1f}%".format(v["vs_peak_pct"])
-                        if v["vs_peak_pct"] is not None
-                        else "-"
-                    ),
-                    trend,
+            first = True
+            for lvl in v["per_conc"]:
+                drift_lines.append(
+                    "| {} | {} | {} | {:+.1f}% | {} | {} |".format(
+                        family["model"] if first else "",
+                        family["isl_osl"] if first else "",
+                        lvl["conc"],
+                        lvl["vs_median_pct"],
+                        (
+                            "{:+.1f}%".format(lvl["vs_peak_pct"])
+                            if lvl["vs_peak_pct"] is not None
+                            else "-"
+                        ),
+                        trend if first else "",
+                    )
                 )
-            )
+                first = False
         drift_lines += [
             "",
             (

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -79,6 +79,14 @@ BASELINE_SANITY_PCT = -25.0  # base this far under main's recent median
 BASELINE_SANITY_SIGMA = 2.5  # ... and clear of that configuration's own noise
 BASELINE_SANITY_MIN_LEVELS = 2  # ... on at least this many judged levels
 BASELINE_SANITY_MIN_POINTS = 6  # ... judged against at least this much history
+# Two windows for two jobs, following the nightly monitor: the level is the
+# median of a short window (a level that shifted weeks ago is not the current
+# normal), the noise band is estimated over a longer one (short windows make a
+# jumpy configuration look stable). Upstream uses 3 and 8; the level window is
+# a floor here rather than a fixed count, because a step inside it is resolved
+# by the onset instead -- see _level_window.
+LEVEL_WINDOW = 3
+VAR_WINDOW = 8
 
 # --- Main-side drift (context, never a verdict on the PR) -------------------
 # Ported from the nightly monitor's trend criterion, with its constants intact.
@@ -253,23 +261,24 @@ def load_history(source=None):
 
     stats = {}
     for key, points in series.items():
-        values = [p["tput"] for p in points if p.get("tput") is not None]
+        ordered_pts = sorted(points, key=lambda p: p["date"])
+        values = [p["tput"] for p in ordered_pts if p.get("tput") is not None]
         if len(values) < BASELINE_SANITY_MIN_POINTS:
             continue
-        # The last few runs, not the whole window: a level that shifted weeks
-        # ago is the current normal, and holding a run against a long-gone one
-        # is the "compared against a peak" mistake in slow motion.
-        recent = values[-8:]
-        median = statistics.median(recent)
+        level = _level_window(ordered_pts)
+        median = statistics.median(level)
+        # The noise band comes from the longer window whatever the level does:
+        # estimating it over three points calls a jumpy configuration stable.
+        var = values[-VAR_WINDOW:]
         if median:
             stats[key] = {
-                "cv": statistics.pstdev(recent) / median,
+                "cv": statistics.pstdev(var) / median,
                 "median": median,
-                # Best of the same window. The median says what main normally
-                # does; the peak says how good it has been, which is the
-                # question a reader asks when the paired delta is near zero.
-                "peak": max(recent),
-                "n": len(recent),
+                # Best of the same window the level came from. The median says
+                # what main does now; the best says how good it has been, which
+                # is what a reader asks when the paired delta is near zero.
+                "peak": max(level),
+                "n": len(level),
             }
     ordered = {
         key: sorted(points, key=lambda p: p["date"]) for key, points in series.items()
@@ -296,7 +305,34 @@ def _drift_lag(points, days, field):
     return (statistics.mean(now[:DRIFT_SMOOTH_K]) / base - 1) * 100
 
 
-def _drift_onset(members):
+def _level_window(points):
+    """The runs that describe main's level *now*.
+
+    A fixed count straddles a step: eight runs across the night something
+    changed give a median that is neither the old level nor the new one, and
+    every comparison against it is wrong by half the step. When a step is
+    visible in the window, only what came after it counts; otherwise the last
+    few runs, which is what the nightly monitor uses.
+    """
+    values = [p["tput"] for p in points if p.get("tput") is not None]
+    recent = points[-VAR_WINDOW:]
+    step = _series_onset([recent])
+    if step:
+        after = [
+            p["tput"]
+            for p in recent
+            if p.get("tput") is not None
+            and datetime.datetime.fromtimestamp(
+                p["date"] / 1000, datetime.timezone.utc
+            ).strftime("%Y-%m-%d")
+            >= step["date"]
+        ]
+        if len(after) >= 2:
+            return after
+    return values[-LEVEL_WINDOW:]
+
+
+def _series_onset(members):
     """The day the level actually changed, found in the data.
 
     Reporting the horizon instead ("7d") says the slide lasted as long as the
@@ -413,7 +449,7 @@ def main_drift(series, models):
                 worst = {
                     "model": model,
                     "isl_osl": isl_osl,
-                    "onset": _drift_onset(members),
+                    "onset": _series_onset(members),
                     "per_conc": sorted(
                         (c, round(d, 1))
                         for c, d in zip(
@@ -1105,88 +1141,99 @@ def render(report, context):
 
     # Cross-check for the paired table. A paired delta cannot distinguish a
     # base at main's usual level from one well under it, so the base is read
-    # against main's recent nightly level whether or not anything is wrong.
-    rows = [
-        (f["model"], f["base_vs_main"])
-        for f in report["families"]
-        if f.get("base_vs_main")
-    ]
+    # against main's recent nightly level whether or not anything is wrong,
+    # with main's own trend beside it in the same row -- they answer one
+    # question together and were two tables under one heading before.
+    drift_by_key = {
+        (d["model"], d["isl_osl"]): d for d in report.get("main_drift") or []
+    }
+    rows = [f for f in report["families"] if f.get("base_vs_main")]
+    # From what this run measured, not from what has history statistics: a
+    # configuration that was measured but has no statistics is still measured,
+    # and calling it otherwise puts it under the wrong heading.
+    measured = {(f["model"], f["isl_osl"]) for f in report["families"]}
+    elsewhere = [d for k, d in drift_by_key.items() if k not in measured]
+    # Drift on configurations this run did measure, when the table that would
+    # carry it cannot be built. Dropping it because a different column is
+    # missing is the silent-skip failure in another costume.
+    orphaned = [d for k, d in drift_by_key.items() if k in measured] if not rows else []
+
     if rows or report.get("main_drift") or report.get("drift_waiting"):
         drift_lines += ["<details>", "<summary>Base against main</summary>", ""]
+
     if rows:
         drift_lines += [
-            "| Model | vs main median | vs main peak |",
-            "|---|---|---|",
+            "| Model | isl/osl | vs recent median | vs recent best | Main trend |",
+            "|---|---|---|---|---|",
         ]
-        for model, v in rows:
+        for family in rows:
+            v = family["base_vs_main"]
+            # Only the shape this run measured. The same model drifting at
+            # another input/output length is a different configuration and
+            # belongs in its own line, not in this row.
+            d = drift_by_key.get((family["model"], family["isl_osl"]))
+            if d:
+                trend = "{:+.1f}% {}".format(
+                    d["median_pct"],
+                    (
+                        "since " + d["onset"]["date"][5:]
+                        if d.get("onset")
+                        else "over {}d".format(d["horizon_days"])
+                    ),
+                )
+            else:
+                trend = "steady"
             drift_lines.append(
-                "| {} | {:+.1f}% | {} |".format(
-                    model,
+                "| {} | {} | {:+.1f}% | {} | {} |".format(
+                    family["model"],
+                    family["isl_osl"],
                     v["vs_median_pct"],
                     (
                         "{:+.1f}%".format(v["vs_peak_pct"])
                         if v["vs_peak_pct"] is not None
                         else "-"
                     ),
+                    trend,
                 )
             )
         drift_lines += [
             "",
             (
-                "Median and best of main's last 8 nightly runs at the same "
-                "configurations. This crosses container images, which spreads "
-                "11-21% against 0.6% within one image, so read it for order of "
-                "magnitude, not precision."
+                "Against main's recent nightly runs at the same "
+                "configuration -- the last 3, or everything since the step if "
+                "one is visible, so a median never straddles a level change. "
+                "The comparison crosses container images, where the spread is "
+                "11-21% against 0.6% within one image; read it for order of "
+                "magnitude. Trend is the nightly monitor's criterion, dated "
+                "from the data rather than from the window."
+            ),
+        ]
+        measured = {(f["model"], f["isl_osl"]) for f in rows}
+        elsewhere = [d for k, d in drift_by_key.items() if k not in measured]
+
+    if orphaned:
+        drift_lines += [
+            "",
+            "Sliding on main: "
+            + "; ".join(
+                "{} {} {:+.1f}%{}".format(
+                    d["model"],
+                    d["isl_osl"],
+                    d["median_pct"],
+                    " since " + d["onset"]["date"][5:] if d.get("onset") else "",
+                )
+                for d in orphaned
             ),
         ]
 
-    if report.get("main_drift"):
-        n = len(report["main_drift"])
+    if elsewhere:
         drift_lines += [
             "",
-            "**Sliding on main** ({} {})".format(n, "family" if n == 1 else "families"),
-            "",
-            (
-                "| Model | Input/output | Onset | Throughput | TPOT "
-                "| Levels &le; -2% |"
-            ),
-            "|---|---|---|---|---|---|",
-        ]
-        for d in report["main_drift"]:
-            drift_lines.append(
-                (
-                    "| {model} | {shape} | {onset} | {tput} | {tpot} "
-                    "| {down} of {tot} |"
-                ).format(
-                    model=d["model"],
-                    shape=d["isl_osl"],
-                    onset=(
-                        "{} ({:+.0f}%)".format(
-                            d["onset"]["date"][5:], d["onset"]["drop_pct"]
-                        )
-                        if d.get("onset")
-                        else "{}d window".format(d["horizon_days"])
-                    ),
-                    tput="{:+.1f}%".format(d["median_pct"]),
-                    tpot=_fmt(d["median_tpot_pct"]),
-                    down=d["n_down"],
-                    tot=d["n_total"],
-                )
-            )
-        for d in report["main_drift"]:
-            if d.get("per_conc"):
-                drift_lines += [
-                    "",
-                    "{}: ".format(d["model"])
-                    + ", ".join(f"c={c} {v:+.1f}%" for c, v in d["per_conc"]),
-                ]
-        drift_lines += [
-            "",
-            (
-                "Onset is the day the level actually moved, found in the "
-                "data -- a step and a slow slide look alike in a window "
-                "figure. The paired delta stays honest either way; the "
-                "absolute level does not."
+            "Also sliding on main, at input/output lengths this run does not "
+            "measure: "
+            + "; ".join(
+                "{} {} {:+.1f}%".format(d["model"], d["isl_osl"], d["median_pct"])
+                for d in elsewhere
             ),
         ]
 

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -265,6 +265,10 @@ def load_history(source=None):
             stats[key] = {
                 "cv": statistics.pstdev(recent) / median,
                 "median": median,
+                # Best of the same window. The median says what main normally
+                # does; the peak says how good it has been, which is the
+                # question a reader asks when the paired delta is near zero.
+                "peak": max(recent),
                 "n": len(recent),
             }
     ordered = {
@@ -539,6 +543,7 @@ def judge_family(members, history_cv):
         ),
         "nonmonotonic": _nonmonotonic(judging),
         "baseline_sanity": _baseline_sanity(judging, history_cv),
+        "base_vs_main": _base_vs_main(judging, history_cv),
         "escalations": _single_escalations(judging, history_cv),
     }
 
@@ -609,6 +614,36 @@ def _median_or_none(values):
     someone points it at a pair of result directories.
     """
     return statistics.median(values) if values else None
+
+
+def _base_vs_main(judging, history):
+    """Where this run's base sits against main's recent nightly level.
+
+    Cross-validation for the paired table, which on its own cannot tell a base
+    at main's usual level from one well under it -- both give the same delta.
+    Reported whether or not anything is wrong, because a reference that only
+    appears when it fires is not a reference.
+
+    The comparison crosses container images (this run's against each nightly's)
+    and that spreads 11-21% where a within-image comparison spreads 0.6%, so
+    only large deviations carry meaning. `_baseline_sanity` is the gate; this
+    is the reading.
+    """
+    med, peak = [], []
+    for member in judging:
+        hist = history.get((member["model"], member["isl_osl"], member["conc"]))
+        if not hist or not hist.get("median"):
+            continue
+        med.append((member["base_tput"] / hist["median"] - 1) * 100)
+        if hist.get("peak"):
+            peak.append((member["base_tput"] / hist["peak"] - 1) * 100)
+    if not med:
+        return None
+    return {
+        "vs_median_pct": statistics.median(med),
+        "vs_peak_pct": _median_or_none(peak),
+        "n_levels": len(med),
+    }
 
 
 def _baseline_sanity(judging, history):
@@ -1067,22 +1102,62 @@ def render(report, context):
     # not a rule: the sentence above it renders as a full-width H2. The blank
     # line is load-bearing.
     drift_lines = [""]
-    # --- main-side context, kept apart from the verdict --------------------
+
+    # Cross-check for the paired table. A paired delta cannot distinguish a
+    # base at main's usual level from one well under it, so the base is read
+    # against main's recent nightly level whether or not anything is wrong.
+    rows = [
+        (f["model"], f["base_vs_main"])
+        for f in report["families"]
+        if f.get("base_vs_main")
+    ]
+    if rows or report.get("main_drift") or report.get("drift_waiting"):
+        drift_lines += ["<details>", "<summary>Base against main</summary>", ""]
+    if rows:
+        drift_lines += [
+            "| Model | vs main median | vs main peak |",
+            "|---|---|---|",
+        ]
+        for model, v in rows:
+            drift_lines.append(
+                "| {} | {:+.1f}% | {} |".format(
+                    model,
+                    v["vs_median_pct"],
+                    (
+                        "{:+.1f}%".format(v["vs_peak_pct"])
+                        if v["vs_peak_pct"] is not None
+                        else "-"
+                    ),
+                )
+            )
+        drift_lines += [
+            "",
+            (
+                "Median and best of main's last 8 nightly runs at the same "
+                "configurations. This crosses container images, which spreads "
+                "11-21% against 0.6% within one image, so read it for order of "
+                "magnitude, not precision."
+            ),
+        ]
+
     if report.get("main_drift"):
         n = len(report["main_drift"])
-        # Context, not a finding: collapsed so the comment opens on the verdict
-        # and the table. GitHub renders <details> inline in comments.
         drift_lines += [
-            "<details>",
-            "<summary><b>Sliding on main — not this PR</b> "
-            "({} {})</summary>".format(n, "family" if n == 1 else "families"),
             "",
-            "| Model | Input/output | Onset | Throughput | TPOT | Levels &le; -2% |",
+            "**Sliding on main** ({} {})".format(n, "family" if n == 1 else "families"),
+            "",
+            (
+                "| Model | Input/output | Onset | Throughput | TPOT "
+                "| Levels &le; -2% |"
+            ),
             "|---|---|---|---|---|---|",
         ]
         for d in report["main_drift"]:
             drift_lines.append(
-                "| {model} | {shape} | {onset} | {tput} | {tpot} | {down} of {tot} |".format(
+                (
+                    "| {model} | {shape} | {onset} | {tput} | {tpot} "
+                    "| {down} of {tot} |"
+                ).format(
                     model=d["model"],
                     shape=d["isl_osl"],
                     onset=(
@@ -1100,37 +1175,29 @@ def render(report, context):
             )
         for d in report["main_drift"]:
             if d.get("per_conc"):
-                drift_lines.append(
+                drift_lines += [
                     "",
-                )
-                drift_lines.append(
                     "{}: ".format(d["model"])
-                    + ", ".join(f"c={c} {v:+.1f}%" for c, v in d["per_conc"])
-                )
+                    + ", ".join(f"c={c} {v:+.1f}%" for c, v in d["per_conc"]),
+                ]
         drift_lines += [
             "",
             (
-                "The delta above is honest, the absolute level is not. Onset is "
-                "the day the level actually moved, found in the data -- a step "
-                "and a slow slide look the same in a window figure."
+                "Onset is the day the level actually moved, found in the "
+                "data -- a step and a slow slide look alike in a window "
+                "figure. The paired delta stays honest either way; the "
+                "absolute level does not."
             ),
-            "</details>",
-            "",
         ]
 
-    # Families the trend criterion could not reach. Absent and clean look the
-    # same otherwise, and a model that has just started running would sit
-    # outside coverage indefinitely with nobody noticing.
     if report.get("drift_waiting"):
         drift_lines += [
-            "<details>",
-            "<summary>Not checked for drift ({})</summary>".format(
-                len(report["drift_waiting"])
-            ),
             "",
+            "Not checked for drift: "
+            + "; ".join(f"{m} {sh} ({why})" for m, sh, why in report["drift_waiting"]),
         ]
-        for model, shape, why in report["drift_waiting"]:
-            drift_lines.append(f"- {model} {shape} -- {why}")
+
+    if rows or report.get("main_drift") or report.get("drift_waiting"):
         drift_lines += ["", "</details>", ""]
 
     # --- shape flags -------------------------------------------------------

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -31,8 +31,6 @@ levels is reported as ``insufficient``; if no family survives, the whole run is
 ``inconclusive``.
 """
 
-from __future__ import annotations
-
 import argparse
 import collections
 import json
@@ -59,6 +57,11 @@ FAMILY_MIN_DOWN = 3  # of those, how many must be down
 FAMILY_MEDIAN_PCT = -3.0  # family median throughput delta that trips the gate
 DOWN_EPS_PCT = -2.0  # a level counts as "down" past this
 TPOT_MIRROR_RATIO = 0.6  # |median TPOT delta / median tput delta| for mirroring
+# TTFT is the other way capacity is lost: requests queue instead of slowing
+# down. It moves much harder than TPOT when it moves at all (+300-700%
+# against a 30% throughput drop in the measured case), so the bar is the
+# same ratio -- it is cleared by a wide margin or not at all.
+TTFT_MIRROR_RATIO = 0.6
 NONMONOTONIC_MARGIN_PCT = 3.0  # interior level this far outside its neighbours
 # A/A residual after the warmup, measured on the platform this runs on. With
 # a 1x-concurrency warmup MI355X held a systematic +4.19% (run 34233036220:
@@ -439,6 +442,9 @@ def judge_family(members, history_cv):
         "reference": reference,
         "median_tput_pct": statistics.median(tputs) if tputs else None,
         "median_tpot_pct": statistics.median(tpots) if tpots else None,
+        "median_ttft_pct": _median_or_none(
+            [m["ttft_pct"] for m in judging if m.get("ttft_pct") is not None]
+        ),
         "n_down": sum(1 for t in tputs if t <= DOWN_EPS_PCT),
         "n_total": len(tputs),
         "median_drift_pct": _median_or_none(
@@ -460,19 +466,42 @@ def judge_family(members, history_cv):
     median_tput = result["median_tput_pct"]
     median_tpot = result["median_tpot_pct"]
 
-    # Mirroring: throughput down while TPOT goes up, by a comparable magnitude.
-    # It separates a real slowdown from measurement wobble, which does not make
-    # the two metrics move in lockstep.
-    mirror = (
+    # Confirmation: throughput down while a latency metric degrades to a
+    # comparable degree. Measurement wobble does not move two metrics in
+    # lockstep, which is what this gate is for.
+    #
+    # TPOT alone is not enough, and assuming it was hid a whole class of
+    # regression. A change that caps how many requests run at once drops
+    # throughput while making each *served* request faster -- TPOT goes DOWN
+    # while the queue behind it grows. Measured on MI308 with max_num_seqs
+    # capped at 16: throughput -25/-33/-29%, TTFT +681/+495/+307%, and TPOT
+    # -64/-78/-88%. The old gate called that `unclear` and reported nothing.
+    # Per-token slowdown and queueing are both real losses of capacity, so
+    # either one confirms.
+    median_ttft = result["median_ttft_pct"]
+    mirror_tpot = (
         median_tpot is not None
         and median_tput < 0
         and median_tpot > 0
         and abs(median_tpot / median_tput) >= TPOT_MIRROR_RATIO
     )
+    mirror_ttft = (
+        median_ttft is not None
+        and median_tput < 0
+        and median_ttft > 0
+        and abs(median_ttft / median_tput) >= TTFT_MIRROR_RATIO
+    )
+    mirror = mirror_tpot or mirror_ttft
     result["mirror"] = mirror
+    result["mirror_via"] = "TPOT" if mirror_tpot else ("TTFT" if mirror_ttft else None)
     result["mirror_ratio"] = (
         abs(median_tpot / median_tput)
         if (median_tpot is not None and median_tput)
+        else None
+    )
+    result["mirror_ratio_ttft"] = (
+        abs(median_ttft / median_tput)
+        if (median_ttft is not None and median_tput)
         else None
     )
 
@@ -981,12 +1010,17 @@ def render(report, context):
         for family in report["families"]:
             if family["status"] != "triggered":
                 continue
-            ratio = family.get("mirror_ratio")
+            via = family.get("mirror_via")
+            ratio = (
+                family.get("mirror_ratio_ttft")
+                if via == "TTFT"
+                else family.get("mirror_ratio")
+            )
             lines.append(
                 f"- **{family['model']}**: {family['n_down']}/{family['n_total']} "
                 f"judging levels down, median {_fmt(family['median_tput_pct'])}, "
                 f"TPOT {_fmt(family['median_tpot_pct'])}"
-                + (f" (mirror ratio {ratio:.2f})" if ratio else "")
+                + (f" (confirmed by {via}, ratio {ratio:.2f})" if ratio and via else "")
             )
             for flag in family["escalations"]:
                 lines.append(

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -884,6 +884,42 @@ def render(report, context):
         "",
     ]
 
+    status = report.get("history_status")
+    if status in ("unavailable", "unmatched"):
+        why = (
+            "could not be read"
+            if status == "unavailable"
+            else (
+                "was read but matched none of the configurations measured here, "
+                "which is what a renamed model or a changed dashboard format "
+                "looks like"
+            )
+        )
+        lines += [
+            "> [!WARNING]",
+            f"> **The baseline check did not run.** The nightly history {why}.",
+            (
+                "> Without it there is nothing confirming the base measurement "
+                "is at main's usual level, and a base that is itself broken "
+                "produces a delta near zero -- the one shape where a green "
+                "verdict is exactly wrong. The paired numbers above stand; the "
+                "verdict is held at `partial` rather than `clean` because of "
+                "this."
+            ),
+            "",
+        ]
+    elif status == "ok":
+        lines += [
+            (
+                "Baseline checked against nightly history for "
+                "{} of {} judged configurations.".format(
+                    report.get("history_matched", 0),
+                    len(report.get("families", [])) * 3,
+                )
+            ),
+            "",
+        ]
+
     # --- baseline sanity: loudest thing on the page when it fires ----------
     for family in report["families"]:
         flags = family.get("baseline_sanity") or []
@@ -977,12 +1013,25 @@ def render(report, context):
         "bad_baseline",
     ):
         thresholds = report["thresholds"]
-        lines.append(
-            f"No judged entry tripped (family median <= "
-            f"{thresholds['family_median_pct']}% and >= "
-            f"{thresholds['family_min_down']} judging levels down and TPOT "
-            f"mirroring)."
-        )
+        # `bad_baseline` outranks `regression` in the ladder, so a run can carry
+        # tripped entries and still land here. Saying nothing tripped in that
+        # case contradicts the table directly above and reads as reassurance.
+        tripped = [f for f in report["families"] if f["status"] == "triggered"]
+        if tripped:
+            names = ", ".join(f["model"] for f in tripped)
+            lines.append(
+                f"{names} tripped the criterion, but the verdict above takes "
+                "precedence: the comparison it rests on cannot be trusted "
+                "yet."
+            )
+        else:
+            lines.append(
+                "No judged entry tripped (family median <= {}% and >= {} "
+                "judging levels down, with TPOT or TTFT confirming).".format(
+                    thresholds["family_median_pct"],
+                    thresholds["family_min_down"],
+                )
+            )
         if report["verdict"] == "untrustworthy":
             lines.append(
                 f"The base commit was measured twice, before and after head, and "
@@ -1206,12 +1255,44 @@ def main():
         history_series, history_cv = load_history(args.history)
     else:
         history_series, history_cv = {}, {}
+
+    # The baseline check is the one thing that catches a base measurement which
+    # is itself broken -- the shape where the paired delta is zero and a green
+    # verdict is exactly wrong. If it cannot run, that must change the verdict,
+    # not just go unmentioned: a check that goes quiet when it breaks is worse
+    # than no check, because the report looks identical either way.
+    # Judged configurations only. Counting the reference levels too produced
+    # "25 of 15", which is worse than saying nothing.
+    measured = {
+        (p["model"], p["isl_osl"], p["conc"])
+        for p in pairs
+        if p["conc"] >= JUDGE_MIN_CONC
+    }
+    if not args.history:
+        # Explicitly opted out (local A/A runs). Not a degradation.
+        history_status = "disabled"
+    elif not history_cv:
+        history_status = "unavailable"
+    elif not (measured & set(history_cv)):
+        # Loaded, but nothing in it lines up with what was measured. This is
+        # what a renamed model or a changed dashboard format looks like, and
+        # it is indistinguishable from a working check unless it is said.
+        history_status = "unmatched"
+    else:
+        history_status = "ok"
+
     models = {p["model"] for p in pairs}
     drift = main_drift(history_series, models) if history_series else []
     report = judge(pairs, history_cv, expected_entries=args.expect_entries, drift=drift)
     report["context"] = args.context
     report["n_pairs"] = len(pairs)
     report["history_configs"] = len(history_cv)
+    report["history_status"] = history_status
+    report["history_matched"] = len(measured & set(history_cv))
+
+    if history_status in ("unavailable", "unmatched") and report["verdict"] == "clean":
+        report["verdict"] = "partial"
+        report["history_downgraded"] = True
 
     print(render_summary(report, args.context))
 

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -1200,7 +1200,7 @@ def render(report, context):
 
     if rows:
         drift_lines += [
-            "| Model | isl/osl | c | vs main now | vs main peak | Main trend |",
+            "| Model | isl/osl | c | vs main median | vs main peak | Main trend |",
             "|---|---|---|---|---|---|",
         ]
         for family in rows:
@@ -1240,14 +1240,15 @@ def render(report, context):
         drift_lines += [
             "",
             (
-                "*now* is main's current level -- the last 3 nightly runs, or "
-                "everything since the step when one is visible, so a median "
-                "never straddles a level change. *peak* is the best main has "
-                "sustained across all recorded history, which does not move as "
-                "history rolls forward: a drop that ages out of every window "
-                "still shows here. Both cross container images, where the "
-                "spread is 11-21% against 0.6% within one image; read them for "
-                "order of magnitude."
+                "**median** is main's level now: the median of its last 3 "
+                "nightly runs, or of everything since the step when one is "
+                "visible, so it never straddles a level change. **peak** is the "
+                "best main has sustained: the highest 3-run mean anywhere in "
+                "recorded history, which does not move as history rolls "
+                "forward, so a drop that has aged out of every window still "
+                "shows. Both cross container images, where the spread is "
+                "11-21% against 0.6% within one image; read them for order of "
+                "magnitude."
             ),
         ]
         measured = {(f["model"], f["isl_osl"]) for f in rows}

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -61,6 +61,23 @@ DOWN_EPS_PCT = -2.0  # a level counts as "down" past this
 TPOT_MIRROR_RATIO = 0.6  # |median TPOT delta / median tput delta| for mirroring
 NONMONOTONIC_MARGIN_PCT = 3.0  # interior level this far outside its neighbours
 MEASURED_RESIDUAL_BIAS_PCT = 1.35  # A/A residual after the warmup; see below
+
+# --- Baseline sanity (crimson only) ----------------------------------------
+BASELINE_SANITY_PCT = -25.0  # base this far under main's recent median
+BASELINE_SANITY_SIGMA = 2.5  # ... and clear of that configuration's own noise
+BASELINE_SANITY_MIN_LEVELS = 2  # ... on at least this many judged levels
+BASELINE_SANITY_MIN_POINTS = 6  # ... judged against at least this much history
+
+# A paired comparison answers "did this change make it worse" and is blind to
+# "main was already broken": if base and head are both 20% down, the delta is
+# zero and the run reports clean. This check reads the base measurement against
+# main's recent history to catch that -- but only at crimson magnitude. Across
+# 372 configurations the 8-run spread on the public dashboard is 7.7% at the
+# median, 13.7% at P75 and 25.1% at P90, all of it ordinary cross-image
+# variation. Anything finer than that is indistinguishable from noise here.
+#
+# Slow drift on main -- the 5% kind that accumulates over weeks -- needs a time
+# series and a trend criterion, which is a nightly-side job, not a PR one.
 DRIFT_TRUST_PCT = 3.0  # base repeated this far apart -> the pairing cannot resolve
 
 # The base commit is measured twice, before and after head. The distance
@@ -129,7 +146,7 @@ def _parse_data_js(text):
 
 
 def load_history_cv(source=None):
-    """Return {(model, isl_osl, conc): coefficient_of_variation} from history.
+    """Return {(model, isl_osl, conc): {"cv", "median", "n"}} from history.
 
     ``source`` may be a local path or None (fetch the public dashboard). Any
     failure yields an empty mapping -- the sigma gate is optional by design and
@@ -184,15 +201,23 @@ def load_history_cv(source=None):
             key = (match.group(2), match.group(3), int(match.group(4)))
             series[key].append(bench.get("value"))
 
-    cv = {}
+    stats = {}
     for key, values in series.items():
         values = [v for v in values if isinstance(v, (int, float))]
-        if len(values) < 6:
+        if len(values) < BASELINE_SANITY_MIN_POINTS:
             continue
-        median = statistics.median(values)
+        # The last few runs, not the whole window: a level that shifted weeks
+        # ago is the current normal, and holding a run against a long-gone one
+        # is the "compared against a peak" mistake in slow motion.
+        recent = values[-8:]
+        median = statistics.median(recent)
         if median:
-            cv[key] = statistics.pstdev(values) / median
-    return cv
+            stats[key] = {
+                "cv": statistics.pstdev(recent) / median,
+                "median": median,
+                "n": len(recent),
+            }
+    return stats
 
 
 # --------------------------------------------------------------------------
@@ -284,6 +309,7 @@ def judge_family(members, history_cv):
             [m["drift_pct"] for m in judging if m["drift_pct"] is not None]
         ),
         "nonmonotonic": _nonmonotonic(judging),
+        "baseline_sanity": _baseline_sanity(judging, history_cv),
         "escalations": _single_escalations(judging, history_cv),
     }
 
@@ -333,6 +359,52 @@ def _median_or_none(values):
     return statistics.median(values) if values else None
 
 
+def _baseline_sanity(judging, history):
+    """Flag a base measurement that sits far under main's recent level.
+
+    Three gates, all required, following the same shape the nightly monitor
+    uses for its highest-confidence class:
+
+    - magnitude: at least BASELINE_SANITY_PCT under the recent median
+    - variance: and clear of that configuration's own noise band, because a
+      fixed percentage condemns a naturally jumpy configuration for behaving
+      normally -- the 8-run spread reaches 25% at P90 across the dashboard
+    - corroboration: on at least BASELINE_SANITY_MIN_LEVELS judged levels,
+      because one level alone is the shape a scheduling blip takes
+
+    Returns the offending levels, or None.
+    """
+    flagged = []
+    for member in judging:
+        hist = history.get((member["model"], member["isl_osl"], member["conc"]))
+        if not hist or not hist["median"]:
+            continue
+        median = hist["median"]
+        delta = (member["base_tput"] - median) / median * 100
+        if delta > BASELINE_SANITY_PCT:
+            continue
+        # Variance gate. A configuration whose own history swings this much is
+        # not saying anything by swinging again.
+        sigma = hist["cv"] * median
+        if sigma > 0 and (median - member["base_tput"]) < BASELINE_SANITY_SIGMA * sigma:
+            continue
+        flagged.append(
+            {
+                "conc": member["conc"],
+                "base_tput": member["base_tput"],
+                "history_median": median,
+                "pct": delta,
+                "sigma_pct": hist["cv"] * 100,
+                "n": hist["n"],
+            }
+        )
+    # Corroboration gate: one level is a blip, several at once is the machine
+    # or the commit.
+    if len(flagged) < BASELINE_SANITY_MIN_LEVELS:
+        return None
+    return flagged
+
+
 def _nonmonotonic(judging):
     """Flag an interior level that sits well outside its immediate neighbours.
 
@@ -380,9 +452,9 @@ def _single_escalations(members, history_cv):
         if delta <= SINGLE_STANDS_ALONE_PCT:
             reasons.append(f"c={member['conc']} dropped {delta:.1f}% on its own")
 
-        cv = history_cv.get((member["model"], member["isl_osl"], member["conc"]))
-        if cv:
-            sigma_pct = cv * 100.0
+        hist = history_cv.get((member["model"], member["isl_osl"], member["conc"]))
+        if hist and hist["cv"]:
+            sigma_pct = hist["cv"] * 100.0
             if abs(delta) > SIGMA_MULT * sigma_pct:
                 reasons.append(
                     f"{abs(delta) / sigma_pct:.1f}x the historical sigma "
@@ -433,6 +505,7 @@ def judge(pairs, history_cv, expected_entries=None):
     # not. Reporting "clean" would be a claim the method does not support, so
     # such a run is handed to the reader instead of summarised away.
     unclear = [f for f in results if f.get("nonmonotonic")]
+    bad_baseline = [f for f in results if f.get("baseline_sanity")]
 
     # Drift larger than the threshold the criterion is asked to resolve means
     # the comparison cannot answer the question, whatever the deltas look like.
@@ -443,7 +516,12 @@ def judge(pairs, history_cv, expected_entries=None):
         and abs(f["median_drift_pct"]) > DRIFT_TRUST_PCT
     ]
 
-    if triggered and not drifted:
+    # A broken baseline outranks every other reading, including a trip: a
+    # regression measured against a bad number is not a regression, and a clean
+    # result against one says nothing at all.
+    if bad_baseline:
+        verdict = "bad_baseline"
+    elif triggered and not drifted:
         verdict = "regression"
     elif not judged:
         verdict = "inconclusive"
@@ -464,6 +542,7 @@ def judge(pairs, history_cv, expected_entries=None):
         "n_missing": n_missing,
         "n_unclear": len(unclear),
         "n_drifted": len(drifted),
+        "n_bad_baseline": len(bad_baseline),
         "median_drift_pct": _median_or_none(
             [
                 f["median_drift_pct"]
@@ -506,6 +585,7 @@ _HEADLINE = {
     "partial": "### No regression found, but coverage was incomplete",
     "unclear": "### Needs a look -- levels moved, but not in a shape the criterion can judge",
     "untrustworthy": "### Cannot be trusted -- the base commit did not measure the same twice",
+    "bad_baseline": "### Do not act on this -- the baseline itself is far below normal",
     "regression": "### Performance regression detected",
     "inconclusive": "### Inconclusive -- not enough data",
 }
@@ -612,6 +692,36 @@ def render(report, context):
         "",
     ]
 
+    # --- baseline sanity: loudest thing on the page when it fires ----------
+    for family in report["families"]:
+        flags = family.get("baseline_sanity") or []
+        if not flags:
+            continue
+        worst = min(flags, key=lambda f: f["pct"])
+        levels = ", ".join(
+            f"c={f['conc']} {f['base_tput']:.0f} vs {f['history_median']:.0f}"
+            for f in flags
+        )
+        lines += [
+            (
+                f"**{family['model']}: the base commit measured "
+                f"{abs(worst['pct']):.0f}% under main's recent level on "
+                f"{len(flags)} of {len(family['judging'])} judged levels** "
+                f"({levels} tok/s, median of the last {worst['n']} nightly "
+                f"runs, {worst['sigma_pct']:.1f}% typical spread)."
+            ),
+            "",
+            (
+                "This comparison cannot be acted on either way. Either main has "
+                "regressed and head merely inherits it -- in which case the "
+                "delta above is correctly near zero and entirely misleading -- "
+                "or the base half was contaminated and every number here is "
+                "measured against a bad one. Both need looking at before the PR "
+                "is judged on this."
+            ),
+            "",
+        ]
+
     # --- shape flags -------------------------------------------------------
     for family in report["families"]:
         for flag in family.get("nonmonotonic") or []:
@@ -633,7 +743,13 @@ def render(report, context):
             "No model reported enough judged levels. "
             "This is **not** a pass -- treat it as no signal."
         )
-    elif report["verdict"] in ("clean", "partial", "unclear", "untrustworthy"):
+    elif report["verdict"] in (
+        "clean",
+        "partial",
+        "unclear",
+        "untrustworthy",
+        "bad_baseline",
+    ):
         thresholds = report["thresholds"]
         lines.append(
             f"No judged entry tripped (family median <= "
@@ -786,7 +902,9 @@ def main():
     parser.add_argument(
         "--history",
         default=None,
-        help="Local data.js for the sigma gate; omit to fetch the dashboard",
+        help="Local data.js. Without it the sigma gate and the baseline sanity "
+        "check are skipped -- this tool does not reach the network on its own, "
+        "so a caller that wants them fetches the file and says so.",
     )
     parser.add_argument(
         "--no-history",
@@ -816,7 +934,9 @@ def main():
     if not pairs:
         print("No base/head pairs matched -- nothing to judge.", file=sys.stderr)
 
-    history_cv = {} if args.no_history else load_history_cv(args.history)
+    # Only a path enables history. Reaching for the network because no flag was
+    # given would put an outbound request behind an omission.
+    history_cv = load_history_cv(args.history) if args.history else {}
     report = judge(pairs, history_cv, expected_entries=args.expect_entries)
     report["context"] = args.context
     report["n_pairs"] = len(pairs)

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -60,6 +60,7 @@ FAMILY_MEDIAN_PCT = -3.0  # family median throughput delta that trips the gate
 DOWN_EPS_PCT = -2.0  # a level counts as "down" past this
 TPOT_MIRROR_RATIO = 0.6  # |median TPOT delta / median tput delta| for mirroring
 NONMONOTONIC_MARGIN_PCT = 3.0  # interior level this far outside its neighbours
+MEASURED_RESIDUAL_BIAS_PCT = 1.35  # A/A residual after the warmup; see below
 DRIFT_TRUST_PCT = 3.0  # base repeated this far apart -> the pairing cannot resolve
 
 # The base commit is measured twice, before and after head. The distance
@@ -79,11 +80,25 @@ DRIFT_TRUST_PCT = 3.0  # base repeated this far apart -> the pairing cannot reso
 # reader needs to tell "small-batch path problem" from "small-c noise" -- so
 # they are reported alongside, labelled, and excluded from every computation.
 
-# FAMILY_MEDIAN_PCT is PROVISIONAL. It was derived by tightening the -4.0 used
-# for nightly time-series monitoring by one notch, on the reasoning that a
-# paired same-machine measurement is quieter than a cross-run comparison. It is
-# not backed by a measurement yet. Calibrate it against an A/A run (same commit,
-# same wheel, repeated) before treating a trip as authoritative.
+# What FAMILY_MEDIAN_PCT can actually resolve, measured rather than assumed.
+#
+# An A/A run -- every phase on one commit, so every delta is noise -- gave
+# +1.35% on MI308 with DeepSeek-V4-Flash at tp=8, after the warmup. A third
+# measurement of the same base commit landed at +1.26%, so the residual is
+# drift over the run, not anything specific to the second half: later readings
+# are faster than earlier ones by about that much, whichever commit they carry.
+#
+# The bias is systematic and favours head, so it subtracts from any regression
+# rather than inventing one. A true -3% reads as roughly -1.65% and does not
+# trip; tripping needs about -4.35%. That is the honest sensitivity of this
+# check, and it is fine for the regressions worth catching -- 5% and up -- but
+# a reader should not take -3.0 as the resolution.
+#
+# One run on one shared machine, and drift varied visibly within it (the
+# benchmark slowed from 1.07 to 1.65 s/it partway through and recovered), so
+# treat 1.35% as an order of magnitude rather than a constant. Averaging a
+# repeated base reading halves it, at the cost of a third measurement; see the
+# workflow for why that trade was declined.
 
 # --- Single-configuration escalation (auxiliary; uses history sigma) --------
 SINGLE_DROP_PCT = -8.0  # a lone level this far down is worth surfacing
@@ -464,7 +479,10 @@ def judge(pairs, history_cv, expected_entries=None):
             "family_min_down": FAMILY_MIN_DOWN,
             "family_min_configs": FAMILY_MIN_CONFIGS,
             "tpot_mirror_ratio": TPOT_MIRROR_RATIO,
-            "family_median_pct_is_provisional": True,
+            # Measured residual bias after the warmup, from an A/A run. It is
+            # systematic and favours head, so the effective trip point is this
+            # much further down than family_median_pct.
+            "measured_residual_bias_pct": MEASURED_RESIDUAL_BIAS_PCT,
         },
     }
 
@@ -741,8 +759,12 @@ def render_summary(report, context):
         ),
         "",
         (
-            "> The family-median threshold is provisional and not yet calibrated "
-            "against a repeated same-commit (A/A) measurement."
+            f"> Measured residual bias after the warmup is "
+            f"{MEASURED_RESIDUAL_BIAS_PCT}%, systematic and favouring head, so "
+            f"a drop trips at roughly "
+            f"{FAMILY_MEDIAN_PCT - MEASURED_RESIDUAL_BIAS_PCT:.2f}% rather than "
+            f"{FAMILY_MEDIAN_PCT}%. Fine for the regressions worth catching; not "
+            f"a resolution of {abs(FAMILY_MEDIAN_PCT)}%."
         ),
     ]
     return "\n".join(lines)

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -33,6 +33,7 @@ levels is reported as ``insufficient``; if no family survives, the whole run is
 
 import argparse
 import collections
+import datetime
 import json
 import re
 import statistics
@@ -98,6 +99,7 @@ DRIFT_MEDIAN_TH = -4.0  # family median change that counts as drift
 DRIFT_MIN_DOWN = 3  # ... on at least this many levels
 DRIFT_DOWN_EPS = -2.0  # a level counts as "down" past this
 DRIFT_TPOT_MIRROR = 0.6  # |TPOT change / throughput change| confirming it
+DRIFT_MIN_RUNS = 7  # runs a level needs before it counts toward a family
 DRIFT_SMOOTH_K = 3  # points averaged at each end, to flatten run-to-run jitter
 
 # A paired comparison answers "did this change make it worse" and is blind to
@@ -290,6 +292,54 @@ def _drift_lag(points, days, field):
     return (statistics.mean(now[:DRIFT_SMOOTH_K]) / base - 1) * 100
 
 
+def _drift_onset(members):
+    """The day the level actually changed, found in the data.
+
+    Reporting the horizon instead ("7d") says the slide lasted as long as the
+    window, whatever the data did -- and the two are routinely different: a
+    single night's step reads as a week of decline. The upstream monitor was
+    rewritten for exactly this, having reported 17 days for a drop that
+    happened over one.
+
+    Each level is normalised by its own mean before the daily index is built,
+    so a high-throughput level cannot dominate the shape, then every split with
+    at least two points on each side is scored by how far the mean falls across
+    it. The steepest split is the onset.
+    """
+    per_day = collections.defaultdict(list)
+    for points in members:
+        values = [p["tput"] for p in points if p.get("tput")]
+        if not values:
+            continue
+        mean = statistics.mean(values)
+        if not mean:
+            continue
+        for p in points:
+            if p.get("tput"):
+                day = datetime.datetime.fromtimestamp(
+                    p["date"] / 1000, datetime.timezone.utc
+                ).strftime("%Y-%m-%d")
+                per_day[day].append(p["tput"] / mean)
+
+    seq = [(d, statistics.mean(v)) for d, v in sorted(per_day.items())]
+    if len(seq) < 5:
+        return None
+    best, best_drop = None, 0.0
+    for i in range(2, len(seq) - 1):
+        pre = statistics.mean(v for _, v in seq[:i])
+        post = statistics.mean(v for _, v in seq[i:])
+        if not pre:
+            continue
+        drop = (pre - post) / pre * 100
+        if drop > best_drop:
+            best, best_drop = seq[i][0], drop
+    # A shallow best split is a slope, not a step -- naming a day for it would
+    # be false precision.
+    if best is None or best_drop < abs(DRIFT_MEDIAN_TH):
+        return None
+    return {"date": best, "drop_pct": -best_drop}
+
+
 def main_drift(series, models):
     """Families on main that have been sliding, restricted to `models`.
 
@@ -303,16 +353,28 @@ def main_drift(series, models):
     one the reader is looking at.
     """
     families = collections.defaultdict(list)
+    # Why a family did not qualify, so a family outside coverage is visible
+    # rather than absent. A silent skip and a clean result look identical.
+    short = collections.defaultdict(list)
     for (model, isl_osl, conc), points in series.items():
         if conc < DRIFT_MIN_CONC or model not in models:
             continue
-        if len(points) < 2 * DRIFT_SMOOTH_K:
+        if len(points) < max(DRIFT_MIN_RUNS, 2 * DRIFT_SMOOTH_K):
+            short[(model, isl_osl)].append((conc, len(points)))
             continue
         families[(model, isl_osl)].append(sorted(points, key=lambda p: p["date"]))
 
     found = []
+    waiting = []
     for (model, isl_osl), members in families.items():
         if len(members) < DRIFT_FAM_MIN_CONFIGS:
+            waiting.append(
+                (
+                    model,
+                    isl_osl,
+                    f"{len(members)} of {DRIFT_FAM_MIN_CONFIGS} levels have enough history",
+                )
+            )
             continue
         worst = None
         for horizon in DRIFT_HORIZONS:
@@ -347,6 +409,20 @@ def main_drift(series, models):
                 worst = {
                     "model": model,
                     "isl_osl": isl_osl,
+                    "onset": _drift_onset(members),
+                    "per_conc": sorted(
+                        (c, round(d, 1))
+                        for c, d in zip(
+                            sorted(
+                                k[2]
+                                for k in series
+                                if k[0] == model
+                                and k[1] == isl_osl
+                                and k[2] >= DRIFT_MIN_CONC
+                            ),
+                            tputs,
+                        )
+                    ),
                     "horizon_days": horizon,
                     "median_pct": median,
                     "median_tpot_pct": median_tpot,
@@ -355,8 +431,19 @@ def main_drift(series, models):
                 }
         if worst:
             found.append(worst)
+    for key, levels in short.items():
+        if key in families:
+            continue
+        best = max(n for _, n in levels)
+        waiting.append(
+            (
+                key[0],
+                key[1],
+                f"no level has {DRIFT_MIN_RUNS} runs yet (most is {best})",
+            )
+        )
     found.sort(key=lambda f: f["median_pct"])
-    return found
+    return {"rows": found, "waiting": sorted(waiting)}
 
 
 # --------------------------------------------------------------------------
@@ -710,7 +797,8 @@ def judge(pairs, history_cv, expected_entries=None, drift=None):
         "n_bad_baseline": len(bad_baseline),
         # Context, deliberately outside the verdict: main sliding is not
         # something this PR did, and folding it in would blame the author.
-        "main_drift": drift or [],
+        "main_drift": (drift or {}).get("rows", []),
+        "drift_waiting": (drift or {}).get("waiting", []),
         "median_drift_pct": _median_or_none(
             [
                 f["median_drift_pct"]
@@ -855,7 +943,7 @@ def render(report, context):
     # in the per-level table. The breakdown is one click away and carries the
     # shape the criterion actually rests on.
     lines += [
-        "| Model | Levels slower | Total Tput | TPOT | TTFT |",
+        f"| Model | Levels &le; {DOWN_EPS_PCT}% | Total Tput | TPOT | TTFT |",
         "|---|---|---|---|---|",
     ]
     for family in report["families"]:
@@ -989,24 +1077,61 @@ def render(report, context):
             "<summary><b>Sliding on main — not this PR</b> "
             "({} {})</summary>".format(n, "family" if n == 1 else "families"),
             "",
-            "| Model | Input/output | Window | Throughput | TPOT | Levels slower |",
+            "| Model | Input/output | Onset | Throughput | TPOT | Levels &le; -2% |",
             "|---|---|---|---|---|---|",
         ]
         for d in report["main_drift"]:
             drift_lines.append(
-                f"| {d['model']} | {d['isl_osl']} | {d['horizon_days']}d "
-                f"| {d['median_pct']:+.1f}% | {_fmt(d['median_tpot_pct'])} "
-                f"| {d['n_down']}/{d['n_total']} |"
+                "| {model} | {shape} | {onset} | {tput} | {tpot} | {down} of {tot} |".format(
+                    model=d["model"],
+                    shape=d["isl_osl"],
+                    onset=(
+                        "{} ({:+.0f}%)".format(
+                            d["onset"]["date"][5:], d["onset"]["drop_pct"]
+                        )
+                        if d.get("onset")
+                        else "{}d window".format(d["horizon_days"])
+                    ),
+                    tput="{:+.1f}%".format(d["median_pct"]),
+                    tpot=_fmt(d["median_tpot_pct"]),
+                    down=d["n_down"],
+                    tot=d["n_total"],
+                )
             )
+        for d in report["main_drift"]:
+            if d.get("per_conc"):
+                drift_lines.append(
+                    "",
+                )
+                drift_lines.append(
+                    "{}: ".format(d["model"])
+                    + ", ".join(f"c={c} {v:+.1f}%" for c, v in d["per_conc"])
+                )
         drift_lines += [
             "",
             (
-                "The delta above is honest, the absolute level is not. Several "
-                "levels of one model sliding together, TPOT mirroring."
+                "The delta above is honest, the absolute level is not. Onset is "
+                "the day the level actually moved, found in the data -- a step "
+                "and a slow slide look the same in a window figure."
             ),
             "</details>",
             "",
         ]
+
+    # Families the trend criterion could not reach. Absent and clean look the
+    # same otherwise, and a model that has just started running would sit
+    # outside coverage indefinitely with nobody noticing.
+    if report.get("drift_waiting"):
+        drift_lines += [
+            "<details>",
+            "<summary>Not checked for drift ({})</summary>".format(
+                len(report["drift_waiting"])
+            ),
+            "",
+        ]
+        for model, shape, why in report["drift_waiting"]:
+            drift_lines.append(f"- {model} {shape} -- {why}")
+        drift_lines += ["", "</details>", ""]
 
     # --- shape flags -------------------------------------------------------
     for family in report["families"]:
@@ -1091,7 +1216,7 @@ def render(report, context):
             )
             lines.append(
                 f"- **{family['model']}**: {family['n_down']} of "
-                f"{family['n_total']} levels slower, median "
+                f"{family['n_total']} levels at or past {DOWN_EPS_PCT}%, median "
                 f"{_fmt(family['median_tput_pct'])}, "
                 f"TPOT {_fmt(family['median_tpot_pct'])}"
                 + (f" (confirmed by {via}, ratio {ratio:.2f})" if ratio and via else "")
@@ -1302,7 +1427,7 @@ def main():
         history_status = "ok"
 
     models = {p["model"] for p in pairs}
-    drift = main_drift(history_series, models) if history_series else []
+    drift = main_drift(history_series, models) if history_series else None
     report = judge(pairs, history_cv, expected_entries=args.expect_entries, drift=drift)
     report["context"] = args.context
     report["n_pairs"] = len(pairs)

--- a/.github/scripts/perf_judge.py
+++ b/.github/scripts/perf_judge.py
@@ -763,7 +763,7 @@ _SCOPE_NOTE = {
         "Every judged entry moved, which points at a shared path "
         "(kernel / attention / scheduler) rather than one model."
     ),
-    "single_entry": "Only one entry moved, which points at a model-specific path.",
+    "single_entry": "One entry only -- a model-specific path.",
     "several_entries": "Several but not all entries moved.",
 }
 
@@ -794,14 +794,17 @@ def _entry_rows(family, show_drift=False):
     length ratio, fixed by --ignore-eos), and ITL and E2EL are recoverable from
     TTFT and TPOT. Listing those too would spend width without adding a fact.
 
-    Judging and reference levels share the table and are labelled, so the shape
-    stays visible: judging levels moving with the reference ones is a broad
-    change, reference levels moving alone is a small-batch path or noise.
+    Judging and reference levels share the table in concurrency order, so the
+    shape stays visible: judging levels moving with the reference ones is a
+    broad change, reference levels moving alone is a small-batch path or noise.
     """
     tripped = family["status"] == "triggered"
     rows = []
     first = True
-    for member in family["judging"] + family["reference"]:
+    # By concurrency, not judged-then-reference: the shape of a regression
+    # across levels is what a reader is scanning for, and a reordered axis
+    # hides it.
+    for member in family["members"]:
         judged = member["conc"] >= JUDGE_MIN_CONC
         # The marker rides with the number rather than occupying its own
         # column, and says what it does rather than naming a category: a reader
@@ -848,31 +851,51 @@ def render(report, context):
     if context:
         lines += [context, ""]
 
-    # Drift only exists when the base was measured twice. Printing a column of
-    # dashes reads as missing data rather than as a phase that did not run.
+    # One row per entry first: five rows a reader can take in, against thirty
+    # in the per-level table. The breakdown is one click away and carries the
+    # shape the criterion actually rests on.
+    lines += [
+        "| Model | Levels down | Total Tput | TPOT | TTFT |",
+        "|---|---|---|---|---|",
+    ]
+    for family in report["families"]:
+        tripped = family["status"] == "triggered"
+        if family["status"] == "insufficient":
+            lines.append("| {} | insufficient | | | |".format(family["model"]))
+            continue
+        lines.append(
+            "| {model} | {down}/{tot} | {tput} | {tpot} | {ttft} |".format(
+                model=(
+                    "**{}**".format(family["model"]) if tripped else family["model"]
+                ),
+                down=family["n_down"],
+                tot=family["n_total"],
+                tput=_pct(family["median_tput_pct"], bold=tripped),
+                tpot=_pct(family["median_tpot_pct"], bold=tripped),
+                ttft=_pct(family.get("median_ttft_pct")),
+            )
+        )
+    lines.append("")
+
     show_drift = any(
         m.get("drift_pct") is not None for f in report["families"] for m in f["members"]
     )
     lines += [
+        "<details>",
+        "<summary>Per-level breakdown</summary>",
+        "",
+        # Stated where the italics actually appear, not after the block closes.
+        f"Italic levels are measured but not judged (c < {JUDGE_MIN_CONC}).",
+        "",
         "| Model | Concurrency | Total Tput | TTFT | TPOT |"
         + (" Drift |" if show_drift else ""),
         "|---|---|---|---|---|" + ("---|" if show_drift else ""),
     ]
     for family in report["families"]:
         lines += _entry_rows(family, show_drift)
+    lines += ["", "</details>", ""]
 
-    has_unjudged = any(
-        m["conc"] < JUDGE_MIN_CONC for f in report["families"] for m in f["members"]
-    )
-    legend = f"Italic levels are measured but not judged (c < {JUDGE_MIN_CONC})."
-    # Only describe the marked rows when the run actually produced some.
-    # Explaining a marker that appears nowhere on the page sends the reader
-    # looking for something that is not there.
-    if not has_unjudged:
-        legend = ""
     lines += [
-        "",
-        legend,
         "",
         # The paired measurement carries a systematic bias toward whichever
         # half ran second, and it is large enough that a reader who takes a
@@ -902,12 +925,8 @@ def render(report, context):
             "> [!WARNING]",
             f"> **The baseline check did not run.** The nightly history {why}.",
             (
-                "> Without it there is nothing confirming the base measurement "
-                "is at main's usual level, and a base that is itself broken "
-                "produces a delta near zero -- the one shape where a green "
-                "verdict is exactly wrong. The paired numbers above stand; the "
-                "verdict is held at `partial` rather than `clean` because of "
-                "this."
+                "> Nothing confirms the base sits at main's usual level, and a "
+                "broken base yields a delta near zero. Held at `partial`."
             ),
             "",
         ]
@@ -962,14 +981,13 @@ def render(report, context):
     drift_lines = [""]
     # --- main-side context, kept apart from the verdict --------------------
     if report.get("main_drift"):
+        n = len(report["main_drift"])
+        # Context, not a finding: collapsed so the comment opens on the verdict
+        # and the table. GitHub renders <details> inline in comments.
         drift_lines += [
-            "---",
-            "",
-            (
-                "**Main-side context — not caused by this PR.** These models "
-                "are sliding on main; the delta above is honest, the absolute "
-                "level is not."
-            ),
+            "<details>",
+            "<summary><b>Sliding on main — not this PR</b> "
+            "({} {})</summary>".format(n, "family" if n == 1 else "families"),
             "",
             "| Model | Input/output | Window | Throughput | TPOT | Levels down |",
             "|---|---|---|---|---|---|",
@@ -983,9 +1001,10 @@ def render(report, context):
         drift_lines += [
             "",
             (
-                "From nightly history: several levels of one model sliding "
-                "together, TPOT mirroring."
+                "The delta above is honest, the absolute level is not. Several "
+                "levels of one model sliding together, TPOT mirroring."
             ),
+            "</details>",
             "",
         ]
 

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -153,6 +153,46 @@ jobs:
       RESULT_FILENAME: ${{ matrix.cell.result_filename }}
       CONTAINER: atom-perf-check
     steps:
+      - name: Reclaim disk before starting
+        timeout-minutes: 15
+        run: |
+          set -uo pipefail
+          # This workflow is heavier on disk than the accuracy suites it shares
+          # runners with: it pulls a ~47GB image with pull-policy always, and
+          # starts three servers in one job. Two jobs of this run died on a
+          # runner that filled up -- one could not write its own diagnostic log
+          # ("No space left on device" under _diag/), the other lost contact
+          # with the server, which is what a full disk looks like from outside.
+          #
+          # Mirrors atom-test.yaml's guard, plus the runner work tree, since
+          # the failure was in the runner's own space rather than Docker's.
+          docker_root="$(docker info --format '{{.DockerRootDir}}' 2>/dev/null)"
+          docker_root="${docker_root:-/var/lib/docker}"
+          echo "runner: ${RUNNER_NAME:-$(hostname)}"
+          df -h / "${docker_root}" "${RUNNER_WORKSPACE:-/tmp}" || true
+
+          available_kb="$(df -Pk "${docker_root}" 2>/dev/null | awk 'NR == 2 {print $4}' || true)"
+          threshold_kb=$((500 * 1024 * 1024))
+          if [ "${available_kb:-0}" -lt "${threshold_kb}" ]; then
+            echo "Docker root under 500 GiB free -- pruning resources older than 30 days"
+            docker container prune -f --filter "until=720h" || true
+            docker image prune -af --filter "until=720h" || true
+            docker builder prune -af --filter "until=720h" || true
+            docker system df || true
+          else
+            echo "Docker root has at least 500 GiB free"
+          fi
+
+          # Runner-side leftovers. Old diagnostic logs are what actually ran the
+          # disk out, and nothing else prunes them.
+          diag="$(dirname "${RUNNER_WORKSPACE:-/tmp}")/_diag"
+          if [ -d "$diag" ]; then
+            before=$(du -sm "$diag" 2>/dev/null | cut -f1)
+            find "$diag" -type f -mtime +7 -delete 2>/dev/null || true
+            echo "runner _diag: ${before:-?}MB -> $(du -sm "$diag" 2>/dev/null | cut -f1)MB"
+          fi
+          df -h / "${docker_root}" || true
+
       - name: Kill leftover containers and reclaim the workspace
         run: |
           docker ps -aq | xargs -r docker rm -f || true

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -218,6 +218,7 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
+          mkdir -p perf-pair
           python3 - <<'PY'
           import json, os, pathlib
           meta = {
@@ -246,6 +247,13 @@ jobs:
         run: |
           docker exec ${{ env.CONTAINER }} bash -lc '.github/scripts/atom_test.sh stop' || true
           docker rm -f ${{ env.CONTAINER }} || true
+          # Safety net for a job that died before the halves could hand the
+          # workspace back: root-owned leftovers break the *next* job's
+          # actions/checkout, not this one, so the failure surfaces somewhere
+          # unrelated. Mirrors benchmark-tmpl.yml's Clean Up.
+          docker run --rm -v "${GITHUB_WORKSPACE:-$PWD}":/workspace -w /workspace --privileged \
+            rocm/atom-dev:latest bash -lc \
+            "chown -R $(id -u):$(id -g) /workspace" || true
           git checkout -- . || true
 
   # ---------------------------------------------------------------- judge ---

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -53,6 +53,15 @@ env:
   PERF_JUDGING_CONCS: 64,128,256
   PERF_REFERENCE_CONCS: ""          # smoke: skip reference levels
   PERF_EXPECTED_ENTRIES: 1
+  # Warmup length as a multiple of the concurrency level, matching the
+  # measurement at 10. Set to 1 to reproduce the short warmup the residual
+  # was first measured under -- the only single-variable way to separate
+  # the warmup from the nightly image, which moves underneath every run.
+  # Not PERF_-prefixed like the others: workflow-level env is inherited
+  # straight into every step, and perf_check_half.sh reads this name, so
+  # no mapping is needed (and a job-level one is not even allowed to
+  # reference env).
+  WARMUP_MULT: 10
 
 jobs:
   # ---------------------------------------------------------------- gate ---

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -196,14 +196,23 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "Image: $DIGEST"
 
+      - name: Stage the pairing script outside the workspace
+        run: |
+          set -euo pipefail
+          # The script checks out the merge-base, which predates this file --
+          # so running it from the workspace deletes it before the second half
+          # can start. Copy it somewhere the checkouts do not reach.
+          cp .github/scripts/perf_check_half.sh "$RUNNER_TEMP/perf_check_half.sh"
+          chmod +x "$RUNNER_TEMP/perf_check_half.sh"
+
       # Base runs first on purpose: the head half then measures on a warm
       # machine. Reversed, head would systematically absorb cold-start cost and
       # read low for reasons that have nothing to do with the change.
       - name: Bench BASE
-        run: .github/scripts/perf_check_half.sh "${{ steps.refs.outputs.base_sha }}" base
+        run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.base_sha }}" base
 
       - name: Bench HEAD
-        run: .github/scripts/perf_check_half.sh "${{ steps.refs.outputs.head_sha }}" head
+        run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.head_sha }}" head
 
       - name: Record provenance
         if: always()

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -1,0 +1,323 @@
+name: ATOM Perf Check (PR)
+
+# Opt-in, non-blocking performance check for pull requests.
+#
+# Measures the merge-base and the PR head back to back inside ONE job, so both
+# halves land on the same machine and the same container instance. GitHub
+# Actions offers no way to pin two jobs to one machine, which is why this
+# cannot reuse benchmark-tmpl.yml (one job per concurrency level).
+#
+# The pairing is not a preference. Per-image historical baselines do not exist:
+# across 52 deduplicated perf runs on the public dashboard, 30 of 39 images were
+# benchmarked exactly once and only 3 reached three runs, while cross-image
+# comparison spreads 11-21% against 0.57% median CV within one image.
+#
+# Because the workspace is bind-mounted into the container (setup-gpu-container
+# passes -v "$GITHUB_WORKSPACE":/workspace), switching commits is a host-side
+# `git checkout` that the running container picks up immediately. No second
+# container, and no new script duplicating benchmark-tmpl.yml's launch/bench
+# logic -- atom_test.sh already does all of it.
+#
+# Concurrency levels split into two roles. Levels at or above 64 decide the
+# verdict; 4 and 32 are measured and displayed but never judged, because low
+# concurrency pollutes a verdict in both directions -- it manufactures false
+# positives and dilutes real ones -- while hiding it altogether removes the
+# evidence a reader needs to tell a small-batch path problem from noise.
+#
+# This workflow never fails the PR. It posts a comment and writes a step
+# summary; the merge decision stays with the reviewer.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, ready_for_review]
+
+concurrency:
+  group: perf-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Smoke configuration. The full set is five entries across five concurrency
+# levels (25 jobs); this cuts it to the cheapest single entry and the three
+# judging levels (3 jobs) so the first real run exercises every code path --
+# same runner, same catalog, same criterion -- at a fraction of the machine
+# time. Widen these once the mechanics are proven; nothing else changes.
+env:
+  PERF_MODELS: glm-5-2-fp8          # tp=4, the only target that is not whole-node
+  PERF_ISL: 8192
+  PERF_OSL: 1024
+  PERF_RATIO: "0.8"
+  PERF_JUDGING_CONCS: 64,128,256
+  PERF_REFERENCE_CONCS: ""          # smoke: skip reference levels
+  PERF_EXPECTED_ENTRIES: 1
+
+jobs:
+  # ---------------------------------------------------------------- gate ---
+  gate:
+    name: perf-check-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require the ci:perf label
+        env:
+          # Deliberately NOT ci:full -- that label already fans out the heavy
+          # accuracy suites, and folding a paired benchmark into it would double
+          # GPU time for every PR that asks for a full run.
+          CI_GATE_LABELS: ci:perf
+        run: .github/scripts/check_heavy_ci_gate.sh
+
+  # -------------------------------------------------------- build matrix ---
+  build-matrix:
+    name: Build perf matrix
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      cells: ${{ steps.build.outputs.cells }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive cells from the benchmark catalog
+        id: build
+        run: |
+          set -euo pipefail
+          # Server args, env vars, model paths and result filenames all come
+          # from models.json via catalog.py -- the same source the nightly
+          # matrix uses. Hard-coding them here would fork the definition of what
+          # each model *is* and drift the moment someone tunes a flag.
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os, sys
+          sys.path.insert(0, ".github/scripts")
+          import catalog
+
+          raw = os.environ["PERF_JUDGING_CONCS"] + "," + \
+                os.environ.get("PERF_REFERENCE_CONCS", "")
+          concs = [c for c in (x.strip() for x in raw.split(",")) if c]
+          isl, osl = os.environ["PERF_ISL"], os.environ["PERF_OSL"]
+          ratio = os.environ["PERF_RATIO"]
+          param_lists = ";".join(f"{isl},{osl},{c},{ratio}" for c in concs)
+
+          wanted = set(os.environ["PERF_MODELS"].split(","))
+          cells = catalog.build_cells(
+              ".github/benchmark/models.json",
+              param_lists=param_lists,
+              model_filter=wanted,
+          )
+          # Base variant for every selected model, plus DeepSeek-V4-Pro MTP3
+          # when that model is in play: base and MTP3 as a pair separate a
+          # speculative-decoding regression from a model-wide one.
+          keep = {(p, "") for p in wanted}
+          if "deepseek-v4-pro" in wanted:
+              keep.add(("deepseek-v4-pro", "-mtp3"))
+          cells = [c for c in cells if (c["prefix"], c["suffix"]) in keep]
+          if len(cells) != len(concs) * len(keep):
+              # A silent shortfall here becomes "insufficient coverage" much
+              # later, in the judge, where the cause is no longer visible.
+              print(
+                  f"::warning::expected {len(concs) * len(keep)} cells, "
+                  f"built {len(cells)}",
+                  file=sys.stderr,
+              )
+          print(f"cells={json.dumps(cells)}")
+          PY
+        env:
+          PERF_MODELS: ${{ env.PERF_MODELS }}
+          PERF_ISL: ${{ env.PERF_ISL }}
+          PERF_OSL: ${{ env.PERF_OSL }}
+          PERF_RATIO: ${{ env.PERF_RATIO }}
+          PERF_JUDGING_CONCS: ${{ env.PERF_JUDGING_CONCS }}
+          PERF_REFERENCE_CONCS: ${{ env.PERF_REFERENCE_CONCS }}
+
+  # -------------------------------------------------------- paired bench ---
+  paired-bench:
+    name: ${{ matrix.cell.display }} c=${{ matrix.cell.conc }}
+    needs: [gate, build-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        cell: ${{ fromJson(needs.build-matrix.outputs.cells) }}
+    runs-on: ${{ matrix.cell.runner }}
+    timeout-minutes: 150
+    env:
+      MODEL_PATH: ${{ matrix.cell.model_path }}
+      ARGS: ${{ matrix.cell.server_args }}
+      ISL: ${{ matrix.cell.isl }}
+      OSL: ${{ matrix.cell.osl }}
+      CONC: ${{ matrix.cell.conc }}
+      RANDOM_RANGE_RATIO: ${{ matrix.cell.ratio }}
+      RESULT_FILENAME: ${{ matrix.cell.result_filename }}
+      CONTAINER: atom-perf-check
+    steps:
+      - name: Kill leftover containers
+        run: docker ps -aq | xargs -r docker rm -f || true
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # merge-base needs full history
+
+      - name: Resolve merge-base
+        id: refs
+        run: |
+          set -euo pipefail
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          # The merge-base, not the base branch tip: the tip moves as other PRs
+          # land, so the same PR measured twice would not be comparable.
+          BASE_SHA=$(git merge-base "origin/${{ github.base_ref }}" "$HEAD_SHA")
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Base $BASE_SHA -> head $HEAD_SHA"
+
+      - name: Start container and download model
+        uses: ./.github/actions/atom-bench-container
+        with:
+          image: rocm/atom-dev:latest
+          container-name: ${{ env.CONTAINER }}
+          model-path: ${{ env.MODEL_PATH }}
+          env-vars: ${{ matrix.cell.env_vars }}
+          hf-token: ${{ secrets.AMD_HF_TOKEN }}
+          download-required: "true"
+          container-env: -e ISL=${{ env.ISL }} -e OSL=${{ env.OSL }} -e CONC=${{ env.CONC }} -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }}
+
+      - name: Pin the image digest
+        id: image
+        run: |
+          set -euo pipefail
+          # `latest` is a floating tag pulled with --pull always. Both halves
+          # share this one container so the pairing is safe regardless, but the
+          # digest has to be recorded or the run cannot be placed against any
+          # other run, and the PR comment cannot say what was measured.
+          DIGEST=$(docker inspect --format '{{index .RepoDigests 0}}' \
+                     rocm/atom-dev:latest 2>/dev/null || echo "unknown")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          echo "Image: $DIGEST"
+
+      # Base runs first on purpose: the head half then measures on a warm
+      # machine. Reversed, head would systematically absorb cold-start cost and
+      # read low for reasons that have nothing to do with the change.
+      - name: Bench BASE
+        run: .github/scripts/perf_check_half.sh "${{ steps.refs.outputs.base_sha }}" base
+
+      - name: Bench HEAD
+        run: .github/scripts/perf_check_half.sh "${{ steps.refs.outputs.head_sha }}" head
+
+      - name: Record provenance
+        if: always()
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, pathlib
+          meta = {
+              "image_digest": os.environ["IMAGE_DIGEST"],
+              "base_sha": os.environ["BASE_SHA"],
+              "head_sha": os.environ["HEAD_SHA"],
+              "runner": os.environ["RUNNER_NAME"],
+          }
+          pathlib.Path("perf-pair/provenance.json").write_text(json.dumps(meta))
+          PY
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+          BASE_SHA: ${{ steps.refs.outputs.base_sha }}
+          HEAD_SHA: ${{ steps.refs.outputs.head_sha }}
+
+      - name: Upload pair
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-pair-${{ matrix.cell.result_filename }}
+          path: perf-pair
+          if-no-files-found: warn
+
+      - name: Clean up
+        if: always()
+        run: |
+          docker exec ${{ env.CONTAINER }} bash -lc '.github/scripts/atom_test.sh stop' || true
+          docker rm -f ${{ env.CONTAINER }} || true
+          git checkout -- . || true
+
+  # ---------------------------------------------------------------- judge ---
+  judge:
+    name: perf-check-judge
+    # gate must stay in `needs` even though paired-bench already depends on it:
+    # `needs.gate` is only in scope for jobs that list it, so referencing it
+    # below without this is an unresolved expression, not a false condition.
+    needs: [gate, paired-bench]
+    if: always() && needs.gate.result == 'success'
+    runs-on: ubuntu-latest        # pure CPU, seconds
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download every pair
+        uses: actions/download-artifact@v7
+        with:
+          pattern: perf-pair-*
+          path: pairs
+
+      - name: Collect base and head halves
+        id: collect
+        run: |
+          set -euo pipefail
+          mkdir -p collected/base collected/head
+          # Artifacts nest one directory per matrix cell; flatten both halves so
+          # the judge sees one base dir and one head dir.
+          find pairs -path '*/base/*.json' -exec cp {} collected/base/ \; || true
+          find pairs -path '*/head/*.json' -exec cp {} collected/head/ \; || true
+          echo "base=$(find collected/base -name '*.json' | wc -l)" >> "$GITHUB_OUTPUT"
+          echo "head=$(find collected/head -name '*.json' | wc -l)" >> "$GITHUB_OUTPUT"
+          DIGEST=$(find pairs -name provenance.json -print -quit \
+                   | xargs -r python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["image_digest"])' \
+                   || echo unknown)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Judge
+        run: |
+          set -euo pipefail
+          CONTEXT="base \`${{ github.event.pull_request.base.sha }}\` -> head \`${{ github.event.pull_request.head.sha }}\` · \`${{ steps.collect.outputs.digest }}\`"
+          # --expect-entries is not optional: an entry whose job died entirely
+          # produces no files at all, so without it a run where most jobs failed
+          # reads as clean.
+          python3 .github/scripts/perf_judge.py \
+            --base-dir collected/base \
+            --head-dir collected/head \
+            --expect-entries "${{ env.PERF_EXPECTED_ENTRIES }}" \
+            --context "$CONTEXT" \
+            --output-json verdict.json \
+            --comment-file comment.md \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post or update the PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- atom-perf-check -->';
+            const body = marker + '\n' + fs.readFileSync('comment.md', 'utf8');
+            const {owner, repo} = context.repo;
+            const issue_number = context.issue.number;
+            // Update in place rather than appending: a PR that is pushed to
+            // repeatedly should carry one current result, not a pile of stale
+            // ones a reader has to date-sort by hand.
+            const existing = await github.paginate(
+              github.rest.issues.listComments, {owner, repo, issue_number});
+            const mine = existing.find(c => c.body && c.body.includes(marker));
+            if (mine) {
+              await github.rest.issues.updateComment(
+                {owner, repo, comment_id: mine.id, body});
+            } else {
+              await github.rest.issues.createComment(
+                {owner, repo, issue_number, body});
+            }
+
+      - name: Upload verdict
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-verdict
+          path: |
+            verdict.json
+            comment.md

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -142,7 +142,7 @@ jobs:
       matrix:
         cell: ${{ fromJson(needs.build-matrix.outputs.cells) }}
     runs-on: ${{ matrix.cell.runner }}
-    timeout-minutes: 240
+    timeout-minutes: 180
     env:
       MODEL_PATH: ${{ matrix.cell.model_path }}
       ARGS: ${{ matrix.cell.server_args }}
@@ -234,19 +234,28 @@ jobs:
           cp .github/scripts/perf_check_half.sh "$RUNNER_TEMP/perf_check_half.sh"
           chmod +x "$RUNNER_TEMP/perf_check_half.sh"
 
-      # warmup -> base -> head -> base2.
+      # warmup -> base -> head.
       #
       # The container is shared by both halves, which is what keeps machine and
       # image fixed -- but it also carries the JIT/autotune caches the first run
-      # populates. Measured on identical code, the second half read 5.9% (c=64)
-      # and 9.1% (c=128) faster than the first, with TPOT and TTFT agreeing.
-      # That is larger than the regression threshold and points the wrong way:
-      # it hides regressions rather than inventing them. The discarded warmup
-      # pays that cost before either measurement.
+      # populates. Measured on identical code with no warmup, the second half
+      # read 5.9% (c=64) and 9.1% (c=128) faster than the first, with TPOT and
+      # TTFT agreeing: larger than the regression threshold, and pointing the
+      # wrong way, since it hides regressions rather than inventing them. The
+      # discarded warmup pays that cost before either measurement.
       #
-      # base2 repeats the base commit after head. Its distance from the first
-      # base is whatever drifted while the pairing ran; without it, head-vs-base
-      # cannot be separated from time passing.
+      # An A/A run (every phase on one commit, MI308, DeepSeek-V4-Flash tp=8)
+      # measured what the warmup leaves behind:
+      #
+      #     head vs base    +1.35%    was +5.9% / +9.1% / +2.8% without warmup
+      #     base2 vs base   +1.26%    a third measurement of the base commit
+      #
+      # The two agree, so the residual is drift over the run rather than
+      # anything specific to head. Averaging a repeated base reading halves it
+      # (+0.71%), but costs a third measurement -- 0.65 percentage points of
+      # sensitivity for 33% more GPU time, which is a bad trade against
+      # regressions worth catching. perf_judge.py still accepts --base2-dir;
+      # add a base2 phase and pass it when a run needs its drift quantified.
       - name: Bench WARMUP (discarded)
         run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.base_sha }}" warmup
 
@@ -256,8 +265,6 @@ jobs:
       - name: Bench HEAD
         run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.head_sha }}" head
 
-      - name: Bench BASE again (drift probe)
-        run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.base_sha }}" base2
 
       - name: Record provenance
         if: always()
@@ -324,12 +331,11 @@ jobs:
         id: collect
         run: |
           set -euo pipefail
-          mkdir -p collected/base collected/head collected/base2
+          mkdir -p collected/base collected/head
           # Artifacts nest one directory per matrix cell; flatten both halves so
           # the judge sees one base dir and one head dir.
           find pairs -path '*/base/*.json' -exec cp {} collected/base/ \; || true
           find pairs -path '*/head/*.json' -exec cp {} collected/head/ \; || true
-          find pairs -path '*/base2/*.json' -exec cp {} collected/base2/ \; || true
           echo "base=$(find collected/base -name '*.json' | wc -l)" >> "$GITHUB_OUTPUT"
           echo "head=$(find collected/head -name '*.json' | wc -l)" >> "$GITHUB_OUTPUT"
           DIGEST=$(find pairs -name provenance.json -print -quit \
@@ -349,7 +355,6 @@ jobs:
           python3 .github/scripts/perf_judge.py \
             --base-dir collected/base \
             --head-dir collected/head \
-            --base2-dir collected/base2 \
             --expect-entries "${{ env.PERF_EXPECTED_ENTRIES }}" \
             --context "$CONTEXT" \
             --output-json verdict.json \

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -153,8 +153,20 @@ jobs:
       RESULT_FILENAME: ${{ matrix.cell.result_filename }}
       CONTAINER: atom-perf-check
     steps:
-      - name: Kill leftover containers
-        run: docker ps -aq | xargs -r docker rm -f || true
+      - name: Kill leftover containers and reclaim the workspace
+        run: |
+          docker ps -aq | xargs -r docker rm -f || true
+          # A previous run's container wrote into the bind-mounted workspace as
+          # root, and actions/checkout runs as the runner user -- it cannot
+          # delete those files and fails before any step of ours executes. The
+          # halves hand ownership back as they go, but a job that died early
+          # never got the chance, so the debris outlives it and lands on
+          # whoever schedules here next. Clear it before checkout, not after.
+          if [ -d "${GITHUB_WORKSPACE}" ]; then
+            docker run --rm -v "${GITHUB_WORKSPACE}":/workspace -w /workspace --privileged \
+              rocm/atom-dev:latest bash -lc \
+              "chown -R $(id -u):$(id -g) /workspace" || true
+          fi
 
       - uses: actions/checkout@v4
         with:
@@ -289,7 +301,9 @@ jobs:
           DIGEST=$(find pairs -name provenance.json -print -quit \
                    | xargs -r python3 -c 'import json,sys;print(json.load(open(sys.argv[1]))["image_digest"])' \
                    || echo unknown)
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+          # xargs -r with no input succeeds silently, so the `|| echo` above
+          # never fires and DIGEST ends up empty rather than "unknown".
+          echo "digest=${DIGEST:-unknown}" >> "$GITHUB_OUTPUT"
 
       - name: Judge
         run: |

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -142,7 +142,7 @@ jobs:
       matrix:
         cell: ${{ fromJson(needs.build-matrix.outputs.cells) }}
     runs-on: ${{ matrix.cell.runner }}
-    timeout-minutes: 150
+    timeout-minutes: 240
     env:
       MODEL_PATH: ${{ matrix.cell.model_path }}
       ARGS: ${{ matrix.cell.server_args }}
@@ -217,14 +217,30 @@ jobs:
           cp .github/scripts/perf_check_half.sh "$RUNNER_TEMP/perf_check_half.sh"
           chmod +x "$RUNNER_TEMP/perf_check_half.sh"
 
-      # Base runs first on purpose: the head half then measures on a warm
-      # machine. Reversed, head would systematically absorb cold-start cost and
-      # read low for reasons that have nothing to do with the change.
+      # warmup -> base -> head -> base2.
+      #
+      # The container is shared by both halves, which is what keeps machine and
+      # image fixed -- but it also carries the JIT/autotune caches the first run
+      # populates. Measured on identical code, the second half read 5.9% (c=64)
+      # and 9.1% (c=128) faster than the first, with TPOT and TTFT agreeing.
+      # That is larger than the regression threshold and points the wrong way:
+      # it hides regressions rather than inventing them. The discarded warmup
+      # pays that cost before either measurement.
+      #
+      # base2 repeats the base commit after head. Its distance from the first
+      # base is whatever drifted while the pairing ran; without it, head-vs-base
+      # cannot be separated from time passing.
+      - name: Bench WARMUP (discarded)
+        run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.base_sha }}" warmup
+
       - name: Bench BASE
         run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.base_sha }}" base
 
       - name: Bench HEAD
         run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.head_sha }}" head
+
+      - name: Bench BASE again (drift probe)
+        run: bash "$RUNNER_TEMP/perf_check_half.sh" "${{ steps.refs.outputs.base_sha }}" base2
 
       - name: Record provenance
         if: always()
@@ -291,11 +307,12 @@ jobs:
         id: collect
         run: |
           set -euo pipefail
-          mkdir -p collected/base collected/head
+          mkdir -p collected/base collected/head collected/base2
           # Artifacts nest one directory per matrix cell; flatten both halves so
           # the judge sees one base dir and one head dir.
           find pairs -path '*/base/*.json' -exec cp {} collected/base/ \; || true
           find pairs -path '*/head/*.json' -exec cp {} collected/head/ \; || true
+          find pairs -path '*/base2/*.json' -exec cp {} collected/base2/ \; || true
           echo "base=$(find collected/base -name '*.json' | wc -l)" >> "$GITHUB_OUTPUT"
           echo "head=$(find collected/head -name '*.json' | wc -l)" >> "$GITHUB_OUTPUT"
           DIGEST=$(find pairs -name provenance.json -print -quit \
@@ -315,6 +332,7 @@ jobs:
           python3 .github/scripts/perf_judge.py \
             --base-dir collected/base \
             --head-dir collected/head \
+            --base2-dir collected/base2 \
             --expect-entries "${{ env.PERF_EXPECTED_ENTRIES }}" \
             --context "$CONTEXT" \
             --output-json verdict.json \

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -345,9 +345,34 @@ jobs:
           # never fires and DIGEST ends up empty rather than "unknown".
           echo "digest=${DIGEST:-unknown}" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch the dashboard history
+        id: history
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          # Used for two things, both secondary to the paired comparison: the
+          # noise band behind the single-level escalation, and the sanity check
+          # that reads the base measurement against main's recent level. Fetched
+          # as its own step so the network access is visible in the log and a
+          # failure is attributable, rather than hiding inside the judge.
+          curl -sSfL --max-time 120 \
+            https://rocm.github.io/ATOM/benchmark-dashboard/data.js \
+            -o dashboard-data.js
+          echo "bytes=$(wc -c < dashboard-data.js)"
+
       - name: Judge
         run: |
           set -euo pipefail
+          # Without history the judge keeps its primary criterion -- levels
+          # moving together needs no noise estimate -- and loses the escalation
+          # and the baseline check. Degrading is correct; pretending we have a
+          # baseline reference we could not fetch would not be.
+          if [ -s dashboard-data.js ]; then
+            HISTORY_ARG="--history dashboard-data.js"
+          else
+            echo "::warning::no dashboard history -- baseline sanity check and sigma gate are off"
+            HISTORY_ARG="--no-history"
+          fi
           CONTEXT="base \`${{ github.event.pull_request.base.sha }}\` -> head \`${{ github.event.pull_request.head.sha }}\` · \`${{ steps.collect.outputs.digest }}\`"
           # --expect-entries is not optional: an entry whose job died entirely
           # produces no files at all, so without it a run where most jobs failed
@@ -355,6 +380,7 @@ jobs:
           python3 .github/scripts/perf_judge.py \
             --base-dir collected/base \
             --head-dir collected/head \
+            $HISTORY_ARG \
             --expect-entries "${{ env.PERF_EXPECTED_ENTRIES }}" \
             --context "$CONTEXT" \
             --output-json verdict.json \

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -195,6 +195,23 @@ jobs:
           download-required: "true"
           container-env: -e ISL=${{ env.ISL }} -e OSL=${{ env.OSL }} -e CONC=${{ env.CONC }} -e RANDOM_RANGE_RATIO=${{ env.RANDOM_RANGE_RATIO }}
 
+      - name: GPU preflight check
+        timeout-minutes: 6
+        env:
+          # A container that dies without stopping its server leaves KFD
+          # processes holding VRAM: atom_test.sh's pkill runs inside the
+          # container, so once the container is gone nothing reaches them. The
+          # next job cannot allocate, and the failure reads as a slow load
+          # rather than a collision. Observed locally -- four workers held 664GB
+          # across four cards after an aborted run, and only a host-side kill
+          # cleared them.
+          #
+          # Native ATOM CI leaves this off because its jobs start one server;
+          # this workflow starts four in a row, so an abort leaves more behind.
+          GPU_PREFLIGHT_KILL_KFD: "1"
+          GPU_PREFLIGHT_ALLOCATION_MB: "8"
+        run: bash .github/scripts/gpu_preflight_check.sh "${{ env.CONTAINER }}" docker
+
       - name: Pin the image digest
         id: image
         run: |

--- a/.github/workflows/atom-perf-check.yaml
+++ b/.github/workflows/atom-perf-check.yaml
@@ -46,13 +46,16 @@ permissions:
 # same runner, same catalog, same criterion -- at a fraction of the machine
 # time. Widen these once the mechanics are proven; nothing else changes.
 env:
-  PERF_MODELS: glm-5-2-fp8          # tp=4, the only target that is not whole-node
+  # Catalog prefixes, not display names -- MiniMax-M3-MXFP8 is `m3-mxfp8` here.
+  # DeepSeek-V4-Pro MTP3 is added automatically alongside its base by the matrix
+  # step, so four names produce five entries.
+  PERF_MODELS: deepseek-v4-pro,kimi-k3,m3-mxfp8,glm-5-2-fp8
   PERF_ISL: 8192
   PERF_OSL: 1024
   PERF_RATIO: "0.8"
   PERF_JUDGING_CONCS: 64,128,256
-  PERF_REFERENCE_CONCS: ""          # smoke: skip reference levels
-  PERF_EXPECTED_ENTRIES: 1
+  PERF_REFERENCE_CONCS: 4,32        # measured and shown, never judged
+  PERF_EXPECTED_ENTRIES: 5
   # Warmup length as a multiple of the concurrency level, matching the
   # measurement at 10. Set to 1 to reproduce the short warmup the residual
   # was first measured under -- the only single-variable way to separate
@@ -125,13 +128,20 @@ jobs:
               keep.add(("deepseek-v4-pro", "-mtp3"))
           cells = [c for c in cells if (c["prefix"], c["suffix"]) in keep]
           if len(cells) != len(concs) * len(keep):
-              # A silent shortfall here becomes "insufficient coverage" much
-              # later, in the judge, where the cause is no longer visible.
+              # Fail here rather than warn. A name that is not in the catalog
+              # builds fewer cells, and every GPU job still runs; the shortfall
+              # only surfaces at the judge, as `partial`, which reads like a job
+              # died rather than like a typo. `minimax-m3-mxfp8` did exactly
+              # that -- the catalog calls it `m3-mxfp8`. This step is free.
+              built = sorted({c["prefix"] + c["suffix"] for c in cells})
+              missing = sorted({p + s for p, s in keep} - set(built))
               print(
-                  f"::warning::expected {len(concs) * len(keep)} cells, "
-                  f"built {len(cells)}",
+                  f"::error::expected {len(concs) * len(keep)} cells, built "
+                  f"{len(cells)}; missing entries: {missing or 'none'} "
+                  f"(check PERF_MODELS against catalog prefixes)",
                   file=sys.stderr,
               )
+              sys.exit(1)
           print(f"cells={json.dumps(cells)}")
           PY
         env:

--- a/.github/workflows/pr-welcome-comment.yaml
+++ b/.github/workflows/pr-welcome-comment.yaml
@@ -33,6 +33,7 @@ jobs:
               "| `ci:atom` | Run native ATOM model accuracy tests |",
               "| `ci:vllm` | Run ATOM vLLM OOT model accuracy tests |",
               "| `ci:sglang` | Run ATOM SGLang model accuracy tests |",
+              "| `ci:perf` | Run the paired performance check (merge-base vs head) and report the delta |",
               "",
               "> Heavy jobs are skipped when the PR is not approved and no matching `ci:*` label is present.",
               `> Add labels via the sidebar or \`gh pr edit ${context.issue.number} --add-label <label>\``,

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,8 @@ online_quant_info_*.json
 # so it lands in `git status` on every local run and gets committed by accident.
 # That has happened before (#1662 removed one), hence the rule rather than care.
 unit-report.xml
+
+# Local A/A pairing runs (perf_check_half.sh output, judged in place)
+perf-pair/
+aa-*.json
+aa-*.log

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -118,6 +118,27 @@ def run_judge(tmp_path, spec, expect=5, concs=ALL_CONCS, drop=()):
     return pj.judge(pairs, {}, expected_entries=expect)
 
 
+def _run_cli(tmp_path, base_dir, head_dir, history=None, expect=5):
+    """Drive the judge through its command line, the way CI does."""
+    out = tmp_path / "verdict.json"
+    cmd = [
+        sys.executable,
+        str(SCRIPTS / "perf_judge.py"),
+        "--base-dir",
+        str(base_dir),
+        "--head-dir",
+        str(head_dir),
+        "--expect-entries",
+        str(expect),
+        "--output-json",
+        str(out),
+    ]
+    cmd += ["--history", str(history)] if history else ["--no-history"]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(out.read_text())
+
+
 def flat(tput=0.0, tpot=0.0):
     return {m: {"tput": tput, "tpot": tpot} for m in BASE_TPUT}
 
@@ -185,6 +206,61 @@ def test_drop_with_neither_latency_moving_does_not_trip(tmp_path):
     kimi = next(f for f in report["families"] if f["model"] == "Kimi-K3")
     assert kimi["mirror"] is False
     assert kimi["mirror_via"] is None
+
+
+def test_missing_history_cannot_report_clean(tmp_path):
+    """A run whose baseline check could not execute is not a green run.
+
+    The baseline check is what catches a base measurement that is itself
+    broken, where the delta is near zero and clean is exactly the wrong call.
+    Degrading quietly would leave a report indistinguishable from one that was
+    actually checked.
+    """
+    base_dir, head_dir = write_pair(tmp_path, flat(tput=-0.4, tpot=-0.1))
+    missing = tmp_path / "nope.js"
+    report = _run_cli(tmp_path, base_dir, head_dir, history=missing)
+    assert report["history_status"] == "unavailable"
+    assert report["verdict"] == "partial"
+    assert report["history_downgraded"] is True
+
+
+def test_history_that_matches_nothing_is_not_a_pass(tmp_path):
+    """History that lines up with no measured configuration is not history.
+
+    This is what a renamed model or a changed dashboard format produces, and
+    from inside the judge it is indistinguishable from a healthy check unless
+    the mismatch is stated.
+    """
+    base_dir, head_dir = write_pair(tmp_path, flat(tput=-0.4, tpot=-0.1))
+    stale = tmp_path / "stale.js"
+    # Enough runs for the history to be usable -- a single point yields no
+    # spread and would read as "unavailable", which is a different failure.
+    runs = [
+        {
+            "date": 1786149015906 + i * 86400000,
+            "commit": {"id": chr(97 + i) * 40},
+            "benches": [
+                {
+                    "name": "ATOM::Renamed-Model 8192/1024 c=%d %s" % (c, metric),
+                    "value": value,
+                    "unit": unit,
+                    "extra": "Run: actions/runs/%d" % i,
+                }
+                for c in (64, 128, 256)
+                for metric, value, unit in (
+                    ("Total Tput", 1000.0 + i, "tok/s"),
+                    ("TPOT", 30.0, "ms"),
+                )
+            ],
+        }
+        for i in range(8)
+    ]
+    stale.write_text(
+        "window.BENCHMARK_DATA = " + json.dumps({"entries": {"Benchmark": runs}})
+    )
+    report = _run_cli(tmp_path, base_dir, head_dir, history=stale)
+    assert report["history_status"] == "unmatched"
+    assert report["verdict"] == "partial"
 
 
 # ------------------------------------------------- incomplete data is not a pass ---

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -574,7 +574,7 @@ def test_main_side_drift_is_reported_apart_from_the_verdict(tmp_path):
     assert report["verdict"] == "clean"
     body = pj.render(report, "")
     assert "<details>" in body
-    assert "Sliding on main" in body
+    assert "Sliding on main" in body  # no history stats: falls back to a line
 
 
 def test_drift_needs_tpot_to_mirror(tmp_path):

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -306,6 +306,93 @@ def test_verdict_holds_without_history(tmp_path):
     assert run_judge(tmp_path, spec)["verdict"] == "regression"
 
 
+def test_a_baseline_far_below_normal_outranks_everything(tmp_path):
+    """A paired comparison is blind to main already being broken: base and head
+    both down 30% gives a delta of zero and reads as clean. Checking the base
+    measurement against main's recent level is the only thing here that can
+    see it."""
+    history = {
+        ("M", "8192/1024", c): {"cv": 0.01, "median": 10000.0, "n": 8} for c in JUDGING
+    }
+    # Both halves sit 30% under what main normally does.
+    base = [_result("M", c, 7000.0, 30.0) for c in JUDGING]
+    head = [_result("M", c, 7000.0, 30.0) for c in JUDGING]
+
+    report = pj.judge(pj.pair_results(base, head), history, expected_entries=1)
+    assert report["verdict"] == "bad_baseline"
+    assert report["n_bad_baseline"] == 1
+
+    body = pj.render(report, "")
+    assert "under main's recent level" in body
+    assert "cannot be acted on" in body
+    # Reported once for the model, not repeated per level.
+    assert body.count("cannot be acted on") == 1
+
+
+def test_a_naturally_jumpy_configuration_is_not_condemned(tmp_path):
+    """A fixed percentage alone condemns a configuration for behaving the way
+    it always has. The 8-run spread on the dashboard reaches 25% at P90, so the
+    deviation has to clear the configuration's own noise as well."""
+    history = {
+        ("M", "8192/1024", c): {"cv": 0.20, "median": 10000.0, "n": 8} for c in JUDGING
+    }
+    base = [_result("M", c, 7400.0, 30.0) for c in JUDGING]  # -26%, but 1.3 sigma
+    head = [_result("M", c, 7400.0, 30.0) for c in JUDGING]
+    report = pj.judge(pj.pair_results(base, head), history, expected_entries=1)
+    assert report["verdict"] == "clean"
+    assert report["n_bad_baseline"] == 0
+
+
+def test_one_level_alone_is_not_enough_to_condemn_the_baseline(tmp_path):
+    """One level off is the shape a scheduling blip takes; several at once is
+    the machine or the commit."""
+    history = {
+        ("M", "8192/1024", c): {"cv": 0.01, "median": 10000.0, "n": 8} for c in JUDGING
+    }
+    base = [
+        _result("M", 64, 7000.0, 30.0),  # only this one is far down
+        _result("M", 128, 9900.0, 30.0),
+        _result("M", 256, 9950.0, 30.0),
+    ]
+    head = [
+        _result("M", c, v, 30.0)
+        for c, v in ((64, 7000.0), (128, 9900.0), (256, 9950.0))
+    ]
+    report = pj.judge(pj.pair_results(base, head), history, expected_entries=1)
+    assert report["n_bad_baseline"] == 0
+
+
+def test_a_healthy_baseline_does_not_trip_the_sanity_check(tmp_path):
+    history = {
+        ("M", "8192/1024", c): {"cv": 0.01, "median": 10000.0, "n": 8} for c in JUDGING
+    }
+    base = [_result("M", c, 9800.0, 30.0) for c in JUDGING]
+    head = [_result("M", c, 9750.0, 30.0) for c in JUDGING]
+    report = pj.judge(pj.pair_results(base, head), history, expected_entries=1)
+    assert report["verdict"] == "clean"
+    assert report["n_bad_baseline"] == 0
+
+
+def test_bad_baseline_outranks_a_trip(tmp_path):
+    """Even a clear regression is not reportable against a broken baseline."""
+    history = {
+        ("M", "8192/1024", c): {"cv": 0.01, "median": 10000.0, "n": 8} for c in JUDGING
+    }
+    base = [_result("M", c, 7000.0, 30.0) for c in JUDGING]
+    head = [_result("M", c, 6300.0, 33.0) for c in JUDGING]  # -10% on top
+    report = pj.judge(pj.pair_results(base, head), history, expected_entries=1)
+    assert report["verdict"] == "bad_baseline"
+
+
+def test_sanity_check_is_skipped_without_history(tmp_path):
+    """No history, no check -- it must not invent a verdict from absence."""
+    base = [_result("M", c, 7000.0, 30.0) for c in JUDGING]
+    head = [_result("M", c, 7000.0, 30.0) for c in JUDGING]
+    report = pj.judge(pj.pair_results(base, head), {}, expected_entries=1)
+    assert report["verdict"] == "clean"
+    assert report["n_bad_baseline"] == 0
+
+
 # ------------------------------------------------------------- contract ---
 def test_thresholds_report_the_measured_residual_bias(tmp_path):
     """The trip point is not the threshold: a measured, systematic bias favours

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -532,6 +532,72 @@ def test_archiving_survives_the_second_checkout(workspace, fake_docker):
     assert json.loads(head_files[0].read_text())["total_token_throughput"] == 16000
 
 
+def test_runs_when_the_target_commit_does_not_contain_the_script(tmp_path, fake_docker):
+    """The merge-base predates this feature, so checking it out removes the
+    script from the workspace. Invoking it from the workspace therefore works
+    for the first half and fails with "No such file or directory" for the
+    second -- the script deletes itself partway through the pairing.
+
+    Guards the fix: the workflow stages the script outside the workspace and
+    runs it from there. Reproduced from a real CI failure (exit 127 on the
+    HEAD half after the BASE half had succeeded).
+    """
+    bindir, _ = fake_docker
+
+    ws = tmp_path / "selfhost"
+    ws.mkdir()
+    _git(ws, "init", "-q")
+    _git(ws, "config", "user.email", "t@example.com")
+    _git(ws, "config", "user.name", "t")
+
+    # base: no .github/scripts at all, exactly like a merge-base predating this
+    (ws / "marker.txt").write_text("base\n")
+    _git(ws, "add", "-A")
+    _git(ws, "commit", "-qm", "base without the pairing script")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ws, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    # head: adds the script, as this PR does
+    scripts = ws / ".github" / "scripts"
+    scripts.mkdir(parents=True)
+    (scripts / "perf_check_half.sh").write_text(HALF_SH.read_text())
+    (scripts / "perf_check_half.sh").chmod(0o755)
+    (ws / "marker.txt").write_text("head\n")
+    _git(ws, "add", "-A")
+    _git(ws, "commit", "-qm", "head adds the pairing script")
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ws, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    # Staged outside the workspace, which is what the workflow does.
+    staged = tmp_path / "staged.sh"
+    staged.write_text(HALF_SH.read_text())
+    staged.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "CONTAINER": "atom-perf-check",
+        "MODEL_PATH": "m",
+        "ARGS": "",
+        "RESULT_FILENAME": RESULT_FILENAME,
+    }
+    for sha, half in ((base_sha, "base"), (head_sha, "head")):
+        result = subprocess.run(
+            ["bash", str(staged), sha, half],
+            cwd=ws,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0, f"{half} half failed: {result.stderr[-400:]}"
+
+    assert len(list((ws / "perf-pair/base").glob("*.json"))) == 1
+    assert len(list((ws / "perf-pair/head").glob("*.json"))) == 1
+
+
 def test_pipeline_end_to_end_reaches_a_verdict(workspace, fake_docker):
     """Both halves, then the judge, on files the script actually produced --
     rather than on fixtures hand-shaped to match what it is assumed to write."""

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -134,7 +134,7 @@ def _run_cli(tmp_path, base_dir, head_dir, history=None, expect=5):
         str(out),
     ]
     cmd += ["--history", str(history)] if history else ["--no-history"]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
     assert proc.returncode == 0, proc.stderr
     return json.loads(out.read_text())
 
@@ -241,10 +241,10 @@ def test_history_that_matches_nothing_is_not_a_pass(tmp_path):
             "commit": {"id": chr(97 + i) * 40},
             "benches": [
                 {
-                    "name": "ATOM::Renamed-Model 8192/1024 c=%d %s" % (c, metric),
+                    "name": f"ATOM::Renamed-Model 8192/1024 c={c} {metric}",
                     "value": value,
                     "unit": unit,
-                    "extra": "Run: actions/runs/%d" % i,
+                    "extra": f"Run: actions/runs/{i}",
                 }
                 for c in (64, 128, 256)
                 for metric, value, unit in (
@@ -261,6 +261,40 @@ def test_history_that_matches_nothing_is_not_a_pass(tmp_path):
     report = _run_cli(tmp_path, base_dir, head_dir, history=stale)
     assert report["history_status"] == "unmatched"
     assert report["verdict"] == "partial"
+
+
+def test_families_outside_drift_coverage_are_listed(tmp_path):
+    """A family the trend criterion cannot reach is named, not skipped.
+
+    Absent and clean look the same in a report, so a model that has just
+    started running would sit outside coverage indefinitely with nobody
+    noticing it never got checked.
+    """
+    now = 1786149015906
+    day = 86400000
+    series = {}
+    # Enough history to be judged.
+    for c in JUDGING:
+        series[("M", "8192/1024", c)] = [
+            {"date": now - i * day, "tput": 1000.0 - i, "tpot": 30.0 + i}
+            for i in range(pj.DRIFT_MIN_RUNS + 2)
+        ]
+    # Two levels only, so the family cannot form.
+    for c in (64, 128):
+        series[("Thin", "8192/1024", c)] = [
+            {"date": now - i * day, "tput": 1000.0, "tpot": 30.0}
+            for i in range(pj.DRIFT_MIN_RUNS + 2)
+        ]
+    # Enough levels, but none has run often enough.
+    for c in JUDGING:
+        series[("New", "8192/1024", c)] = [
+            {"date": now - i * day, "tput": 1000.0, "tpot": 30.0} for i in range(3)
+        ]
+    waiting = pj.main_drift(series, {"M", "Thin", "New"})["waiting"]
+    named = {w[0]: w[2] for w in waiting}
+    assert "Thin" in named and "levels have enough history" in named["Thin"]
+    assert "New" in named and "runs yet" in named["New"]
+    assert "M" not in named
 
 
 # ------------------------------------------------- incomplete data is not a pass ---
@@ -526,14 +560,15 @@ def test_main_side_drift_is_reported_apart_from_the_verdict(tmp_path):
     """A slide on main leaves the paired delta honest and the absolute level
     wrong. Reporting only "no change" would read as "fine"."""
     series = _series("M", JUDGING, 14, 10000.0, 9000.0, 30.0, 33.0)  # -10%, TPOT +10%
-    drift = pj.main_drift(series, {"M"})
+    result = pj.main_drift(series, {"M"})
+    drift = result["rows"]
     assert len(drift) == 1
     assert drift[0]["median_pct"] < pj.DRIFT_MEDIAN_TH
     assert drift[0]["n_down"] == len(JUDGING)
 
     base = [_result("M", c, 9000.0, 33.0) for c in JUDGING]
     head = [_result("M", c, 8995.0, 33.0) for c in JUDGING]
-    report = pj.judge(pj.pair_results(base, head), {}, expected_entries=1, drift=drift)
+    report = pj.judge(pj.pair_results(base, head), {}, expected_entries=1, drift=result)
 
     # The PR itself is clean, and the drift does not change that.
     assert report["verdict"] == "clean"
@@ -545,20 +580,20 @@ def test_main_side_drift_is_reported_apart_from_the_verdict(tmp_path):
 def test_drift_needs_tpot_to_mirror(tmp_path):
     """Throughput sliding with TPOT flat is measurement wobble, not a slowdown."""
     series = _series("M", JUDGING, 14, 10000.0, 9000.0, 30.0, 30.0)
-    assert pj.main_drift(series, {"M"}) == []
+    assert pj.main_drift(series, {"M"})["rows"] == []
 
 
 def test_drift_is_scoped_to_the_models_measured(tmp_path):
     """Listing every drifting family in the repository would bury the one the
     reader came for."""
     series = _series("Other", JUDGING, 14, 10000.0, 9000.0, 30.0, 33.0)
-    assert pj.main_drift(series, {"M"}) == []
-    assert pj.main_drift(series, {"Other"}) != []
+    assert pj.main_drift(series, {"M"})["rows"] == []
+    assert pj.main_drift(series, {"Other"})["rows"] != []
 
 
 def test_drift_ignores_low_concurrency(tmp_path):
     series = _series("M", [4, 8, 32], 14, 10000.0, 9000.0, 30.0, 33.0)
-    assert pj.main_drift(series, {"M"}) == []
+    assert pj.main_drift(series, {"M"})["rows"] == []
 
 
 # ------------------------------------------------------------- contract ---

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -433,6 +433,7 @@ def run_half(ws, bindir, sha, half, **env):
             "MODEL_PATH": "deepseek-ai/DeepSeek-V4-Pro",
             "ARGS": "--kv_cache_dtype fp8 -tp 8 --method mtp",
             "RESULT_FILENAME": RESULT_FILENAME,
+            "CONC": "128",
             **env,
         },
     )
@@ -445,7 +446,7 @@ def test_rejects_an_unknown_half(workspace, fake_docker):
     bindir, _ = fake_docker
     result = run_half(ws, bindir, base_sha, "middle")
     assert result.returncode == 2
-    assert "must be 'base' or 'head'" in result.stderr
+    assert "must be warmup|base|head|base2" in result.stderr
 
 
 def test_requires_its_environment(workspace, fake_docker):
@@ -582,6 +583,7 @@ def test_runs_when_the_target_commit_does_not_contain_the_script(tmp_path, fake_
         "MODEL_PATH": "m",
         "ARGS": "",
         "RESULT_FILENAME": RESULT_FILENAME,
+        "CONC": "128",
     }
     for sha, half in ((base_sha, "base"), (head_sha, "head")):
         result = subprocess.run(
@@ -596,6 +598,63 @@ def test_runs_when_the_target_commit_does_not_contain_the_script(tmp_path, fake_
 
     assert len(list((ws / "perf-pair/base").glob("*.json"))) == 1
     assert len(list((ws / "perf-pair/head").glob("*.json"))) == 1
+
+
+def test_warmup_half_discards_its_results(workspace, fake_docker):
+    """The warmup exists to pay for the caches the first measured half would
+    otherwise populate. A warmup result reaching the judge would be
+    indistinguishable from a measurement, so it must not be collected."""
+    ws, base_sha, _ = workspace
+    bindir, _log = fake_docker
+
+    result = run_half(ws, bindir, base_sha, "warmup")
+    assert result.returncode == 0
+    assert "results discarded" in result.stdout
+    assert list((ws / "perf-pair/warmup").glob("*.json")) == []
+    # ... and it asks for a shorter run rather than a full one.
+    assert "NUM_PROMPTS_OVERRIDE" in result.stdout
+
+
+def test_repeated_base_reading_yields_a_drift_figure(tmp_path):
+    """base is measured twice, before and after head. The distance between the
+    two readings is what drifted while the pairing ran, and the baseline is
+    their mean so that drift cancels to first order."""
+    base = [_result("M", c, 10000.0, 30.0) for c in JUDGING]
+    base2 = [_result("M", c, 10200.0, 30.0) for c in JUDGING]  # +2% over the run
+    head = [_result("M", c, 10100.0, 30.0) for c in JUDGING]
+
+    pairs = pj.pair_results(base, head, base2)
+    assert len(pairs) == 3
+    for p in pairs:
+        assert p["drift_pct"] == pytest.approx(2.0, abs=0.01)
+        # Naively head/base reads +1%; against the mean of the two it is flat,
+        # which is what a commit that changed nothing should look like.
+        assert p["tput_pct"] == pytest.approx(0.0, abs=0.02)
+
+
+def test_drift_beyond_the_resolvable_threshold_is_not_trusted(tmp_path):
+    """When the base commit does not measure the same twice, the comparison
+    cannot answer the question, whatever the deltas look like."""
+    base = [_result("M", c, 10000.0, 30.0) for c in JUDGING]
+    base2 = [_result("M", c, 10800.0, 30.0) for c in JUDGING]  # +8%
+    head = [_result("M", c, 9600.0, 33.0) for c in JUDGING]  # would look like -8%
+
+    report = pj.judge(pj.pair_results(base, head, base2), {}, expected_entries=1)
+    assert report["verdict"] == "untrustworthy"
+    assert report["n_drifted"] == 1
+    body = pj.render(report, "")
+    assert "did not measure the same twice" in body
+    assert "cannot be attributed to the change" in body
+
+
+def test_absent_second_reading_falls_back_to_a_single_baseline(tmp_path):
+    base = [_result("M", c, 10000.0, 30.0) for c in JUDGING]
+    head = [_result("M", c, 9000.0, 33.0) for c in JUDGING]
+    pairs = pj.pair_results(base, head)
+    assert all(p["drift_pct"] is None for p in pairs)
+    assert pairs[0]["tput_pct"] == pytest.approx(-10.0, abs=0.01)
+    report = pj.judge(pairs, {}, expected_entries=1)
+    assert report["verdict"] == "regression"
 
 
 def test_pipeline_end_to_end_reaches_a_verdict(workspace, fake_docker):

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -307,9 +307,14 @@ def test_verdict_holds_without_history(tmp_path):
 
 
 # ------------------------------------------------------------- contract ---
-def test_thresholds_are_reported_as_provisional(tmp_path):
+def test_thresholds_report_the_measured_residual_bias(tmp_path):
+    """The trip point is not the threshold: a measured, systematic bias favours
+    head, so a real drop has to exceed both before it registers. Reporting the
+    threshold alone would overstate what the check resolves."""
     report = run_judge(tmp_path, flat())
-    assert report["thresholds"]["family_median_pct_is_provisional"] is True
+    bias = report["thresholds"]["measured_residual_bias_pct"]
+    assert bias > 0
+    assert bias == pj.MEASURED_RESIDUAL_BIAS_PCT
 
 
 def test_judging_levels_start_at_the_documented_boundary():

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -325,7 +325,10 @@ def test_low_concurrency_never_reaches_the_verdict(tmp_path):
     # Excluded from the verdict, but not hidden -- that is the whole point.
     body = pj.render(report, "")
     assert "-19.8%" in body
-    assert "(not judged)" in body
+    # Shown, and marked as excluded -- italic rather than a parenthetical: the
+    # audience already knows small batches are noisy.
+    assert "| *4* |" in body
+    assert "Italic levels are measured but not judged" in body
     assert "median of judged" in body
 
 

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -1,0 +1,634 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the PR performance check.
+
+Covers both halves of the feature, mirroring tests/test_benchmark_catalog.py's
+convention of one test module per CI feature rather than one per source file:
+
+- perf_judge.py    -- what counts as a regression, and what must never read as
+                      a pass
+- perf_check_half.sh -- the pairing mechanics: checkout, launch, benchmark,
+                      stop, archive, in that order
+
+Everything runs on CPU. `docker` and the container's atom_test.sh are replaced
+by shims on PATH, so argument passing and ordering are exercised for real
+without a GPU.
+
+The cases that matter most are the ones where a naive implementation quietly
+returns a pass:
+
+- an entry that regressed but lost a concurrency level
+- a matrix where most jobs died
+- a shape the criterion cannot summarise
+- low-concurrency noise (must not trip the verdict, must still be visible)
+- a half that produced nothing (must not be filled in with an invented result)
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / ".github" / "scripts"
+HALF_SH = SCRIPTS / "perf_check_half.sh"
+
+sys.path.insert(0, str(SCRIPTS))
+
+import perf_judge as pj
+
+JUDGING = [64, 128, 256]
+REFERENCE = [4, 32]
+ALL_CONCS = REFERENCE + JUDGING
+
+BASE_TPUT = {
+    "DeepSeek-V4-Pro": 17354.8,
+    "DeepSeek-V4-Pro-mtp3": 19743.0,
+    "Kimi-K3": 15120.4,
+    "MiniMax-M3-MXFP8": 16402.1,
+    "GLM-5.2-FP8": 11718.1,
+}
+
+
+def _result(model, conc, tput, tpot, ttft=420.0):
+    return {
+        "benchmark_backend": "ATOM",
+        "benchmark_model_name": model,
+        "random_input_len": 8192,
+        "random_output_len": 1024,
+        "max_concurrency": conc,
+        "output_throughput": tput / 2,
+        "total_token_throughput": tput,
+        "mean_ttft_ms": ttft,
+        "mean_tpot_ms": tpot,
+    }
+
+
+def write_pair(tmp_path, spec, concs=ALL_CONCS, drop=()):
+    """Materialise a base/head pair.
+
+    ``spec`` maps model -> {"tput": pct, "tpot": pct, "per_conc": {conc: pct}}.
+    ``drop`` lists (model, conc) whose head half is missing, standing in for a
+    job that died.
+    """
+    base_dir, head_dir = tmp_path / "base", tmp_path / "head"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    head_dir.mkdir(parents=True, exist_ok=True)
+
+    for model, entry in spec.items():
+        for conc in concs:
+            # Low concurrency genuinely yields lower absolute throughput; the
+            # judge works on ratios, but keeping it realistic guards against an
+            # accidental dependence on magnitude.
+            base_value = BASE_TPUT[model] * (0.6 if conc < 64 else 1.0)
+            delta = entry.get("per_conc", {}).get(conc, entry.get("tput", 0.0))
+            tpot_delta = entry.get("tpot", 0.0)
+
+            name = f"{model}-8192-1024-{conc}-0.8.json"
+            (base_dir / name).write_text(
+                json.dumps(_result(model, conc, base_value, 30.0))
+            )
+            if (model, conc) in drop:
+                continue
+            (head_dir / name).write_text(
+                json.dumps(
+                    _result(
+                        model,
+                        conc,
+                        base_value * (1 + delta / 100),
+                        30.0 * (1 + tpot_delta / 100),
+                    )
+                )
+            )
+    return base_dir, head_dir
+
+
+def run_judge(tmp_path, spec, expect=5, concs=ALL_CONCS, drop=()):
+    base_dir, head_dir = write_pair(tmp_path, spec, concs=concs, drop=drop)
+    pairs = pj.pair_results(
+        pj.load_results(base_dir, recursive=True),
+        pj.load_results(head_dir, recursive=True),
+    )
+    return pj.judge(pairs, {}, expected_entries=expect)
+
+
+def flat(tput=0.0, tpot=0.0):
+    return {m: {"tput": tput, "tpot": tpot} for m in BASE_TPUT}
+
+
+# ---------------------------------------------------------------- verdicts ---
+def test_no_change_is_clean(tmp_path):
+    report = run_judge(tmp_path, flat(tput=-0.4, tpot=-0.1))
+    assert report["verdict"] == "clean"
+    assert report["n_triggered"] == 0
+    assert report["n_judged"] == 5
+
+
+def test_one_entry_regressing_is_scoped_to_that_entry(tmp_path):
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["DeepSeek-V4-Pro-mtp3"] = {"tput": -6.0, "tpot": 5.1}
+    report = run_judge(tmp_path, spec)
+    assert report["verdict"] == "regression"
+    assert report["n_triggered"] == 1
+    assert report["scope"] == "single_entry"
+    tripped = [f for f in report["families"] if f["status"] == "triggered"]
+    assert tripped[0]["model"] == "DeepSeek-V4-Pro-mtp3"
+
+
+def test_every_entry_regressing_is_scoped_as_shared_path(tmp_path):
+    report = run_judge(tmp_path, flat(tput=-5.5, tpot=4.8))
+    assert report["verdict"] == "regression"
+    assert report["scope"] == "all_entries"
+
+
+def test_drop_without_tpot_mirroring_does_not_trip(tmp_path):
+    """Throughput down but TPOT flat is measurement wobble, not a slowdown."""
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["Kimi-K3"] = {"tput": -4.0, "tpot": 0.5}
+    report = run_judge(tmp_path, spec)
+    assert report["verdict"] == "clean"
+    kimi = next(f for f in report["families"] if f["model"] == "Kimi-K3")
+    assert kimi["status"] == "clean"
+    assert kimi["mirror"] is False
+
+
+# ------------------------------------------------- incomplete data is not a pass ---
+def test_regressed_entry_missing_a_level_does_not_read_as_clean(tmp_path):
+    """The failure this guards against: the one entry that regressed loses a
+    concurrency level, becomes unjudgeable, and the run reports clean."""
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["DeepSeek-V4-Pro-mtp3"] = {"tput": -6.0, "tpot": 5.1}
+    report = run_judge(tmp_path, spec, drop=[("DeepSeek-V4-Pro-mtp3", 256)])
+
+    assert report["verdict"] != "clean"
+    assert report["verdict"] == "partial"
+    assert report["n_insufficient"] == 1
+
+    # ... and the drop it did measure must still be spelled out to the reader.
+    body = pj.render(report, "")
+    assert "could not be judged" in body
+    assert "-6.0%" in body
+
+
+def test_mostly_dead_matrix_does_not_read_as_clean(tmp_path):
+    """Four of five entries produced nothing. The survivor being fine says
+    nothing about the run, and expected_entries is what makes that visible."""
+    spec = {"GLM-5.2-FP8": {"tput": -0.2, "tpot": 0.1}}
+    report = run_judge(tmp_path, spec, expect=5)
+    assert report["verdict"] == "partial"
+    assert report["n_missing"] == 4
+
+
+def test_nothing_judgeable_is_inconclusive(tmp_path):
+    report = run_judge(tmp_path, flat(), concs=[4, 32], expect=5)
+    assert report["verdict"] == "inconclusive"
+    assert report["n_judged"] == 0
+    assert "not** a pass" in pj.render(report, "")
+
+
+def test_positive_finding_survives_missing_coverage(tmp_path):
+    """A regression stands on its own; gaps elsewhere do not soften it."""
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["DeepSeek-V4-Pro"] = {"tput": -6.0, "tpot": 5.1}
+    report = run_judge(tmp_path, spec, drop=[("Kimi-K3", 128), ("Kimi-K3", 256)])
+    assert report["verdict"] == "regression"
+
+
+# ------------------------------------------------ judging vs reference levels ---
+def test_low_concurrency_never_reaches_the_verdict(tmp_path):
+    """Small-c levels pollute a verdict in both directions, so they are
+    measured and shown but excluded from every computation."""
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["Kimi-K3"] = {
+        "per_conc": {4: -19.8, 32: -9.0, 64: -0.3, 128: 0.2, 256: -0.1},
+        "tpot": 0.1,
+    }
+    report = run_judge(tmp_path, spec)
+
+    assert report["verdict"] == "clean"
+    kimi = next(f for f in report["families"] if f["model"] == "Kimi-K3")
+    assert [m["conc"] for m in kimi["judging"]] == JUDGING
+    assert [m["conc"] for m in kimi["reference"]] == REFERENCE
+    assert kimi["median_tput_pct"] == pytest.approx(-0.1, abs=0.05)
+
+    # Excluded from the verdict, but not hidden -- that is the whole point.
+    body = pj.render(report, "")
+    assert "-19.8%" in body
+    assert "Reference levels" in body
+
+
+def test_reference_only_entry_is_insufficient(tmp_path):
+    report = run_judge(tmp_path, flat(tput=-9.0, tpot=6.0), concs=[4, 32])
+    assert all(f["status"] == "insufficient" for f in report["families"])
+
+
+# ------------------------------------------------------------- shape flags ---
+def test_nonmonotonic_shape_is_not_asserted_either_way(tmp_path):
+    """c=64 -8.6%, c=128 -0.3%, c=256 -7.8% medians to -7.8% and would read as
+    a two-sided drop; the real signal is that one level behaves unlike its
+    neighbours. Median and count both stop describing the data here."""
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["GLM-5.2-FP8"] = {
+        "per_conc": {4: -3.0, 32: -5.0, 64: -8.6, 128: -0.3, 256: -7.8},
+        "tpot": 5.0,
+    }
+    report = run_judge(tmp_path, spec)
+
+    assert report["verdict"] == "unclear"
+    glm = next(f for f in report["families"] if f["model"] == "GLM-5.2-FP8")
+    assert glm["nonmonotonic"]
+    assert glm["nonmonotonic"][0]["conc"] == 128
+    assert "does not follow its neighbours" in pj.render(report, "")
+
+
+def test_uniform_drop_is_not_flagged_as_nonmonotonic(tmp_path):
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["Kimi-K3"] = {"tput": -6.0, "tpot": 5.1}
+    report = run_judge(tmp_path, spec)
+    assert all(not f.get("nonmonotonic") for f in report["families"])
+
+
+def test_two_judging_levels_cannot_express_shape(tmp_path):
+    """Below three judging levels the family is not judged at all, which is
+    also why the matrix runs three rather than two."""
+    report = run_judge(tmp_path, flat(tput=-6.0, tpot=5.0), concs=[128, 256])
+    assert all(f["status"] == "insufficient" for f in report["families"])
+    assert report["verdict"] == "inconclusive"
+
+
+# ------------------------------------------------------- history / sigma ---
+def _data_js(points):
+    runs = [
+        {
+            "date": i,
+            "commit": {"id": f"c{i}"},
+            "benches": [
+                {
+                    "name": "ATOM::M 8192/1024 c=128 Total Tput (tok/s)",
+                    "unit": "tok/s",
+                    "value": value,
+                    "extra": f"Run: https://github.com/x/y/actions/runs/{run_id}",
+                }
+            ],
+        }
+        for i, (run_id, value) in enumerate(points)
+    ]
+    return "window.BENCHMARK_DATA = " + json.dumps({"entries": {"Benchmark": runs}})
+
+
+def test_history_deduplicates_by_actions_run_id(tmp_path):
+    """The dashboard republishes one run against several commits. Duplicates
+    have zero spread, so leaving them in biases sigma toward 'very stable'."""
+    src = tmp_path / "data.js"
+    src.write_text(
+        _data_js([("1", 100.0), ("1", 100.0), ("1", 100.0), ("2", 110.0), ("3", 90.0)])
+    )
+    # Three of five points collapse to one, leaving three observations -- below
+    # the six required, so nothing is reported rather than a fabricated sigma.
+    assert pj.load_history_cv(str(src)) == {}
+
+
+def test_history_failure_is_not_fatal(tmp_path):
+    assert pj.load_history_cv(str(tmp_path / "absent.js")) == {}
+    (tmp_path / "junk.js").write_text("not json at all")
+    assert pj.load_history_cv(str(tmp_path / "junk.js")) == {}
+
+
+def test_verdict_holds_without_history(tmp_path):
+    """Family linkage needs no noise band; sigma must never gate a verdict."""
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["Kimi-K3"] = {"tput": -6.0, "tpot": 5.1}
+    assert run_judge(tmp_path, spec)["verdict"] == "regression"
+
+
+# ------------------------------------------------------------- contract ---
+def test_thresholds_are_reported_as_provisional(tmp_path):
+    report = run_judge(tmp_path, flat())
+    assert report["thresholds"]["family_median_pct_is_provisional"] is True
+
+
+def test_judging_levels_start_at_the_documented_boundary():
+    assert pj.JUDGE_MIN_CONC == 64
+    assert pj.FAMILY_MIN_CONFIGS == 3
+    assert pj.FAMILY_MIN_DOWN == pj.FAMILY_MIN_CONFIGS
+
+
+def test_cli_never_signals_failure_through_the_exit_code(tmp_path, monkeypatch):
+    """The check informs the reviewer; it does not gate the merge. Signalling
+    through the exit code would turn it into a required check by accident."""
+    spec = flat(tput=-8.0, tpot=6.0)
+    base_dir, head_dir = write_pair(tmp_path, spec)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "perf_judge.py",
+            "--base-dir",
+            str(base_dir),
+            "--head-dir",
+            str(head_dir),
+            "--no-history",
+            "--expect-entries",
+            "5",
+            "--output-json",
+            str(tmp_path / "verdict.json"),
+        ],
+    )
+    assert pj.main() == 0
+    verdict = json.loads((tmp_path / "verdict.json").read_text())
+    assert verdict["verdict"] == "regression"
+
+
+# ======================== perf_check_half.sh ========================
+
+RESULT_FILENAME = "deepseek-v4-pro-mtp3-8192-1024-128-0.8"
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """A git repo with two commits, standing in for the checked-out PR."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _git(ws, "init", "-q")
+    _git(ws, "config", "user.email", "t@example.com")
+    _git(ws, "config", "user.name", "t")
+
+    (ws / "marker.txt").write_text("base\n")
+    _git(ws, "add", "-A")
+    _git(ws, "commit", "-qm", "base")
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ws, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    (ws / "marker.txt").write_text("head\n")
+    _git(ws, "add", "-A")
+    _git(ws, "commit", "-qm", "head")
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ws, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    return ws, base_sha, head_sha
+
+
+@pytest.fixture
+def fake_docker(tmp_path):
+    """A `docker` shim that records calls and fabricates a benchmark result.
+
+    It reads marker.txt from the workspace, so the throughput it reports
+    depends on which commit is currently checked out -- that is how the test
+    proves the checkout actually took effect before the benchmark ran.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "docker.log"
+
+    (bindir / "docker").write_text(textwrap.dedent(f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            echo "ARGS: $*" >> "{log}"
+            # `docker exec -i ... bash -l` receives the launch command on stdin.
+            if [[ "$*" == *"-i"* ]]; then
+              echo "STDIN: $(cat)" >> "{log}"
+              exit 0
+            fi
+            case "$*" in
+              *benchmark*)
+                marker=$(cat marker.txt)
+                if [ "$marker" = "head" ]; then tput=16000; else tput=17000; fi
+                cat > "{RESULT_FILENAME}.json" <<EOF
+            {{"benchmark_backend":"ATOM",
+             "benchmark_model_name":"DeepSeek-V4-Pro-mtp3",
+             "random_input_len":8192,"random_output_len":1024,
+             "max_concurrency":128,
+             "output_throughput":$((tput/2)),"total_token_throughput":$tput,
+             "mean_ttft_ms":420.0,"mean_tpot_ms":30.0}}
+            EOF
+                ;;
+              *stop*) echo "STOP" >> "{log}" ;;
+            esac
+            """))
+    (bindir / "docker").chmod(0o755)
+    return bindir, log
+
+
+def run_half(ws, bindir, sha, half, **env):
+    result = subprocess.run(
+        ["bash", str(HALF_SH), sha, half],
+        cwd=ws,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "CONTAINER": "atom-perf-check",
+            "MODEL_PATH": "deepseek-ai/DeepSeek-V4-Pro",
+            "ARGS": "--kv_cache_dtype fp8 -tp 8 --method mtp",
+            "RESULT_FILENAME": RESULT_FILENAME,
+            **env,
+        },
+    )
+    return result
+
+
+# ------------------------------------------------------------ arguments ---
+def test_rejects_an_unknown_half(workspace, fake_docker):
+    ws, base_sha, _ = workspace
+    bindir, _ = fake_docker
+    result = run_half(ws, bindir, base_sha, "middle")
+    assert result.returncode == 2
+    assert "must be 'base' or 'head'" in result.stderr
+
+
+def test_requires_its_environment(workspace, fake_docker):
+    ws, base_sha, _ = workspace
+    bindir, _ = fake_docker
+    result = subprocess.run(
+        ["bash", str(HALF_SH), base_sha, "base"],
+        cwd=ws,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": f"{bindir}:{os.environ['PATH']}"},
+    )
+    assert result.returncode != 0
+    assert "CONTAINER" in result.stderr
+
+
+# -------------------------------------------------------------- one half ---
+def test_checks_out_the_requested_commit_before_benchmarking(workspace, fake_docker):
+    ws, base_sha, _head_sha = workspace
+    bindir, _ = fake_docker
+
+    run_half(ws, bindir, base_sha, "base")
+    # The shim reports throughput based on marker.txt, so this value can only
+    # be produced if the checkout landed before the benchmark ran.
+    payload = json.loads(
+        (ws / "perf-pair/base" / f"{RESULT_FILENAME}.json").read_text()
+    )
+    assert payload["total_token_throughput"] == 17000
+
+
+def test_passes_server_args_through_stdin_not_the_command_line(workspace, fake_docker):
+    """Quoting in ARGS must be parsed once, by the container's bash. Inlining it
+    into `bash -lc "..."` collapses single-quoted JSON values."""
+    ws, base_sha, _ = workspace
+    bindir, log = fake_docker
+    run_half(ws, bindir, base_sha, "base")
+    text = log.read_text()
+    assert "STDIN: .github/scripts/atom_test.sh launch" in text
+    assert "--method mtp" in text
+
+
+def test_stops_the_server_after_measuring(workspace, fake_docker):
+    ws, base_sha, _ = workspace
+    bindir, log = fake_docker
+    run_half(ws, bindir, base_sha, "base")
+    lines = log.read_text().splitlines()
+    bench = next(i for i, ln in enumerate(lines) if "benchmark" in ln)
+    stop = next(i for i, ln in enumerate(lines) if ln == "STOP")
+    assert stop > bench, "stop must follow the benchmark, not precede it"
+
+
+def test_missing_results_warn_rather_than_fabricate(workspace, tmp_path):
+    """A half that produced nothing must leave the directory empty. Inventing a
+    result here would turn missing evidence into a passing comparison."""
+    ws, base_sha, _ = workspace
+    bindir = tmp_path / "silent"
+    bindir.mkdir()
+    (bindir / "docker").write_text("#!/usr/bin/env bash\nexit 0\n")
+    (bindir / "docker").chmod(0o755)
+
+    result = run_half(ws, bindir, base_sha, "base")
+    assert result.returncode == 0
+    assert "::warning::" in result.stdout
+    assert list((ws / "perf-pair/base").glob("*.json")) == []
+
+
+# ------------------------------------------------------- both halves ---
+def test_archiving_survives_the_second_checkout(workspace, fake_docker):
+    """The ordering guard: `git clean` between halves would wipe the base
+    results if they were not copied out first."""
+    ws, base_sha, head_sha = workspace
+    bindir, _ = fake_docker
+
+    run_half(ws, bindir, base_sha, "base")
+    run_half(ws, bindir, head_sha, "head")
+
+    base_files = list((ws / "perf-pair/base").glob("*.json"))
+    head_files = list((ws / "perf-pair/head").glob("*.json"))
+    assert len(base_files) == 1, "base results were destroyed by the head checkout"
+    assert len(head_files) == 1
+
+    assert json.loads(base_files[0].read_text())["total_token_throughput"] == 17000
+    assert json.loads(head_files[0].read_text())["total_token_throughput"] == 16000
+
+
+def test_pipeline_end_to_end_reaches_a_verdict(workspace, fake_docker):
+    """Both halves, then the judge, on files the script actually produced --
+    rather than on fixtures hand-shaped to match what it is assumed to write."""
+    ws, base_sha, head_sha = workspace
+    bindir, _ = fake_docker
+
+    run_half(ws, bindir, base_sha, "base")
+    run_half(ws, bindir, head_sha, "head")
+
+    pairs = pj.pair_results(
+        pj.load_results(ws / "perf-pair/base", recursive=True),
+        pj.load_results(ws / "perf-pair/head", recursive=True),
+    )
+    assert len(pairs) == 1
+    assert pairs[0]["model"] == "DeepSeek-V4-Pro-mtp3"
+    assert pairs[0]["conc"] == 128
+    assert pairs[0]["tput_pct"] == pytest.approx(-5.88, abs=0.05)
+
+    # One concurrency level cannot satisfy the linkage criterion, and the judge
+    # must say so rather than call a single -5.9% reading a regression.
+    #
+    # `inconclusive`, not `partial`: nothing at all could be judged here.
+    # `partial` is the weaker claim -- some entries were judged and came back
+    # clean, but the coverage behind that was incomplete.
+    report = pj.judge(pairs, {}, expected_entries=1)
+    assert report["verdict"] == "inconclusive"
+    assert report["n_judged"] == 0
+    assert report["n_insufficient"] == 1
+
+    body = pj.render(report, "")
+    assert "not** a pass" in body
+    # The level that did report dropped ~6%; that must not vanish just because
+    # the family could not be judged.
+    assert "could not be judged" in body
+    assert "-5.9%" in body
+
+
+def test_full_matrix_of_halves_produces_a_regression(workspace, tmp_path):
+    """Three judging levels from the script's own output, end to end."""
+    ws, base_sha, head_sha = workspace
+    bindir = tmp_path / "bin3"
+    bindir.mkdir()
+    (bindir / "docker").write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            if [[ "$*" == *"-i"* ]]; then cat > /dev/null; exit 0; fi
+            case "$*" in
+              *benchmark*)
+                marker=$(cat marker.txt)
+                for c in 64 128 256; do
+                  if [ "$marker" = "head" ]; then t=$((16000+c)); p=32; else t=$((17000+c)); p=30; fi
+                  cat > "run-8192-1024-$c-0.8.json" <<EOF
+            {"benchmark_backend":"ATOM","benchmark_model_name":"M",
+             "random_input_len":8192,"random_output_len":1024,
+             "max_concurrency":$c,"output_throughput":$t,
+             "total_token_throughput":$t,"mean_ttft_ms":420.0,"mean_tpot_ms":$p}
+            EOF
+                done
+                ;;
+            esac
+            """))
+    (bindir / "docker").chmod(0o755)
+
+    for sha, half in ((base_sha, "base"), (head_sha, "head")):
+        run_half(ws, bindir, sha, half, RESULT_FILENAME="run")
+
+    pairs = pj.pair_results(
+        pj.load_results(ws / "perf-pair/base", recursive=True),
+        pj.load_results(ws / "perf-pair/head", recursive=True),
+    )
+    report = pj.judge(pairs, {}, expected_entries=1)
+    assert len(pairs) == 3
+    assert report["verdict"] == "regression"
+    family = report["families"][0]
+    assert family["n_down"] == 3
+    assert family["mirror"] is True
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_pr_comment_script_is_valid_javascript():
+    """The github-script block is JS embedded in YAML; nothing else checks it."""
+    import yaml
+
+    workflow = yaml.safe_load(
+        (REPO / ".github" / "workflows" / "atom-perf-check.yaml").read_text()
+    )
+    steps = workflow["jobs"]["judge"]["steps"]
+    script = next(
+        s["with"]["script"]
+        for s in steps
+        if str(s.get("uses", "")).startswith("actions/github-script")
+    )
+    # Wrap in an async function: the body uses top-level await.
+    subprocess.run(
+        ["node", "--check", "-"],
+        input=f"async function main() {{\n{script}\n}}",
+        text=True,
+        check=True,
+        capture_output=True,
+    )

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -290,13 +290,13 @@ def test_history_deduplicates_by_actions_run_id(tmp_path):
     )
     # Three of five points collapse to one, leaving three observations -- below
     # the six required, so nothing is reported rather than a fabricated sigma.
-    assert pj.load_history_cv(str(src)) == {}
+    assert pj.load_history(str(src))[1] == {}
 
 
 def test_history_failure_is_not_fatal(tmp_path):
-    assert pj.load_history_cv(str(tmp_path / "absent.js")) == {}
+    assert pj.load_history(str(tmp_path / "absent.js")) == ({}, {})
     (tmp_path / "junk.js").write_text("not json at all")
-    assert pj.load_history_cv(str(tmp_path / "junk.js")) == {}
+    assert pj.load_history(str(tmp_path / "junk.js")) == ({}, {})
 
 
 def test_verdict_holds_without_history(tmp_path):
@@ -391,6 +391,64 @@ def test_sanity_check_is_skipped_without_history(tmp_path):
     report = pj.judge(pj.pair_results(base, head), {}, expected_entries=1)
     assert report["verdict"] == "clean"
     assert report["n_bad_baseline"] == 0
+
+
+def _series(model, concs, days, start, end, tpot_start=30.0, tpot_end=30.0):
+    """A per-configuration series sliding linearly from start to end."""
+    out = {}
+    n = 8
+    for c in concs:
+        pts = []
+        for i in range(n):
+            frac = i / (n - 1)
+            pts.append(
+                {
+                    "date": (days * 86400 * 1000 * i) // (n - 1),
+                    "tput": start + (end - start) * frac,
+                    "tpot": tpot_start + (tpot_end - tpot_start) * frac,
+                }
+            )
+        out[(model, "8192/1024", c)] = pts
+    return out
+
+
+def test_main_side_drift_is_reported_apart_from_the_verdict(tmp_path):
+    """A slide on main leaves the paired delta honest and the absolute level
+    wrong. Reporting only "no change" would read as "fine"."""
+    series = _series("M", JUDGING, 14, 10000.0, 9000.0, 30.0, 33.0)  # -10%, TPOT +10%
+    drift = pj.main_drift(series, {"M"})
+    assert len(drift) == 1
+    assert drift[0]["median_pct"] < pj.DRIFT_MEDIAN_TH
+    assert drift[0]["n_down"] == len(JUDGING)
+
+    base = [_result("M", c, 9000.0, 33.0) for c in JUDGING]
+    head = [_result("M", c, 8995.0, 33.0) for c in JUDGING]
+    report = pj.judge(pj.pair_results(base, head), {}, expected_entries=1, drift=drift)
+
+    # The PR itself is clean, and the drift does not change that.
+    assert report["verdict"] == "clean"
+    body = pj.render(report, "")
+    assert "not caused by this PR" in body
+    assert "Main-side context" in body
+
+
+def test_drift_needs_tpot_to_mirror(tmp_path):
+    """Throughput sliding with TPOT flat is measurement wobble, not a slowdown."""
+    series = _series("M", JUDGING, 14, 10000.0, 9000.0, 30.0, 30.0)
+    assert pj.main_drift(series, {"M"}) == []
+
+
+def test_drift_is_scoped_to_the_models_measured(tmp_path):
+    """Listing every drifting family in the repository would bury the one the
+    reader came for."""
+    series = _series("Other", JUDGING, 14, 10000.0, 9000.0, 30.0, 33.0)
+    assert pj.main_drift(series, {"M"}) == []
+    assert pj.main_drift(series, {"Other"}) != []
+
+
+def test_drift_ignores_low_concurrency(tmp_path):
+    series = _series("M", [4, 8, 32], 14, 10000.0, 9000.0, 30.0, 33.0)
+    assert pj.main_drift(series, {"M"}) == []
 
 
 # ------------------------------------------------------------- contract ---

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -297,6 +297,30 @@ def test_families_outside_drift_coverage_are_listed(tmp_path):
     assert "M" not in named
 
 
+def test_peak_does_not_forget_a_drop_that_aged_out(tmp_path):
+    """A level that dropped long ago and never recovered still reads as down.
+
+    Every window rolls forward. Once the good runs leave it the baseline falls
+    with them, the shortfall shrinks, and a permanent regression becomes the
+    new normal -- upstream closed a family as healthy while it sat 12.3% under
+    its peak. The anchor is taken over all history for that reason.
+    """
+    old_high = [1000.0, 1010.0, 1005.0]
+    settled = [900.0] * 12  # dropped 10%, long enough to fill any window
+    values = old_high + settled
+    anchor = pj._anchor(values)
+    assert anchor == pytest.approx(1005.0, abs=1.0)
+
+    points = [
+        {"date": 1786149015906 + i * 86400000, "tput": v, "tpot": 30.0}
+        for i, v in enumerate(values)
+    ]
+    # The level window sees only the settled runs...
+    assert pj._level_window(points) == pytest.approx([900.0] * 3, abs=0.1)
+    # ...but the anchor still remembers what main used to do.
+    assert (900.0 / anchor - 1) * 100 < -9
+
+
 # ------------------------------------------------- incomplete data is not a pass ---
 def test_regressed_entry_missing_a_level_does_not_read_as_clean(tmp_path):
     """The failure this guards against: the one entry that regressed loses a

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -218,8 +218,8 @@ def test_low_concurrency_never_reaches_the_verdict(tmp_path):
     # Excluded from the verdict, but not hidden -- that is the whole point.
     body = pj.render(report, "")
     assert "-19.8%" in body
-    assert "| ref |" in body
-    assert "| judge |" in body
+    assert "(not judged)" in body
+    assert "median of judged" in body
 
 
 def test_reference_only_entry_is_insufficient(tmp_path):

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -218,7 +218,8 @@ def test_low_concurrency_never_reaches_the_verdict(tmp_path):
     # Excluded from the verdict, but not hidden -- that is the whole point.
     body = pj.render(report, "")
     assert "-19.8%" in body
-    assert "Reference levels" in body
+    assert "| ref |" in body
+    assert "| judge |" in body
 
 
 def test_reference_only_entry_is_insufficient(tmp_path):

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -87,6 +87,7 @@ def write_pair(tmp_path, spec, concs=ALL_CONCS, drop=()):
             base_value = BASE_TPUT[model] * (0.6 if conc < 64 else 1.0)
             delta = entry.get("per_conc", {}).get(conc, entry.get("tput", 0.0))
             tpot_delta = entry.get("tpot", 0.0)
+            ttft_delta = entry.get("ttft", 0.0)
 
             name = f"{model}-8192-1024-{conc}-0.8.json"
             (base_dir / name).write_text(
@@ -101,6 +102,7 @@ def write_pair(tmp_path, spec, concs=ALL_CONCS, drop=()):
                         conc,
                         base_value * (1 + delta / 100),
                         30.0 * (1 + tpot_delta / 100),
+                        420.0 * (1 + ttft_delta / 100),
                     )
                 )
             )
@@ -154,6 +156,35 @@ def test_drop_without_tpot_mirroring_does_not_trip(tmp_path):
     kimi = next(f for f in report["families"] if f["model"] == "Kimi-K3")
     assert kimi["status"] == "clean"
     assert kimi["mirror"] is False
+
+
+def test_queueing_regression_trips_via_ttft(tmp_path):
+    """Throughput down while requests queue is a regression, even as TPOT falls.
+
+    Measured on MI308 with max_num_seqs capped at 16: -29% throughput, TTFT
+    +495%, TPOT -78%. Capping how many requests run at once makes each served
+    request faster while the queue behind it grows, so a gate that demanded
+    TPOT rise called a 29% capacity loss `unclear` and reported nothing.
+    """
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["Kimi-K3"] = {"tput": -29.3, "tpot": -77.8, "ttft": 494.8}
+    report = run_judge(tmp_path, spec)
+    assert report["verdict"] == "regression"
+    kimi = next(f for f in report["families"] if f["model"] == "Kimi-K3")
+    assert kimi["status"] == "triggered"
+    assert kimi["mirror"] is True
+    assert kimi["mirror_via"] == "TTFT"
+
+
+def test_drop_with_neither_latency_moving_does_not_trip(tmp_path):
+    """Widening the gate to TTFT must not turn it into no gate at all."""
+    spec = flat(tput=-0.4, tpot=-0.1)
+    spec["Kimi-K3"] = {"tput": -4.0, "tpot": 0.5, "ttft": 0.2}
+    report = run_judge(tmp_path, spec)
+    assert report["verdict"] == "clean"
+    kimi = next(f for f in report["families"] if f["model"] == "Kimi-K3")
+    assert kimi["mirror"] is False
+    assert kimi["mirror_via"] is None
 
 
 # ------------------------------------------------- incomplete data is not a pass ---

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -538,8 +538,8 @@ def test_main_side_drift_is_reported_apart_from_the_verdict(tmp_path):
     # The PR itself is clean, and the drift does not change that.
     assert report["verdict"] == "clean"
     body = pj.render(report, "")
-    assert "not caused by this PR" in body
-    assert "Main-side context" in body
+    assert "<details>" in body
+    assert "Sliding on main" in body
 
 
 def test_drift_needs_tpot_to_mirror(tmp_path):

--- a/tests/test_perf_check.py
+++ b/tests/test_perf_check.py
@@ -435,6 +435,9 @@ def run_half(ws, bindir, sha, half, **env):
             "ARGS": "--kv_cache_dtype fp8 -tp 8 --method mtp",
             "RESULT_FILENAME": RESULT_FILENAME,
             "CONC": "128",
+            "ISL": "8192",
+            "OSL": "1024",
+            "RANDOM_RANGE_RATIO": "0.8",
             **env,
         },
     )
@@ -488,6 +491,28 @@ def test_passes_server_args_through_stdin_not_the_command_line(workspace, fake_d
     text = log.read_text()
     assert "STDIN: .github/scripts/atom_test.sh launch" in text
     assert "--method mtp" in text
+
+
+def test_benchmark_parameters_reach_the_container(workspace, fake_docker):
+    """atom_test.sh reads ISL/OSL/CONC/RANDOM_RANGE_RATIO from its own
+    environment under `set -u`, so anything missing aborts the benchmark after
+    the model has already loaded. CI injects them when the container starts,
+    which hides the omission wherever the container was started that way -- it
+    surfaced only against a locally started container, as
+    "line 447: ISL: unbound variable".
+    """
+    ws, base_sha, _ = workspace
+    bindir, log = fake_docker
+    run_half(ws, bindir, base_sha, "base")
+
+    bench_call = [
+        ln
+        for ln in log.read_text().splitlines()
+        if ln.startswith("ARGS:") and "benchmark" in ln
+    ]
+    assert bench_call, "no benchmark invocation recorded"
+    for var in ("ISL=8192", "OSL=1024", "CONC=128", "RANDOM_RANGE_RATIO=0.8"):
+        assert var in bench_call[0], f"{var} not passed to the container"
 
 
 def test_stops_the_server_after_measuring(workspace, fake_docker):
@@ -585,6 +610,9 @@ def test_runs_when_the_target_commit_does_not_contain_the_script(tmp_path, fake_
         "ARGS": "",
         "RESULT_FILENAME": RESULT_FILENAME,
         "CONC": "128",
+        "ISL": "8192",
+        "OSL": "1024",
+        "RANDOM_RANGE_RATIO": "0.8",
     }
     for sha, half in ((base_sha, "base"), (head_sha, "head")):
         result = subprocess.run(


### PR DESCRIPTION
Adds a label-gated, non-blocking performance check. On `ci:perf` it measures the merge-base and the PR head back to back and reports the delta as a PR comment. It never fails the PR, sets no required status check, and is deliberately **not** part of `ci:full`.

**Five entries across four concurrency levels, 20 jobs**, on dummy weights. The build-matrix step fails on a short matrix rather than letting a mistyped catalog name surface at the judge as `partial`.

## Why a paired measurement, not a historical baseline

Per-image baselines do not exist: across 52 deduplicated perf runs on the public dashboard, **30 of 39 container images were benchmarked exactly once**, and cross-image comparison spreads 11–21% against 0.57% median CV within one image. Running both commits in the same job and container instance holds machine and image fixed, so the commit is the only difference.

`benchmark-tmpl.yml` cannot be reused: it runs one job per concurrency level, and Actions cannot pin two jobs to one machine. Switching commits inside the job is a host-side `git checkout` the running container picks up immediately, because `setup-gpu-container` bind-mounts the workspace — no second container, no duplicated launch logic. `atom_test.sh` already does all of it.

## Dummy weights, and what they cost

Model load is **76% of the benchmark it precedes**, and each job pays it three times (warmup, base, head). Medians from the 31 successful jobs of ATOM Benchmark run `35121706150` (2026-09-16), on the MI355X runners this workflow uses:

| model | n | load, median |
|---|--:|--:|
| Kimi-K3 | 1 | **634.8 s** |
| GLM-5.2-FP8 | 3 | 344.3 s |
| DeepSeek-V4-Pro | 8 | 297.1 s |
| MiniMax-M3-MXFP8 | 3 | 156.1 s |

The same DeepSeek-V4-Pro cell at c=64 benchmarks in 368.8 s. `--load_dummy=xavier` drops the load to ~0.1 s.

**It is not free.** On MI308X with DeepSeek-V4-Flash at tp=8, dummy weights ran **20.2% slower** — 4542 vs 5425 tok/s, TPOT 121.0 vs 100.6 ms — because `--fake-eplb` lights all 256 experts every decode step where learned routing lights fewer. Net on that cell: ~327 s saved against 75 s paid, **~12 min per job**. The saving is concentrated at low concurrency, where load dominates the phase; at the top level it approaches break-even.

`--fake-eplb` is required, not cosmetic: `--load_dummy` alone leaves the recycled `e_score_correction_bias` in place, collapsing every token onto one EP rank (`moe.py:2899`). MXFP4 is the validated dummy path (`loader.py:179`). The flags are appended in `perf_check_half.sh`, not in the matrix cell, so the three phases cannot disagree about how weights were loaded; clear `DUMMY_WEIGHT_ARGS` to measure on real weights.

Two consequences, stated rather than hidden:

- Absolute numbers no longer line up with the dashboard, so the judge runs `--no-history` and the comment says so. Absolute truth stays with the nightly benchmark, which is why dummy weights are right here and would be wrong there.
- The **magnitude** of a delta is not calibrated against a known injection under dummy weights. Sensitivity is so far measured only as A/A: on MI308, signal +0.40% and drift +0.21%, against +1.35% and +1.26% on real weights. Quieter, n=1 per arm.

The nearest analogue is an aiter operator test — synthetic inputs, repeatability bought with realism — with one difference worth keeping in view: an operator test covers each operator on shapes chosen for it, while this is **one workload whose operator mix `--fake-eplb` has changed**. MoE grouped-GEMM is amplified and attention damped, so sensitivity is not uniform, and a claim that this line covers attention-side regressions would need its own evidence.

## The warmup is not optional

Sharing the container holds the environment fixed but carries the JIT/autotune caches the first run populates — aiter's JIT, torch inductor, hipblaslt tuning, not ATOM's own compile cache, which `atom_test.sh launch` clears each time. On identical code with no warmup:

```
          Total Tput      TPOT       TTFT
c=64        +5.89%       -5.43%     -9.68%
c=128       +9.14%       -8.30%    -11.29%
c=256       +2.77%       -2.63%     -2.91%
```

All three metrics agree and all favour whichever half ran second — larger than the threshold the check must resolve, and pointing the wrong way: a 6% regression would have read as flat.

A discarded warmup removes it, but only at the measurement's own prompt count. At a tenth of it the residual held on MI308 (+1.35%) and failed on MI355X: **+4.19 / +5.65 / +3.10%** at c=64/128/256 across three machines, TPOT mirroring each — needing a ~8.5% drop to trip. At full prompt count: **−0.39 / +0.27 / +1.84%**. Cost 236 → 278 GPU-minutes across the three levels (+17.5%). The two rounds differ in image as well as warmup, so a single-variable re-check is still owed and is cheap.

What remains is spread, not bias, which is why the verdict is the family median across levels. **A single level carries about ±1.8 points of slack; the median does not.** The comment and step summary state this next to the table, and the figure is re-measured whenever the flow changes, because this PR doubles as its own A/A fixture. Averaging a repeated base reading would halve the remainder at the cost of a third measurement per job — a worse trade than removing the cause. `perf_judge.py` still accepts `--base2-dir` for runs that need drift quantified.

## What decides the verdict

Family linkage rather than a per-configuration threshold: independent levels moving together is far less likely than any one moving, and unlike a sigma gate it needs no estimate of the noise band — which matters, because per-image history is too sparse to supply one.

A drop is confirmed only when a latency metric degrades with it. TPOT alone was not enough. A commit capping `max_num_seqs` at 16, benchmarked against its parent on MI308 through the real pairing path:

```
       tput      TTFT       TPOT
c=64  -25.3%  +680.7%    -63.6%
c=128 -32.7%  +494.8%    -77.8%
c=256 -29.3%  +307.4%    -88.2%
```

Capping concurrency makes each *served* request faster while the queue grows, so TPOT falls and the old gate called a 29% capacity loss `unclear`. Either per-token slowdown or queueing confirms now, at the same ratio; re-judging the two completed A/A runs with the widened gate leaves both `clean`. This run is also the only end-to-end evidence that the check reports a regression at all — everything else measured on hardware was A/A, which proves only that it does not invent them.

Levels below `c=64` are measured and displayed but never judged. Low concurrency pollutes a verdict both ways: it manufactured a −4.2% flag on an entry sitting at its historical peak on large levels, and diluted a −12.0% large-concurrency median to −7.1% across all levels. `c=4` is kept and labelled because it is where a small-batch path problem still shows; `c=32` was dropped for earning neither keep.

Seven verdicts, of which exactly one says "no problem":

| verdict | meaning |
|---|---|
| `bad_baseline` | the base measurement is far below main's recent level; outranks everything |
| `regression` | at least one model tripped |
| `inconclusive` | nothing could be judged |
| `untrustworthy` | the base commit did not measure the same twice |
| `unclear` | a shape the criterion cannot describe |
| `partial` | judged entries are clean, but coverage was incomplete |
| `clean` | fully covered, regular, nothing tripped |

An entry that lost a level is `insufficient`; a matrix where entries produced nothing is `partial`. Verified in production: a run where all three GPU jobs died reported `Inconclusive -- not enough data`, with "this is **not** a pass" in the body.

## Two blind spots a paired comparison cannot cover

*Both checks below are history-based and switched off while `DUMMY_WEIGHT_ARGS` is set, because dashboard history records real-weight runs. The code is unchanged; clearing the variable brings them back.*

**The baseline being broken.** If base and head are both 30% down the delta is zero and the run reports clean — the one shape where a confident green is exactly wrong. The base is checked against main's recent level at crimson magnitude only: at least 25% under the median, clear of 2.5× that configuration's own spread, on at least two judged levels. Anything finer is unreadable — across 372 configurations the 8-run spread is 7.7% at the median and 25.1% at P90. Because that gate only speaks when it fires, the reading is reported every run regardless, against both main's current level and the best main has sustained. The second is anchored to all history rather than a window: the nightly monitor closed a family as recovered while it sat 12.3% under its peak.

**Main already sliding.** Base and head both sit on top of a slide, so the delta stays honest while the absolute level does not. The nightly monitor's trend criterion is ported here, constants intact: a family is flagged only when several levels move together and TPOT mirrors the move. Per family because amplitude alone cannot separate signal from noise — across 414 configurations the 14-day change is symmetric, 18 below −10% against 22 above +10%. Each family is dated from the data, not the window; on current history this dates MiniMax-M3-MXFP8 to 2026-09-03, the same night found by hand against the nightly image boundary.

History that could not be read, or matched no measured configuration, holds the verdict at `partial` and names what failed — a report where the baseline check never executed used to look identical to one where it passed.

## Scope

New files only; no existing benchmark code is modified. Reuses `check_heavy_ci_gate.sh`, `catalog.py`, `atom-bench-container`, `atom_test.sh`, `gpu_preflight_check.sh` and `summarize.py`.

```
.github/workflows/atom-perf-check.yaml
.github/scripts/perf_judge.py
.github/scripts/perf_check_half.sh
tests/test_perf_check.py
.github/workflows/pr-welcome-comment.yaml   (+1 line)
```

The label gate is wired as `atom-test.yaml` and its siblings wire it: `check_heavy_ci_gate.sh` always exits 0 — an unlabelled PR is not a failure — and reports through `should_run`, so every job below is gated on that output rather than on `needs:` alone. A test walks the workflow and asserts each non-gate job reads the decision, because a job that only lists the gate in `needs` looks gated and is not. 55 unit tests cover the criterion and the pairing mechanics with `docker` shimmed, and run in `pre-checks.yaml` without a GPU.

## Notes for review

- **The dummy-weight path has not yet completed a full CI run**; every run since the switch was cancelled by a subsequent push.
- `GPU_PREFLIGHT_KILL_KFD=1` is on where native ATOM CI leaves it off. A container that dies without stopping its server leaves KFD processes holding VRAM, and this workflow starts three servers per job rather than one. Observed: four workers held 664 GB across four cards after an aborted run.
- The disk guard mirrors `atom-test.yaml`'s, plus the runner's own `_diag` tree — two jobs died on a runner that filled up there, reporting no failing step, which is what a full disk looks like from inside the job.
