### PR TITLE
Reduce frontend stalls by coalescing tokens before detokenization

### DIFF
--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -116,10 +116,10 @@ class StreamOutputCollector:
     and socket writing. Detokenizer state is advanced only by ``get()``, on the
     event loop; the engine output threads never decode collector-bound chunks.
 
-    Nothing is ever held back. With a consumer that keeps up nothing ever
-    merges, and delivery is identical to the queue this replaces. Merging only
-    covers chunks that were already waiting, so a token is never delivered later
-    than it would have been.
+    There is no timer or minimum batch size: get() can consume any pending
+    delta immediately. Merging covers only unread chunks, but decoding runs
+    synchronously on the event loop, so this is not a delivery-latency bound.
+    Large backlogs can delay other consumers while their text is decoded.
 
     ``tag`` is the fan-out sibling index (``SamplingParams.n>1``) or ``None`` for
     a plain single-sequence stream. Chunks merge per tag, so siblings never mix.
@@ -156,9 +156,18 @@ class StreamOutputCollector:
             self._ready.clear()
         state = chunk.pop("_detokenizer", None)
         if state is not None:
-            chunk["text"] = state.update(
-                chunk["token_ids"], bool(chunk.get("finished"))
-            )
+            try:
+                chunk["text"] = state.update(
+                    chunk["token_ids"], bool(chunk.get("finished"))
+                )
+            except Exception:
+                logger.exception(
+                    "Error detokenizing stream %s (tag=%s)", self.request_id, tag
+                )
+                # Keep token accounting and terminal metadata, and let fan-out
+                # siblings continue. Failed tokens remain in the detokenizer;
+                # a later update can decode them without appending them twice.
+                chunk["text"] = ""
         return chunk if tag is None else (tag, chunk)
 
 
@@ -238,17 +247,18 @@ class _BufferedChunk(NamedTuple):
 class StreamBatchDispatcher:
     """Collect one engine step per output thread and dispatch it by event loop.
 
-    Holds no per-stream state. Each stream's detokenizer belongs to the engine
-    callback that feeds it, and rides along on every chunk, so nothing here is
-    shared between the output threads and the event loop and nothing has to be
-    cleaned up: when the engine drops a finished stream's callback the
-    detokenizer goes with it.
+    The dispatcher has no persistent per-stream registry. Each engine callback
+    creates one detokenizer and must reuse it for every chunk of its
+    (collector, tag); every collector-bound chunk carries that same state.
+    Merging keeps the first pending chunk's state, so it must not be replaced
+    partway through a stream.
 
-    It used to live in a dict here, which cost a lock -- 27% of the API
-    server's CPU, since every buffered chunk looked its state up with all
-    output threads contending -- and then, without the lock, cost an entry
-    that two threads had to keep in agreement and that teardown had to
-    remember to remove.
+    For StreamOutputCollector, references cross threads but only get() on the
+    event loop mutates the state. Output threads just pass it through. An unread
+    chunk or queued delivery keeps the state (including its token history) alive
+    after the engine drops the finished callback; consuming or discarding those
+    references allows it to be reclaimed. Queue consumers use eager decoding
+    on their output thread instead.
     """
 
     def __init__(self, tokenizer: Any, synthetic_text: str | None = None):

--- a/atom/entrypoints/openai/streaming_dispatch.py
+++ b/atom/entrypoints/openai/streaming_dispatch.py
@@ -4,9 +4,9 @@
 """Cross-thread dispatch and per-request delivery for streaming model output.
 
 Two halves of one hand-off. :class:`StreamBatchDispatcher` runs on the engine
-output threads: it buffers a whole engine step, detokenizes it, and schedules a
-single callback per event loop. :class:`StreamOutputCollector` is the loop-side
-landing point each stream's SSE generator reads from.
+output threads and schedules a whole engine step per event loop.
+:class:`StreamOutputCollector` merges pending token deltas before decoding them
+when the SSE consumer reads, so a slow consumer does not accumulate decode work.
 """
 
 import array
