### PR TITLE
bench: set ATOM_GC_THRESHOLD for the EPLB MegaMoE c=4096 case

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -78,7 +78,7 @@
       ]
     },
     {
-      "display": "DeepSeek-V4-Pro EPLB r0 MegaMoE",
+      "display": "DeepSeek-V4-Pro EPLB r0",
       "path": "deepseek-ai/DeepSeek-V4-Pro",
       "prefix": "deepseek-v4-pro-eplb",
       "runner": "atom-mi355-8gpu.predownload",
@@ -109,6 +109,7 @@
           "suffix": "-mega",
           "extra_args": "--eplb-config '{\"num_redundant_experts\": 0, \"placement_policy\": \"naive\", \"rebalance_interval\": 200, \"load_window_size\": 200, \"rebalance_min_balancedness\": 2.0}' --gpu-memory-utilization 0.85",
           "bench_args": "--num-prompts 20480 --num-warmups 256",
+          "env_vars": "ATOM_GC_THRESHOLD=20000,50,50",
           "conc_min": 4096,
           "conc_max": 4096
         }


### PR DESCRIPTION
## What

- Set `ATOM_GC_THRESHOLD=20000,50,50` on the **DeepSeek-V4-Pro EPLB r0 MegaMoE c=4096** benchmark case.
- Drop the duplicated `MegaMoE` from that job's name.

## Why the env var

`ATOM_GC_THRESHOLD` defaults to empty (`atom/utils/envs.py`), so CI has always run on CPython's default `(700,10,10)`.

Same-machine 2×2 (v2-038, one container, one model, same bench, `--gpu-memory-utilization 0.85` throughout, 2 rounds per cell):

| image | GC default | `20000,50,50` | delta |
|---|---|---|---|
| `nightly_202609011458` | **6.10** req/s, TPOT 478 ms | **7.32** req/s, TPOT 353 ms | **+20.0%** |
| `nightly_202608221457` | 7.25 req/s, TPOT 362 ms | 7.27 req/s, TPOT 355 ms | +0.3% (noise) |

This is an interaction, not a general win:

- If raising thresholds were a blanket speedup, both rows would move. Only one does.
- The 08-22 → 09-01 drop this case regressed by (~−16% here, −25% on another cluster) is **fully recovered** by the env var — 7.32 ≥ 7.25.
- TTFT is flat across all 8 runs (spread ≤0.8% within a round position), so the whole effect sits in the decode output path, not prefill.

The frontend gained a per-frame allocation on that path in the 08-22 → 09-01 window (one `FrameWait` per stream per frame, plus the `merge_chunk` rewrite). At c=4096 that is enough to push gen2 collections into the single core the API server is bound to. Raising the thresholds removes the cost; on 08-22, which has no such allocation, there is nothing to remove.

Scoped to c=4096 only — c=512 has far fewer live objects and stays on the default so the two remain independent measurements.

A follow-up worth considering separately: either change the default, or remove the per-frame allocation in `streaming_dispatch.py` (`FrameWait` has three `__slots__` fields and could be a pair of functions instead of an object).

## Why the rename

`display` already ended in `MegaMoE` and the variant `label` adds it again, so every job rendered as:

```
DeepSeek-V4-Pro EPLB r0 MegaMoE MegaMoE 8k1k / c=4096
```

`prefix`/`suffix` are untouched, so result filenames and dashboard history are unaffected.