@@ -111,12 +111,10 @@ def merge_chunk(into: dict, new: dict) -> None:
 class StreamOutputCollector:
     """Per-request delivery point that merges chunks when the consumer lags.
 
-    Replaces the unbounded ``asyncio.Queue`` that used to sit between the engine
-    output threads and the SSE response generators. A queue hands over one item
-    per ``get()``, so when the frontend cannot keep up with the GPU the backlog
-    grows without bound and every queued item still costs its own coroutine
-    wakeup, JSON encode and socket write. Here a stream holds at most one chunk:
-    anything arriving behind an unread one merges into it.
+    A stream holds at most one pending chunk per tag. Raw token deltas from the
+    dispatcher merge here before detokenization, coroutine wakeup, JSON encoding
+    and socket writing. Detokenizer state is advanced only by ``get()``, on the
+    event loop; the engine output threads never decode collector-bound chunks.
 
     Nothing is ever held back. With a consumer that keeps up nothing ever
     merges, and delivery is identical to the queue this replaces. Merging only
@@ -156,6 +154,11 @@ class StreamOutputCollector:
         del self._pending[tag]
         if not self._pending:
             self._ready.clear()
+        state = chunk.pop("_detokenizer", None)
+        if state is not None:
+            chunk["text"] = state.update(
+                chunk["token_ids"], bool(chunk.get("finished"))
+            )
         return chunk if tag is None else (tag, chunk)
 
 
@@ -275,7 +278,7 @@ class StreamBatchDispatcher:
         buf.append(_BufferedChunk(loop, collector, state, chunk, tag))
 
     def flush(self) -> None:
-        """Detokenize buffered chunks and schedule one delivery per event loop."""
+        """Schedule raw chunks, letting each consumer coalesce before decoding."""
         tl = self._thread_local
         buf = getattr(tl, "buf", None)
         if not buf:
@@ -284,10 +287,18 @@ class StreamBatchDispatcher:
 
         by_loop: dict[AbstractEventLoop, list[tuple[Any, Any]]] = {}
         for item in buf:
-            item.chunk["text"] = item.state.update(
-                item.chunk.get("token_ids") or [],
-                bool(item.chunk.get("finished")),
-            )
+            if isinstance(item.collector, StreamOutputCollector):
+                # Keep this state with the pending chunk until get(). Moving
+                # only the JSON/socket work downstream still made four output
+                # threads decode every token while contending for the GIL.
+                item.chunk["_detokenizer"] = item.state
+            else:
+                # Queue consumers cannot decode on read and still receive a
+                # prepared chunk, as before.
+                item.chunk["text"] = item.state.update(
+                    item.chunk.get("token_ids") or [],
+                    bool(item.chunk.get("finished")),
+                )
             payload = item.chunk if item.tag is None else (item.tag, item.chunk)
             by_loop.setdefault(item.loop, []).append((item.collector, payload))
 

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -1230,6 +1230,13 @@ class CoreManager:
 
     def _mark_seq_prefill_complete(self, seq_id) -> None:
         """Release only a sequence's prefill-token charge, once."""
+        # Every decode token reaches this path, but the immutable charge tuple
+        # changes to zero on the first output. Avoid contending with the other
+        # DP output threads for a no-op; re-read under the lock before changing
+        # counters because abort/finish may release the charge concurrently.
+        entry = self._seq_load.get(seq_id)
+        if entry is None or entry[2] == 0:
+            return
         with self._lb_lock:
             entry = self._seq_load.get(seq_id)
             if entry is None:

--- a/atom/model_engine/engine_core_mgr.py
+++ b/atom/model_engine/engine_core_mgr.py
@@ -1230,12 +1230,15 @@ class CoreManager:
 
     def _mark_seq_prefill_complete(self, seq_id) -> None:
         """Release only a sequence's prefill-token charge, once."""
-        # Every decode token reaches this path, but the immutable charge tuple
-        # changes to zero on the first output. Avoid contending with the other
-        # DP output threads for a no-op; re-read under the lock before changing
+        # Every decode token reaches this path. The prefill charge may be zero
+        # at admission, or already released by the first output. Avoid taking
+        # the router lock for a no-op; re-read under the lock before changing
         # counters because abort/finish may release the charge concurrently.
         entry = self._seq_load.get(seq_id)
-        if entry is None or entry[2] == 0:
+        if entry is None:
+            return
+        _, _, tok_cost = entry
+        if tok_cost == 0:
             return
         with self._lb_lock:
             entry = self._seq_load.get(seq_id)

--- a/docs/serving_benchmarking_guide.md
+++ b/docs/serving_benchmarking_guide.md
@@ -94,21 +94,37 @@ Streaming responses use the SSE (Server-Sent Events) protocol with
 
 #### Delivery under load
 
-The API server is a single Python process, so at high concurrency the fixed
-per-chunk cost of delivering tokens (detokenize, coroutine wakeup, JSON encode,
-socket write) can cap throughput before the GPU does. Two things keep that cost
-down:
+The API server is a single Python process, so at high concurrency detokenization
+and per-chunk delivery work (coroutine wakeup, JSON encoding, socket writes) can
+cap throughput before the GPU does. Two things reduce that work:
 
-- **Backlog merging.** Each request's chunks land in a `StreamOutputCollector`
-  (`atom/entrypoints/openai/streaming_dispatch.py`), which holds at most one
-  chunk per stream: anything arriving behind an unread one merges into it.
-  Nothing is held back waiting for more, so a consumer that keeps up sees
-  exactly one chunk per engine step.
+- **Merge before detokenization.** Engine output threads hand raw token deltas
+  to `StreamOutputCollector` (`atom/entrypoints/openai/streaming_dispatch.py`).
+  It keeps one pending chunk per stream or fan-out tag, merging unread token
+  IDs and metadata. The consumer decodes the accumulated delta in `get()`, so
+  backlog merging saves repeated detokenization as well as delivery work.
+  There is no timer or minimum batch size; a consumer that keeps up can read
+  each delta as it arrives.
 - **msgspec frame encoding** (`atom/entrypoints/openai/sse.py`), roughly 5.8x
   cheaper per frame than `json.dumps`.
 
-**A token *can* be delivered later than the engine produced it, by a bounded
-amount.** Two stages downstream of the collector read the text for markers —
+Detokenizer state is shared by reference but mutated only on the event loop;
+queued or unread chunks keep it alive after the engine callback is removed.
+A decode exception is logged with the request and fan-out tag. That chunk is
+returned with empty text while retaining token counts and terminal metadata,
+so a failed decode does not terminate sibling streams. Buffered tokens can be
+recovered by a later successful update; text from a failing terminal update
+cannot be guaranteed.
+
+Decoding is synchronous on the event loop. A large accumulated delta can delay
+other requests, and one pending chunk does not bound its token count or memory.
+There is no guarantee of unchanged TTFT or ITL. The serving benchmark measures
+intervals between SSE events carrying choices, which may contain multiple
+merged tokens or empty text; these intervals are not GPU token-generation
+latencies.
+
+**Marker lookahead bounds buffered bytes, not wall-clock delivery latency.**
+Two stages downstream of the collector read the text for markers —
 the reasoning channel's delimiters
 (`atom/entrypoints/openai/reasoning.py`) and the opening tags of whichever
 tool-call format this model uses (`atom/entrypoints/openai/tool_parser/`) —
@@ -116,10 +132,11 @@ and neither may hand out a byte that could turn out to be the first character
 of one. Both ask the same
 question through `MarkerScanner`
 (`atom/entrypoints/openai/marker_scanner.py`): release everything except the
-longest *suffix* of the buffer that is a prefix of some marker. The wait is
-therefore bounded by the longest marker a format declares, a few dozen bytes,
-and is usually zero — a chunk whose tail cannot begin a marker is released
-whole.
+longest *suffix* of the buffer that is a prefix of some marker. The retained
+suffix is therefore bounded by the longest marker a format declares, a few
+dozen bytes, and is usually empty — a chunk whose tail cannot begin a marker
+is released whole. Event-loop scheduling and socket backpressure can still
+add delivery delay.
 
 This is worth stating because it used to be unbounded. The rule was "hold
 everything once a marker's first character appears *anywhere* in the buffer",

--- a/tests/entrypoints/test_streaming_dispatch.py
+++ b/tests/entrypoints/test_streaming_dispatch.py
@@ -444,3 +444,148 @@ def test_each_stream_gets_its_own_detokenizer():
 
     assert first is not second
     assert not first.tokens and not second.tokens
+
+
+class _CountingTokenizer(_Utf8ByteTokenizer):
+    def __init__(self):
+        self.calls = 0
+
+    def decode(self, token_ids, skip_special_tokens=True):
+        self.calls += 1
+        return super().decode(token_ids, skip_special_tokens)
+
+
+def test_backlogged_tokens_are_merged_before_decoding():
+    tokenizer = _CountingTokenizer()
+    dispatcher = StreamBatchDispatcher(tokenizer)
+    loop = _RecordingLoop()
+    collector = StreamOutputCollector("slow-reader")
+    state = dispatcher.new_state()
+    payload = ("你好 🎉 " * 40).encode()
+    for i, byte in enumerate(payload):
+        dispatcher.enqueue(
+            loop=loop,
+            collector=collector,
+            state=state,
+            chunk={
+                "token_ids": [byte],
+                "finished": i == len(payload) - 1,
+                "finish_reason": "length" if i == len(payload) - 1 else None,
+                "num_cached_tokens": 7 if i == 0 else 0,
+            },
+        )
+        dispatcher.flush()
+    loop.run()
+
+    # Producers and delivery callbacks must not spend time decoding a backlog
+    # the consumer will fold into a single response anyway.
+    assert tokenizer.calls == 0
+    chunk = _resolve(collector.get())
+    assert chunk["text"] == payload.decode()
+    assert chunk["token_ids"] == list(payload)
+    assert chunk["finished"] is True
+    assert chunk["finish_reason"] == "length"
+    assert chunk["num_cached_tokens"] == 7
+    assert "_detokenizer" not in chunk
+    assert tokenizer.calls <= 2
+
+
+def test_deferred_decode_keeps_fanout_and_partial_unicode_separate():
+    dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
+    loop = _ImmediateLoop()
+    collector = StreamOutputCollector("fanout")
+    states = [dispatcher.new_state(), dispatcher.new_state()]
+
+    def send(tag, ids, finished=False):
+        dispatcher.enqueue(
+            loop=loop,
+            collector=collector,
+            state=states[tag],
+            chunk={"token_ids": ids, "finished": finished},
+            tag=tag,
+        )
+        dispatcher.flush()
+
+    send(0, [0xE4])
+    assert _resolve(collector.get())[1]["text"] == ""
+    send(1, list(b"other"), True)
+    send(0, [0xBD])
+    send(0, [0xA0], True)
+    assert _resolve(collector.get()) == (
+        1,
+        {"token_ids": list(b"other"), "text": "other", "finished": True},
+    )
+    assert _resolve(collector.get()) == (
+        0,
+        {"token_ids": [0xBD, 0xA0], "text": "你", "finished": True},
+    )
+
+
+def test_deferred_synthetic_stream_preserves_token_count():
+    tokenizer = _CountingTokenizer()
+    dispatcher = StreamBatchDispatcher(tokenizer, synthetic_text="synthetic ")
+    loop = _ImmediateLoop()
+    collector = StreamOutputCollector("synthetic")
+    state = dispatcher.new_state()
+    for byte in b"abc":
+        dispatcher.enqueue(
+            loop=loop,
+            collector=collector,
+            state=state,
+            chunk={"token_ids": [byte], "finished": byte == ord("c")},
+        )
+        dispatcher.flush()
+    chunk = _resolve(collector.get())
+    assert chunk["text"] == "synthetic " * 3
+    assert chunk["token_ids"] == list(b"abc")
+    assert chunk["finished"] is True
+    assert tokenizer.calls > 0  # synthetic output still pays the decoding cost
+
+
+def test_concurrent_output_threads_preserve_stream_contents_and_termination():
+    async def scenario():
+        dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
+        loop = asyncio.get_running_loop()
+        collectors = [StreamOutputCollector(str(i)) for i in range(16)]
+        states = [dispatcher.new_state() for _ in collectors]
+        payloads = [(f"stream {i}: 你好 🎉 " * 5).encode() for i in range(16)]
+
+        def produce(rank):
+            for step in range(max(map(len, payloads))):
+                for i in range(rank, len(collectors), 4):
+                    if step >= len(payloads[i]):
+                        continue
+                    dispatcher.enqueue(
+                        loop=loop,
+                        collector=collectors[i],
+                        state=states[i],
+                        chunk={
+                            "token_ids": [payloads[i][step]],
+                            "finished": step == len(payloads[i]) - 1,
+                        },
+                    )
+                dispatcher.flush()
+
+        async def consume(i):
+            text = ""
+            tokens = []
+            while True:
+                chunk = await collectors[i].get()
+                text += chunk["text"]
+                tokens.extend(chunk["token_ids"])
+                if chunk["finished"]:
+                    break
+                await asyncio.sleep(0)
+            assert text == payloads[i].decode()
+            assert tokens == list(payloads[i])
+            assert not collectors[i]._pending
+
+        await asyncio.wait_for(
+            asyncio.gather(
+                *(asyncio.to_thread(produce, rank) for rank in range(4)),
+                *(consume(i) for i in range(len(collectors))),
+            ),
+            timeout=5,
+        )
+
+    asyncio.run(scenario())

--- a/tests/entrypoints/test_streaming_dispatch.py
+++ b/tests/entrypoints/test_streaming_dispatch.py
@@ -71,8 +71,8 @@ def test_incremental_detokenizer_holds_incomplete_utf8():
 def test_dispatcher_batches_direct_and_tagged_chunks_per_loop():
     dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
     loop = _ImmediateLoop()
-    direct_queue = asyncio.Queue()
-    tagged_queue = asyncio.Queue()
+    direct_queue = StreamOutputCollector("direct")
+    tagged_queue = StreamOutputCollector("fanout")
 
     dispatcher.enqueue(
         loop=loop,
@@ -90,8 +90,8 @@ def test_dispatcher_batches_direct_and_tagged_chunks_per_loop():
     dispatcher.flush()
 
     assert len(loop.calls) == 1
-    assert direct_queue.get_nowait()["text"] == "A"
-    sibling_index, chunk = tagged_queue.get_nowait()
+    assert _resolve(direct_queue.get())["text"] == "A"
+    sibling_index, chunk = _resolve(tagged_queue.get())
     assert sibling_index == 0
     assert chunk["text"] == "B"
 
@@ -99,7 +99,7 @@ def test_dispatcher_batches_direct_and_tagged_chunks_per_loop():
 def test_dispatcher_keeps_fanout_detokenizer_state_separate():
     dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
     loop = _ImmediateLoop()
-    queue = asyncio.Queue()
+    queue = StreamOutputCollector("fanout")
     sibling_0, sibling_1 = dispatcher.new_state(), dispatcher.new_state()
 
     dispatcher.enqueue(
@@ -118,8 +118,8 @@ def test_dispatcher_keeps_fanout_detokenizer_state_separate():
     )
     dispatcher.flush()
 
-    assert queue.get_nowait()[1]["text"] == ""
-    assert queue.get_nowait()[1]["text"] == "X"
+    assert _resolve(queue.get())[1]["text"] == ""
+    assert _resolve(queue.get())[1]["text"] == "X"
 
     # Sibling 0's half character survives sibling 1 finishing in between.
     dispatcher.enqueue(
@@ -131,46 +131,63 @@ def test_dispatcher_keeps_fanout_detokenizer_state_separate():
     )
     dispatcher.flush()
 
-    assert queue.get_nowait()[1]["text"] == "你"
+    assert _resolve(queue.get())[1]["text"] == "你"
 
 
 def test_a_fresh_stream_does_not_inherit_a_half_decoded_character():
-    """Each stream's detokenizer is its own object, so bytes cannot leak over."""
+    """Two fresh states in the same batch cannot share a partial character."""
     dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
     loop = _ImmediateLoop()
-    queue = asyncio.Queue()
-
-    for _ in range(2):
-        dispatcher.enqueue(
-            loop=loop,
-            collector=queue,
-            state=dispatcher.new_state(),
-            chunk={"token_ids": [0xE4], "finished": False},
-        )
+    partial = StreamOutputCollector("partial")
+    fresh = StreamOutputCollector("fresh")
+    partial_state = dispatcher.new_state()
+    dispatcher.enqueue(
+        loop=loop,
+        collector=partial,
+        state=partial_state,
+        chunk={"token_ids": [0xE4], "finished": False},
+    )
+    dispatcher.enqueue(
+        loop=loop,
+        collector=fresh,
+        state=dispatcher.new_state(),
+        chunk={"token_ids": [ord("A")], "finished": True},
+    )
     dispatcher.flush()
 
-    for _ in range(2):
-        dispatcher.enqueue(
-            loop=loop,
-            collector=queue,
-            state=dispatcher.new_state(),
-            chunk={"token_ids": [ord("A")], "finished": True},
-        )
+    assert len(loop.calls) == 1
+    assert _resolve(partial.get())["text"] == ""
+    assert _resolve(fresh.get())["text"] == "A"
+    dispatcher.enqueue(
+        loop=loop,
+        collector=partial,
+        state=partial_state,
+        chunk={"token_ids": [0xBD, 0xA0], "finished": True},
+    )
     dispatcher.flush()
-
-    assert queue.get_nowait()["text"] == ""
-    assert queue.get_nowait()["text"] == ""
-    assert queue.get_nowait()["text"] == "A"
-    assert queue.get_nowait()["text"] == "A"
+    assert _resolve(partial.get())["text"] == "你"
 
 
-def test_collector_hands_over_a_lone_chunk_untouched():
-    """A consumer that keeps up must see exactly what the queue used to give."""
+def test_collector_decodes_a_lone_chunk_without_waiting_for_more():
+    """The shipped dispatcher path is immediately readable without a timer."""
+    tokenizer = _CountingTokenizer()
+    dispatcher = StreamBatchDispatcher(tokenizer)
     collector = StreamOutputCollector("request-1")
-    chunk = {"token_ids": [1], "text": "a", "finished": False}
-    collector.put_nowait(chunk)
+    dispatcher.enqueue(
+        loop=_ImmediateLoop(),
+        collector=collector,
+        state=dispatcher.new_state(),
+        chunk={"token_ids": [ord("a")], "finished": False},
+    )
+    dispatcher.flush()
 
-    assert _resolve(collector.get()) is chunk
+    assert tokenizer.calls == 0
+    assert _resolve(collector.get()) == {
+        "token_ids": [ord("a")],
+        "text": "a",
+        "finished": False,
+    }
+    assert tokenizer.calls == 2
 
 
 def test_collector_merges_a_backlog_into_one_chunk():
@@ -312,6 +329,7 @@ def test_a_step_is_delivered_in_a_single_loop_callback():
         )
     dispatcher.flush()
 
+    assert len(loop.pending) == 1
     assert loop.run() == 1
     for collector in collectors:
         assert _resolve(collector.get())["text"] == "A"
@@ -408,23 +426,14 @@ def test_merge_keeps_the_text_it_had_when_the_delta_is_not_a_string():
 
 
 def test_dispatcher_keeps_no_per_stream_state():
-    """The dispatcher must stay stateless between streams.
-
-    Detokenizers used to live in a dict here: first behind a lock that cost 27%
-    of the API server's CPU, then lock-free with an index two threads had to
-    keep in agreement and teardown had to remember to clear -- draining 8192
-    streams cost 894 ms of scanning, and a missed removal leaked a detokenizer
-    whose token list grows without bound. Now each one belongs to the engine
-    callback that feeds it, so there is nothing here to leak or to race on.
-    """
+    """Finished callbacks may go away while collectors still own unread state."""
     dispatcher = StreamBatchDispatcher(_Utf8ByteTokenizer())
     loop = _ImmediateLoop()
-    queue = asyncio.Queue()
-
-    for _ in range(64):
+    collectors = [StreamOutputCollector(str(i)) for i in range(64)]
+    for collector in collectors:
         dispatcher.enqueue(
             loop=loop,
-            collector=queue,
+            collector=collector,
             state=dispatcher.new_state(),
             chunk={"token_ids": [ord("A")], "finished": True},
         )
@@ -435,6 +444,8 @@ def test_dispatcher_keeps_no_per_stream_state():
         "synthetic_text",
         "_thread_local",
     }
+    for collector in collectors:
+        assert _resolve(collector.get())["text"] == "A"
 
 
 def test_each_stream_gets_its_own_detokenizer():
@@ -535,11 +546,12 @@ def test_deferred_synthetic_stream_preserves_token_count():
             chunk={"token_ids": [byte], "finished": byte == ord("c")},
         )
         dispatcher.flush()
+    assert tokenizer.calls == 0
     chunk = _resolve(collector.get())
     assert chunk["text"] == "synthetic " * 3
     assert chunk["token_ids"] == list(b"abc")
     assert chunk["finished"] is True
-    assert tokenizer.calls > 0  # synthetic output still pays the decoding cost
+    assert tokenizer.calls == 2  # one real update for three accumulated tokens
 
 
 def test_concurrent_output_threads_preserve_stream_contents_and_termination():
@@ -589,3 +601,87 @@ def test_concurrent_output_threads_preserve_stream_contents_and_termination():
         )
 
     asyncio.run(scenario())
+
+
+class _FailOnceTokenizer(_CountingTokenizer):
+    def __init__(self, fail_on):
+        super().__init__()
+        self.fail_on = fail_on
+
+    def decode(self, token_ids, skip_special_tokens=True):
+        if self.calls + 1 == self.fail_on:
+            self.calls += 1
+            raise ValueError("injected decode failure")
+        return super().decode(token_ids, skip_special_tokens)
+
+
+@pytest.mark.parametrize("fail_on", (3, 4), ids=("prefix", "new-text"))
+def test_decode_failure_keeps_tokens_for_a_later_update(fail_on, caplog):
+    # Each update decodes the prefix and then the new text. Either call can
+    # fail after tokens.extend(), before the prefix/read offsets advance.
+    dispatcher = StreamBatchDispatcher(_FailOnceTokenizer(fail_on))
+    collector = StreamOutputCollector("recoverable")
+    state = dispatcher.new_state()
+    loop = _ImmediateLoop()
+
+    def send(byte, finished=False):
+        dispatcher.enqueue(
+            loop=loop,
+            collector=collector,
+            state=state,
+            chunk={"token_ids": [byte], "finished": finished},
+        )
+        dispatcher.flush()
+        return _resolve(collector.get())
+
+    assert send(ord("A"))["text"] == "A"
+    failed = send(ord("B"))
+    assert failed == {"token_ids": [ord("B")], "text": "", "finished": False}
+    recovered = send(ord("C"), finished=True)
+    assert recovered == {"token_ids": [ord("C")], "text": "BC", "finished": True}
+    assert list(state.tokens) == list(b"ABC")
+    assert "Error detokenizing stream recoverable (tag=None)" in caplog.text
+    assert "injected decode failure" in caplog.text
+
+
+@pytest.mark.parametrize("fail_on", (1, 2), ids=("prefix", "new-text"))
+def test_failed_terminal_decode_preserves_metadata_and_fanout(fail_on, caplog):
+    dispatcher = StreamBatchDispatcher(_FailOnceTokenizer(fail_on))
+    collector = StreamOutputCollector("fanout-error")
+    loop = _ImmediateLoop()
+    states = [dispatcher.new_state(), dispatcher.new_state()]
+    for tag, ids, finished in ((0, [65], False), (0, [66], True), (1, [90], True)):
+        dispatcher.enqueue(
+            loop=loop,
+            collector=collector,
+            state=states[tag],
+            chunk={
+                "token_ids": ids,
+                "finished": finished,
+                "finish_reason": "length" if finished else None,
+                "num_cached_tokens": 7,
+                "kv_transfer_params": {"source": "prefill"},
+            },
+            tag=tag,
+        )
+    dispatcher.flush()
+
+    tag, failed = _resolve(collector.get())
+    assert tag == 0
+    assert failed == {
+        "token_ids": [65, 66],
+        "text": "",
+        "finished": True,
+        "finish_reason": "length",
+        "num_cached_tokens": 7,
+        "kv_transfer_params": {"source": "prefill"},
+    }
+    tag, healthy = _resolve(collector.get())
+    assert tag == 1
+    assert healthy["text"] == "Z"
+    assert healthy["token_ids"] == [90]
+    assert healthy["finished"] is True
+    assert not collector._pending
+    assert not collector._ready.is_set()
+    assert "Error detokenizing stream fanout-error (tag=0)" in caplog.text
+    assert "injected decode failure" in caplog.text

--- a/tests/entrypoints/test_streaming_tokenizer.py
+++ b/tests/entrypoints/test_streaming_tokenizer.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: MIT
+"""Merged and single-token decoding must agree without model downloads or GPUs."""
+
+import asyncio
+from itertools import cycle
+
+import pytest
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers, trainers
+from transformers import PreTrainedTokenizerFast
+
+from atom.entrypoints.openai.streaming_dispatch import (
+    IncrementalStreamDetokenizer,
+    StreamBatchDispatcher,
+    StreamOutputCollector,
+)
+
+_TEXTS = (
+    "你好，世界！ 日本語 한국어 العربية हिन्दी русский",
+    "👩🏽‍💻 👨‍👩‍👧‍👦 🙂🌍",
+    "café e\u0301 naïve résumé",
+    "a  b\t c \n\n trailing  ",
+    "def f(x):\n    return x + 1  # comment\n",
+    "Hello <special> world! <special>",
+)
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    # Exercise the real HF wrapper and byte-level BPE backend entirely offline.
+    backend = Tokenizer(models.BPE())
+    backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    backend.decoder = decoders.ByteLevel()
+    backend.train_from_iterator(
+        _TEXTS,
+        trainers.BpeTrainer(
+            vocab_size=320,
+            initial_alphabet=pre_tokenizers.ByteLevel.alphabet(),
+            special_tokens=["<special>"],
+            show_progress=False,
+        ),
+    )
+    return PreTrainedTokenizerFast(
+        tokenizer_object=backend,
+        additional_special_tokens=["<special>"],
+        clean_up_tokenization_spaces=False,
+    )
+
+
+@pytest.mark.parametrize("text", _TEXTS)
+@pytest.mark.parametrize(
+    "drain_pattern", ((1,), (2,), (3,), (8,), (4096,), (1, 1, 1, 8, 2, 1))
+)
+def test_merged_tokens_match_single_token_updates(tokenizer, text, drain_pattern):
+    ids = tokenizer.encode(text, add_special_tokens=False)
+    reference = IncrementalStreamDetokenizer(tokenizer)
+    expected = "".join(
+        reference.update([token], finished=i == len(ids) - 1)
+        for i, token in enumerate(ids)
+    )
+    assert expected == tokenizer.decode(ids, skip_special_tokens=True)
+
+    async def run():
+        dispatcher = StreamBatchDispatcher(tokenizer)
+        collector = StreamOutputCollector("merged-tokenizer")
+        state = dispatcher.new_state()
+        loop = asyncio.get_running_loop()
+        intervals = cycle(drain_pattern)
+        remaining = next(intervals)
+        texts, delivered_ids, terminal = [], [], 0
+        for i, token in enumerate(ids):
+            finished = i == len(ids) - 1
+            dispatcher.enqueue(
+                loop=loop,
+                collector=collector,
+                state=state,
+                chunk={"token_ids": [token], "finished": finished},
+            )
+            dispatcher.flush()
+            await asyncio.sleep(0)  # Deliver without forcing the consumer to read.
+            remaining -= 1
+            if remaining == 0 or finished:
+                chunk = await collector.get()
+                texts.append(chunk["text"])
+                delivered_ids.extend(chunk["token_ids"])
+                terminal += bool(chunk["finished"])
+                remaining = next(intervals)
+        return "".join(texts), delivered_ids, terminal
+
+    assert asyncio.run(run()) == (expected, ids, 1)

--- a/tests/test_dp_load_balance.py
+++ b/tests/test_dp_load_balance.py
@@ -518,3 +518,26 @@ def test_reset_clears_even_with_charged_in_flight():
 def test_dp_lb_strategies_constant():
     assert DP_LB_STRATEGIES == ("round_robin", "least_requests", "least_tokens")
     assert "least_request" not in DP_LB_STRATEGIES  # guards against typos
+
+
+def test_decode_bookkeeping_does_not_wait_for_an_unrelated_router_lock():
+    from threading import Event, Thread
+
+    mgr = _make_mgr(2, strategy="least_tokens")
+    seq = _FakeSeq("a", num_prompt_tokens=20)
+    _route(mgr, [seq])
+    mgr._mark_seq_prefill_complete(seq.id)
+    completed = Event()
+
+    def receive_decode_token():
+        mgr._mark_seq_prefill_complete(seq.id)
+        completed.set()
+
+    with mgr._lb_lock:
+        worker = Thread(target=receive_decode_token)
+        worker.start()
+        progressed_while_router_locked = completed.wait(timeout=2)
+    worker.join(timeout=2)
+    assert progressed_while_router_locked
+    assert sum(mgr._rank_reqs) == 1
+    assert sum(mgr._rank_tokens) == 0

--- a/tests/test_dp_load_balance.py
+++ b/tests/test_dp_load_balance.py
@@ -10,7 +10,7 @@
 # conftest.py supplies the atom.* / zmq stubs the import chain needs.
 
 import pickle
-from threading import Lock
+from threading import Event, Lock, Thread
 
 import pytest
 
@@ -521,12 +521,13 @@ def test_dp_lb_strategies_constant():
 
 
 def test_decode_bookkeeping_does_not_wait_for_an_unrelated_router_lock():
-    from threading import Event, Thread
-
     mgr = _make_mgr(2, strategy="least_tokens")
     seq = _FakeSeq("a", num_prompt_tokens=20)
     _route(mgr, [seq])
+    assert sum(mgr._rank_reqs) == 1
+    assert sum(mgr._rank_tokens) == 20
     mgr._mark_seq_prefill_complete(seq.id)
+    assert sum(mgr._rank_tokens) == 0
     completed = Event()
 
     def receive_decode_token():


### PR DESCRIPTION
## Problem and change

With 4096 streaming requests and a concurrency limit of 2048, the model can finish the first wave while the API process is still draining its output. The benchmark holds each concurrency slot until the full response completes, so the next requests cannot enter the engine. A DeepSeek-V4-Pro run on the main baseline showed a roughly 30.76-second gap in CPU operator/runtime activity on all four DP ranks between waves.

`StreamOutputCollector` already merges unread chunks, but `StreamBatchDispatcher.flush()` previously detokenized every delta before that merge. This change passes raw token deltas and their per-stream detokenizer state to the collector, then decodes the accumulated tokens when the consumer calls `get()`. Backlogged streams therefore avoid repeated decode calls and output-thread GIL contention. There is no timer or minimum batch size; available chunks remain immediately readable. The existing queue compatibility path retains eager decoding; production OpenAI streams use collectors. Per-stream/fan-out state, token order, finish metadata, and incremental Unicode handling are preserved.

The output path also calls `_mark_seq_prefill_complete()` after prefill is already accounted for. An early read now skips `_lb_lock` when the immutable charge tuple is absent or its prefill charge is zero. Counter mutations still re-read and validate the entry under the lock to handle concurrent finish/abort.

Deferred decode exceptions are logged with the request ID and fan-out tag. The consumer receives empty text for the failed update while retaining token accounting and terminal metadata, so one bad decode cannot terminate sibling streams. A later successful update can recover buffered tokens without appending them twice; text from a failing terminal update is not guaranteed. Documentation now states the single-mutator invariant, pending-state lifetime, and the fact that synchronous event-loop decoding does not guarantee unchanged TTFT/ITL.

## Validation

Latest revision (`e7393994`) was validated on CPU only, with GPU visibility disabled:

- `python -m pytest -q tests/entrypoints tests/test_dp_load_balance.py --ignore=tests/entrypoints/test_openai_server.py`: **1952 passed, 31 skipped, 3 xfailed**.
- Regression tests inject exceptions in both prefix and new-text decoding, checking recovery without duplicate tokens, terminal metadata, logging, and fan-out isolation.
- Dispatcher tests now exercise the production collector path for per-loop batching, independent stream state, and immediate reads. Synthetic-output tests assert zero decode calls before consumption and exactly two after merging.
- 36 committed offline checks use a locally trained byte-level BPE tokenizer through the real HF wrapper to compare merged deltas against single-token updates, including full and mid-stream backlogs, multilingual text, emoji-ZWJ, whitespace, code, accents, and special tokens. No model download is needed.
- Earlier validation at `4dafab6d` included 25 checks with the actual DeepSeek tokenizer. Those checks and the GPU A/B below were not rerun for this revision.
- Black and `git diff --check` passed. Ruff findings were unchanged from the baseline (three BLE001 and one S110 in `engine_core_mgr.py`).

## DeepSeek-V4-Pro A/B (measured at `4dafab6d`)

These are the original performance measurements, not a GPU rerun of `e7393994`.

Baseline: `2458289a58d5cfbb3542d232023c58b8fc81345f` on `origin/main`. Both runs used the same gfx1250 model/server configuration, four DP ranks, profiling enabled, 4096 random requests, concurrency 2048, 1024 input tokens, 1024 output tokens, infinite request rate, and ignored EOS. The two production changes above were applied together.

| Metric | Main baseline | `4dafab6d` |
| --- | ---: | ---: |
| Successful requests | 4096 / 4096 | 4096 / 4096 |
| Output tokens per request | 1024 | 1024 |
| Benchmark duration | 221.05 s | 155.80 s |
| Output throughput | 18,974 tokens/s | 26,920 tokens/s |
| Mean TTFT | 12,016 ms | 11,672 ms |
| Mean TPOT | 96.00 ms | 61.55 ms |
| Maximum internal CPU operator/runtime gap, per rank | 30.7591–30.7598 s | 0.2699–0.2963 s |
| Internal CPU operator/runtime gaps over 1 s | One per rank | Zero on all four ranks |

This single A/B measurement reduced duration by **29.5%** and increased output throughput by **41.9%**. Benchmark duration excludes profiler shutdown/export. Gap measurements use the union of CPU operator/runtime intervals between the first and last event; model-step annotations independently had no internal gap above 0.4 seconds after the change.

GPU kernel traces ended before the complete CPU model-step timeline in both runs, so these results do not establish a whole-run GPU utilization percentage or strictly gap-free GPU execution. The measured improvement is removal of the long inter-wave scheduling stall and faster end-to-end completion. Multiple-run variance and the individual contribution of each change have not been measured.

## Follow-up scope

The review's larger collector-state/API refactor (including removal of the queue compatibility path) and the separate atomesh streaming path remain follow-up work. The state identity invariant is documented in this change. Event-loop occupancy and high-concurrency consumers that keep up still need dedicated latency measurement; there is no claim of an ITL bound. The `ci:atom` label was removed, and native/vLLM/SGLang GPU accuracy jobs were skipped. The repository also starts an ungated GPU offline smoke job on every PR update; it entered the offline-inference step before this separate trigger was noticed. Run 34217907352 was cancelled and its cleanup step completed. Local validation used CPU only, and all remote Pre Checkin checks (including non-GPU unit tests) passed. No new GPU performance result is claimed for this revision.
