### PR TITLE
[Perf][MiniMax-M3] Bound the decode index-score split by blocks-per-chunk

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -34,6 +34,15 @@ def use_pa_decode_bf16_asm() -> bool:
     )
 
 
+# Largest query group the gluon decode kernel can take: its register-layout
+# table has arms for 16/32/64 only, and past 64 nothing binds `register_bases`
+# -- the failure is a Triton compile error that never mentions speculation.
+# The group is max_seqlen_q * (q_heads / kv_heads), so drafting multiplies it:
+# M3 sits exactly on the limit today (16 x 4 draft positions), and one more
+# draft token would overflow it. vLLM guards the same bound.
+PA_GLUON_MAX_QUERY_GROUP_SIZE = 64
+
+
 class PagedAttentionImpl(nn.Module):
     """
     Attention paged implementation
@@ -489,7 +498,14 @@ class PagedAttentionImpl(nn.Module):
 
         num_seqs = attn_metadata.context_lens.shape[0]
 
-        if envs.ATOM_USE_UNIFIED_ATTN or self.use_flash_layout:
+        # Group-size term last: k_cache only carries the 5D shuffle layout this
+        # indexing assumes when the gluon path is otherwise the choice.
+        if (
+            envs.ATOM_USE_UNIFIED_ATTN
+            or self.use_flash_layout
+            or attn_metadata.max_seqlen_q * (q.shape[1] // k_cache.shape[1])
+            > PA_GLUON_MAX_QUERY_GROUP_SIZE
+        ):
             # print(q.shape, k_cache.shape, v_cache.shape)
             sliding_window = (
                 (self.sliding_window - 1, 0) if self.sliding_window > 0 else (-1, -1)

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -54,10 +54,7 @@ def gluon_decode_over_limit(max_qlen: int, num_heads: int, num_kv_heads: int) ->
     group_p2 = qlen_p2 * max(
         16 // qlen_p2, 1 << (num_heads // num_kv_heads - 1).bit_length()
     )
-    return (
-        max_qlen > PA_GLUON_MAX_QUERY_LEN
-        or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
-    )
+    return max_qlen > PA_GLUON_MAX_QUERY_LEN or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
 
 
 class PagedAttentionImpl(nn.Module):

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -565,9 +565,7 @@ class PagedAttentionImpl(nn.Module):
             max_context_partition_num,
             query_group_size,
         )
-        exp_sums = torch.empty(
-            intermediate_shape, dtype=torch.float32, device=q.device
-        )
+        exp_sums = torch.empty(intermediate_shape, dtype=torch.float32, device=q.device)
         max_logits = torch.empty(
             intermediate_shape, dtype=torch.float32, device=q.device
         )
@@ -885,7 +883,9 @@ class PagedAttentionImpl(nn.Module):
         get_heuristic_kernel silently re-runs with mtp=1, a kernel built for
         another query length, and computes a wrong answer instead of refusing.
         """
-        over_gluon = gluon_decode_over_limit(max_qlen, self.num_heads, self.num_kv_heads)
+        over_gluon = gluon_decode_over_limit(
+            max_qlen, self.num_heads, self.num_kv_heads
+        )
         over_asm = (
             int(max_qlen) * (self.num_heads // self.num_kv_heads)
             > PA_ASM_MAX_QUERY_GROUP_SIZE

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -167,6 +167,21 @@ class PagedAttentionImpl(nn.Module):
             return False
         return q.shape[1] % k.shape[1] == 0
 
+    def _reject_per_token_scales_on_unified(self, k_scale, v_scale, phase: str):
+        """unified_attention carries one descale for the whole tensor.
+
+        Feeding it a per-token cache is not an error downstream, just wrong
+        numbers, so it has to be refused here. Both phases route into unified on
+        the same conditions, so both check.
+        """
+        if (k_scale is not None and k_scale.numel() > 1) or (
+            v_scale is not None and v_scale.numel() > 1
+        ):
+            raise NotImplementedError(
+                f"layer {self.layer_num} takes unified_attention for {phase}, "
+                "which cannot carry its per-token KV scales"
+            )
+
     def forward_impl(
         self,
         q: torch.Tensor,
@@ -490,16 +505,7 @@ class PagedAttentionImpl(nn.Module):
         of the reasons for it.
         """
         attn_metadata = fwd_ctx.attn_metadata
-
-        # unified takes a single descale for the whole tensor. Feeding it a
-        # per-token cache is not an error downstream, just wrong numbers.
-        if (k_scale is not None and k_scale.numel() > 1) or (
-            v_scale is not None and v_scale.numel() > 1
-        ):
-            raise NotImplementedError(
-                f"query length {attn_metadata.max_seqlen_q} routes this layer to "
-                "unified_attention, which cannot carry its per-token KV scales"
-            )
+        self._reject_per_token_scales_on_unified(k_scale, v_scale, "decode")
 
         if envs.ATOM_USE_UNIFIED_ATTN and self.kv_cache_dtype.startswith("fp8"):
             o = torch.empty(*q.shape, dtype=torch.bfloat16, device=q.device)
@@ -787,7 +793,6 @@ class PagedAttentionImpl(nn.Module):
     def prefill_attention_triton(
         self, q, k, v, k_cache, v_cache, k_scale, v_scale, fwd_ctx: ForwardContext
     ):
-
         # unified_attention supports both prefill and decode, over either the 4D
         # flash layout (shuffled_kv_cache=False) or the 5D SHUFFLE layout
         # (shuffled_kv_cache=True):
@@ -825,6 +830,9 @@ class PagedAttentionImpl(nn.Module):
         # are read straight from `k_cache`/`v_cache`, identical to the
         # prefix-cache-hit path.
         if envs.ATOM_USE_UNIFIED_ATTN or attn_metadata.has_cached:
+            # Only this branch reads the quantized cache; the else below passes
+            # raw bf16 K/V, where a per-token scale never reaches the kernel.
+            self._reject_per_token_scales_on_unified(k_scale, v_scale, "prefill")
             k_for_attn = k_cache
             v_for_attn = v_cache
             # Reads the paged KV cache, which is 5D SHUFFLE unless the (default)
@@ -876,26 +884,38 @@ class PagedAttentionImpl(nn.Module):
     def _dispatch_decode(self, max_qlen: int = 1):
         """The single place that answers which decode kernel runs.
 
-        The runners do not re-decide; the vLLM bridge mirrors this order. Both
+        The runners do not re-decide. The vLLM bridge shares the constants and
+        the predicate, not this order -- its arms differ (no unified fallback,
+        no sliding-window arm). Both
         paged kernels stop short of unified, at different points, and drafting
         multiplies the query group into both limits. ASM is the one that must be
         checked here rather than inside its runner: past its envelope
         get_heuristic_kernel silently re-runs with mtp=1, a kernel built for
         another query length, and computes a wrong answer instead of refusing.
         """
+        # Clamped once here so both gates see the same value; the predicate
+        # clamps internally too, and a sentinel would otherwise split them.
+        max_qlen = max(1, int(max_qlen))
         over_gluon = gluon_decode_over_limit(
             max_qlen, self.num_heads, self.num_kv_heads
         )
         over_asm = (
-            int(max_qlen) * (self.num_heads // self.num_kv_heads)
+            max_qlen * (self.num_heads // self.num_kv_heads)
             > PA_ASM_MAX_QUERY_GROUP_SIZE
+        )
+
+        # unified takes any shape; the two paged kernels do not. Kept as one
+        # expression because a sliding-window layer needs the same answer, and
+        # it returns before the env checks below.
+        wants_unified = (
+            envs.ATOM_USE_UNIFIED_ATTN or self.use_flash_layout or over_gluon
         )
 
         # Sliding-window layers must use triton (ASM paths don't support it)
         if self.sliding_window != -1:
             return (
                 self.paged_attention_unified
-                if over_gluon
+                if wants_unified
                 else self.paged_attention_triton
             )
 
@@ -904,17 +924,20 @@ class PagedAttentionImpl(nn.Module):
         if envs.ATOM_USE_UNIFIED_ATTN:
             if envs.ATOM_FORCE_ATTN_TRITON:
                 return self.paged_attention_unified
-            if atom_config.kv_cache_block_size == 256 and not over_asm:
+            if atom_config.kv_cache_block_size == 256:
                 return self.paged_attention_persistent_asm
             return self.paged_attention_unified
 
-        if self.use_flash_layout or over_gluon:
+        if wants_unified:
             return self.paged_attention_unified
         if self.use_triton_attn:
             return self.paged_attention_triton
 
-        if use_pa_decode_bf16_asm() and not over_asm:
-            return self.paged_attention_persistent_asm
+        # use_pa_decode_bf16_asm() requires ATOM_USE_UNIFIED_ATTN, which the
+        # block above has already returned on, so it cannot be reached here.
+        # Only run_pa_fwd_asm is bounded here. The persistent paths above call
+        # pa_persistent_fwd / pa_decode_bf16_asm, different kernels with their
+        # own tables, so this envelope does not describe them.
         if over_asm:
             return self.paged_attention_triton
         return self.paged_attention_asm

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -39,6 +39,25 @@ def use_pa_decode_bf16_asm() -> bool:
 # a gqa=8 model reaches the length one first.
 PA_GLUON_MAX_QUERY_LEN = 4
 PA_GLUON_MAX_QUERY_GROUP_SIZE = 64
+# ASM paged attention's own envelope, well inside gluon's.
+PA_ASM_MAX_QUERY_GROUP_SIZE = 16
+
+
+def gluon_decode_over_limit(max_qlen: int, num_heads: int, num_kv_heads: int) -> bool:
+    """Whether decode is past what the gluon kernel takes.
+
+    pow2, not the raw product: that is what the kernel indexes its layout table
+    with, and it rounds a small group up to fill 16.
+    """
+    max_qlen = int(max_qlen)
+    qlen_p2 = 1 << (max_qlen - 1).bit_length()
+    group_p2 = qlen_p2 * max(
+        16 // qlen_p2, 1 << (num_heads // num_kv_heads - 1).bit_length()
+    )
+    return (
+        max_qlen > PA_GLUON_MAX_QUERY_LEN
+        or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
+    )
 
 
 class PagedAttentionImpl(nn.Module):
@@ -498,20 +517,14 @@ class PagedAttentionImpl(nn.Module):
 
         num_seqs = attn_metadata.context_lens.shape[0]
 
-        # pow2, not the raw product: that is what the kernel indexes its
-        # layout table with, and it rounds a small group up to fill 16.
-        qlen_p2 = 1 << (attn_metadata.max_seqlen_q - 1).bit_length()
-        group = self.num_heads // self.num_kv_heads
-        group_p2 = qlen_p2 * max(16 // qlen_p2, 1 << (group - 1).bit_length())
-        gluon_over_limit = (
-            attn_metadata.max_seqlen_q > PA_GLUON_MAX_QUERY_LEN
-            or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
+        gluon_over_limit = gluon_decode_over_limit(
+            attn_metadata.max_seqlen_q, self.num_heads, self.num_kv_heads
         )
         # unified takes one descale for the whole tensor. Running a per-token
         # cache through it is not an error downstream, just wrong numbers.
         if gluon_over_limit and k_scale is not None and k_scale.numel() > 1:
             raise NotImplementedError(
-                f"query length {attn_metadata.max_seqlen_q} / group {group_p2} "
+                f"query length {attn_metadata.max_seqlen_q} "
                 "is past what the gluon decode kernel takes, and the unified "
                 "fallback cannot carry this layer's per-token KV scales"
             )

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -34,12 +34,14 @@ def use_pa_decode_bf16_asm() -> bool:
     )
 
 
-# Largest query group the gluon decode kernel can take: its register-layout
-# table has arms for 16/32/64 only, and past 64 nothing binds `register_bases`
-# -- the failure is a Triton compile error that never mentions speculation.
-# The group is max_seqlen_q * (q_heads / kv_heads), so drafting multiplies it:
-# M3 sits exactly on the limit today (16 x 4 draft positions), and one more
-# draft token would overflow it. vLLM guards the same bound.
+# Two independent limits the gluon decode kernel asserts on
+# (aiter pa_decode_gluon.py): the query length itself, and the query group
+# max_seqlen_q * (q_heads / kv_heads). Drafting multiplies both, so a model can
+# hit either one first -- M3 sits exactly on the group limit today (16 x 4 draft
+# positions) while a gqa=8 model reaches the length limit with the group still
+# at 40. Checked here so the choice of backend accounts for them, rather than
+# reaching the kernel and asserting.
+PA_GLUON_MAX_QUERY_LEN = 4
 PA_GLUON_MAX_QUERY_GROUP_SIZE = 64
 
 
@@ -498,14 +500,23 @@ class PagedAttentionImpl(nn.Module):
 
         num_seqs = attn_metadata.context_lens.shape[0]
 
-        # Group-size term last: k_cache only carries the 5D shuffle layout this
-        # indexing assumes when the gluon path is otherwise the choice.
-        if (
-            envs.ATOM_USE_UNIFIED_ATTN
-            or self.use_flash_layout
-            or attn_metadata.max_seqlen_q * (q.shape[1] // k_cache.shape[1])
+        gluon_over_limit = (
+            attn_metadata.max_seqlen_q > PA_GLUON_MAX_QUERY_LEN
+            or attn_metadata.max_seqlen_q * (self.num_heads // self.num_kv_heads)
             > PA_GLUON_MAX_QUERY_GROUP_SIZE
-        ):
+        )
+        # unified takes one descale for the whole tensor, so a per-token
+        # quantized cache cannot be expressed on this path. Refuse rather than
+        # run: the wrong descale is not an error anywhere downstream, it is just
+        # wrong numbers. The gluon branch below is what handles per-token.
+        if gluon_over_limit and k_scale is not None and k_scale.numel() > 1:
+            raise NotImplementedError(
+                f"query length {attn_metadata.max_seqlen_q} / group "
+                f"{attn_metadata.max_seqlen_q * (self.num_heads // self.num_kv_heads)} "
+                "is past what the gluon decode kernel takes, and the unified "
+                "fallback cannot carry this layer's per-token KV scales"
+            )
+        if envs.ATOM_USE_UNIFIED_ATTN or self.use_flash_layout or gluon_over_limit:
             # print(q.shape, k_cache.shape, v_cache.shape)
             sliding_window = (
                 (self.sliding_window - 1, 0) if self.sliding_window > 0 else (-1, -1)

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -35,12 +35,13 @@ def use_pa_decode_bf16_asm() -> bool:
 
 
 # Two independent limits the gluon decode kernel asserts on
-# (aiter pa_decode_gluon.py): the query length itself, and the query group
-# max_seqlen_q * (q_heads / kv_heads). Drafting multiplies both, so a model can
-# hit either one first -- M3 sits exactly on the group limit today (16 x 4 draft
-# positions) while a gqa=8 model reaches the length limit with the group still
-# at 40. Checked here so the choice of backend accounts for them, rather than
-# reaching the kernel and asserting.
+# (aiter pa_decode_gluon.py): the query length itself, and the query group.
+# Drafting multiplies both, so a model can hit either one first -- M3 sits
+# exactly on the group limit today (16 x 4 draft positions) while a gqa=8 model
+# reaches the length limit with its group still at 40. Both are checked against
+# the pow2 forms the kernel actually indexes its layout table with, not the raw
+# product, so the choice of backend accounts for them rather than reaching the
+# kernel and asserting.
 PA_GLUON_MAX_QUERY_LEN = 4
 PA_GLUON_MAX_QUERY_GROUP_SIZE = 64
 
@@ -89,7 +90,9 @@ class PagedAttentionImpl(nn.Module):
             if self.kv_cache_dtype == "fp8"
             else 1.0
         )
-        self.kv_scale = torch.tensor(self.kv_scale_float, dtype=torch.float32)
+        self.kv_scale = torch.tensor(
+            self.kv_scale_float, dtype=torch.float32, device=self.device
+        )
         # Pre-allocated fp8 dequant scale for the pa_decode_bf16_asm path. Built
         # here (outside CUDAGraph capture) and reused so the kernel wrapper never
         # allocates a tensor mid-capture.
@@ -500,10 +503,16 @@ class PagedAttentionImpl(nn.Module):
 
         num_seqs = attn_metadata.context_lens.shape[0]
 
+        # The kernel sizes its register layout from the pow2 forms, not the
+        # raw product (aiter pa_decode_gluon.py:383-389), and rounds a small
+        # group up to fill 16. Checking the raw product lets qlen=3 with
+        # gqa 17-21 through at 4*32=128, which has no arm in the table.
+        qlen_p2 = 1 << (attn_metadata.max_seqlen_q - 1).bit_length()
+        group = self.num_heads // self.num_kv_heads
+        group_p2 = qlen_p2 * max(16 // qlen_p2, 1 << (group - 1).bit_length())
         gluon_over_limit = (
             attn_metadata.max_seqlen_q > PA_GLUON_MAX_QUERY_LEN
-            or attn_metadata.max_seqlen_q * (self.num_heads // self.num_kv_heads)
-            > PA_GLUON_MAX_QUERY_GROUP_SIZE
+            or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
         )
         # unified takes one descale for the whole tensor, so a per-token
         # quantized cache cannot be expressed on this path. Refuse rather than
@@ -511,8 +520,7 @@ class PagedAttentionImpl(nn.Module):
         # wrong numbers. The gluon branch below is what handles per-token.
         if gluon_over_limit and k_scale is not None and k_scale.numel() > 1:
             raise NotImplementedError(
-                f"query length {attn_metadata.max_seqlen_q} / group "
-                f"{attn_metadata.max_seqlen_q * (self.num_heads // self.num_kv_heads)} "
+                f"query length {attn_metadata.max_seqlen_q} / group {group_p2} "
                 "is past what the gluon decode kernel takes, and the unified "
                 "fallback cannot carry this layer's per-token KV scales"
             )

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -14,7 +14,9 @@ from torch import nn
 
 from atom.config import get_current_atom_config
 from atom.model_ops.base_attention import (
+    PA_ASM_MAX_QUERY_GROUP_SIZE,
     cp_mha_gather_cache,
+    gluon_decode_over_limit,
     run_pa_decode_gluon,
     run_pa_fwd_asm,
 )
@@ -32,29 +34,6 @@ def use_pa_decode_bf16_asm() -> bool:
         and not envs.ATOM_FORCE_ATTN_TRITON
         and get_gfx() == "gfx1250"
     )
-
-
-# Two limits the gluon decode kernel asserts on independently, both multiplied
-# by drafting: M3 sits exactly on the group one today (16 x 4 draft positions),
-# a gqa=8 model reaches the length one first.
-PA_GLUON_MAX_QUERY_LEN = 4
-PA_GLUON_MAX_QUERY_GROUP_SIZE = 64
-# ASM paged attention's own envelope, well inside gluon's.
-PA_ASM_MAX_QUERY_GROUP_SIZE = 16
-
-
-def gluon_decode_over_limit(max_qlen: int, num_heads: int, num_kv_heads: int) -> bool:
-    """Whether decode is past what the gluon kernel takes.
-
-    pow2, not the raw product: that is what the kernel indexes its layout table
-    with, and it rounds a small group up to fill 16.
-    """
-    max_qlen = int(max_qlen)
-    qlen_p2 = 1 << (max_qlen - 1).bit_length()
-    group_p2 = qlen_p2 * max(
-        16 // qlen_p2, 1 << (num_heads // num_kv_heads - 1).bit_length()
-    )
-    return max_qlen > PA_GLUON_MAX_QUERY_LEN or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
 
 
 class PagedAttentionImpl(nn.Module):
@@ -500,124 +479,135 @@ class PagedAttentionImpl(nn.Module):
         x = int(k_cache.shape[-1])
         return v_cache.view(n, nh, block_size // x, head_dim, x)
 
-    @mark_trace(prefix="paged_attention_triton", torch_compile=False)
-    def paged_attention_triton(
+    @mark_trace(prefix="paged_attention_unified", torch_compile=False)
+    def paged_attention_unified(
         self, q, k, v, k_cache, v_cache, k_scale, v_scale, fwd_ctx: ForwardContext
     ):
+        """Decode through unified_attention: the widest envelope, no q-len cap.
 
+        _dispatch_decode sends every shape here that the paged kernels decline,
+        so the per-token check belongs to arriving here rather than to any one
+        of the reasons for it.
+        """
         attn_metadata = fwd_ctx.attn_metadata
+
+        # unified takes a single descale for the whole tensor. Feeding it a
+        # per-token cache is not an error downstream, just wrong numbers.
+        if (k_scale is not None and k_scale.numel() > 1) or (
+            v_scale is not None and v_scale.numel() > 1
+        ):
+            raise NotImplementedError(
+                f"query length {attn_metadata.max_seqlen_q} routes this layer to "
+                "unified_attention, which cannot carry its per-token KV scales"
+            )
 
         if envs.ATOM_USE_UNIFIED_ATTN and self.kv_cache_dtype.startswith("fp8"):
             o = torch.empty(*q.shape, dtype=torch.bfloat16, device=q.device)
         else:
             o = torch.empty_like(q)
 
+        sliding_window = (
+            (self.sliding_window - 1, 0) if self.sliding_window > 0 else (-1, -1)
+        )
+        unified_attention(
+            q,
+            k_cache,
+            v_cache,
+            o,
+            cu_seqlens_q=attn_metadata.cu_seqlens_q,
+            seqused_k=attn_metadata.context_lens,
+            max_seqlen_q=attn_metadata.max_seqlen_q,
+            max_seqlen_k=attn_metadata.max_seqlen_k,
+            softmax_scale=self.scale,
+            causal=True,
+            alibi_slopes=None,
+            window_size=sliding_window,
+            block_table=attn_metadata.block_tables,
+            softcap=0,
+            q_descale=None,
+            k_descale=self.kv_scale,
+            v_descale=self.kv_scale,
+            sinks=self.sinks,
+            shuffled_kv_cache=not self.use_flash_layout,
+        )
+        return o
+
+    @mark_trace(prefix="paged_attention_triton", torch_compile=False)
+    def paged_attention_triton(
+        self, q, k, v, k_cache, v_cache, k_scale, v_scale, fwd_ctx: ForwardContext
+    ):
+        """Decode through the gluon paged kernel. Callers must have cleared
+        gluon_decode_over_limit -- _dispatch_decode is where that happens."""
+
+        attn_metadata = fwd_ctx.attn_metadata
+
+        o = torch.empty_like(q)
+
         num_seqs = attn_metadata.context_lens.shape[0]
 
-        gluon_over_limit = gluon_decode_over_limit(
-            attn_metadata.max_seqlen_q, self.num_heads, self.num_kv_heads
+        _, num_q_heads_total, head_size = q.shape
+        _, num_kv_heads, _, _, _ = k_cache.shape
+        query_group_size = attn_metadata.max_seqlen_q * (
+            num_q_heads_total // num_kv_heads
         )
-        # unified takes one descale for the whole tensor. Running a per-token
-        # cache through it is not an error downstream, just wrong numbers.
-        if gluon_over_limit and k_scale is not None and k_scale.numel() > 1:
-            raise NotImplementedError(
-                f"query length {attn_metadata.max_seqlen_q} "
-                "is past what the gluon decode kernel takes, and the unified "
-                "fallback cannot carry this layer's per-token KV scales"
-            )
-        if envs.ATOM_USE_UNIFIED_ATTN or self.use_flash_layout or gluon_over_limit:
-            # print(q.shape, k_cache.shape, v_cache.shape)
-            sliding_window = (
-                (self.sliding_window - 1, 0) if self.sliding_window > 0 else (-1, -1)
-            )
+        assert num_q_heads_total % num_kv_heads == 0
 
-            shuffled_kv_cache = not self.use_flash_layout
+        max_context_partition_num = get_recommended_splits(num_seqs, num_kv_heads)
 
-            unified_attention(
-                q,
-                k_cache,
-                v_cache,
-                o,
-                cu_seqlens_q=attn_metadata.cu_seqlens_q,
-                seqused_k=attn_metadata.context_lens,
-                max_seqlen_q=attn_metadata.max_seqlen_q,
-                max_seqlen_k=attn_metadata.max_seqlen_k,
-                softmax_scale=self.scale,
-                causal=True,
-                alibi_slopes=None,
-                window_size=sliding_window,
-                block_table=attn_metadata.block_tables,
-                softcap=0,
-                q_descale=None,
-                k_descale=self.kv_scale,
-                v_descale=self.kv_scale,
-                sinks=self.sinks,
-                shuffled_kv_cache=shuffled_kv_cache,
-            )
-        else:
-            _, num_q_heads_total, head_size = q.shape
-            _, num_kv_heads, _, _, _ = k_cache.shape
-            query_group_size = attn_metadata.max_seqlen_q * (
-                num_q_heads_total // num_kv_heads
-            )
-            assert num_q_heads_total % num_kv_heads == 0
+        context_partition_size = 256
+        if self.sliding_window > 0:
+            max_context_partition_num = 1
+            context_partition_size = 128
 
-            max_context_partition_num = get_recommended_splits(num_seqs, num_kv_heads)
+        intermediate_shape = (
+            num_seqs,
+            num_kv_heads,
+            max_context_partition_num,
+            query_group_size,
+        )
+        exp_sums = torch.empty(
+            intermediate_shape, dtype=torch.float32, device=q.device
+        )
+        max_logits = torch.empty(
+            intermediate_shape, dtype=torch.float32, device=q.device
+        )
+        temporary_output = torch.empty(
+            *intermediate_shape,
+            head_size,
+            dtype=q.dtype,
+            device=q.device,
+        )
 
-            context_partition_size = 256
-            if self.sliding_window > 0:
-                max_context_partition_num = 1
-                context_partition_size = 128
+        if k_scale is not None and k_scale.numel() > 1:
+            k_scale = k_scale.unsqueeze(-1)
+            v_scale = v_scale.unsqueeze(-1)
 
-            intermediate_shape = (
-                num_seqs,
-                num_kv_heads,
-                max_context_partition_num,
-                query_group_size,
-            )
-            exp_sums = torch.empty(
-                intermediate_shape, dtype=torch.float32, device=q.device
-            )
-            max_logits = torch.empty(
-                intermediate_shape, dtype=torch.float32, device=q.device
-            )
-            temporary_output = torch.empty(
-                *intermediate_shape,
-                head_size,
-                dtype=q.dtype,
-                device=q.device,
-            )
-
-            if k_scale is not None and k_scale.numel() > 1:
-                k_scale = k_scale.unsqueeze(-1)
-                v_scale = v_scale.unsqueeze(-1)
-
-            compute_type = (
-                torch.bfloat16 if self.kv_cache_dtype == "bf16" else aiter.dtypes.fp8
-            )
-            run_pa_decode_gluon(
-                output=o,
-                q=q,
-                k_cache=k_cache,
-                v_cache=v_cache,
-                context_lens=attn_metadata.context_lens,
-                block_tables=attn_metadata.block_tables,
-                softmax_scale=self.scale,
-                max_seqlen_q=attn_metadata.max_seqlen_q,
-                max_context_partition_num=max_context_partition_num,
-                context_partition_size=context_partition_size,
-                compute_type=compute_type,
-                q_scale=None,
-                k_scale=None if self.kv_cache_dtype == "bf16" else k_scale,
-                v_scale=None if self.kv_cache_dtype == "bf16" else v_scale,
-                exp_sums=exp_sums,
-                max_logits=max_logits,
-                temporary_output=temporary_output,
-                alibi_slopes=None,
-                sinks=self.sinks,
-                sliding_window=self.sliding_window,
-                ps=True,
-            )
+        compute_type = (
+            torch.bfloat16 if self.kv_cache_dtype == "bf16" else aiter.dtypes.fp8
+        )
+        run_pa_decode_gluon(
+            output=o,
+            q=q,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            context_lens=attn_metadata.context_lens,
+            block_tables=attn_metadata.block_tables,
+            softmax_scale=self.scale,
+            max_seqlen_q=attn_metadata.max_seqlen_q,
+            max_context_partition_num=max_context_partition_num,
+            context_partition_size=context_partition_size,
+            compute_type=compute_type,
+            q_scale=None,
+            k_scale=None if self.kv_cache_dtype == "bf16" else k_scale,
+            v_scale=None if self.kv_cache_dtype == "bf16" else v_scale,
+            exp_sums=exp_sums,
+            max_logits=max_logits,
+            temporary_output=temporary_output,
+            alibi_slopes=None,
+            sinks=self.sinks,
+            sliding_window=self.sliding_window,
+            ps=True,
+        )
 
         return o
 
@@ -885,25 +875,48 @@ class PagedAttentionImpl(nn.Module):
 
         return o
 
-    def _dispatch_decode(self):
+    def _dispatch_decode(self, max_qlen: int = 1):
+        """The single place that answers which decode kernel runs.
+
+        The runners do not re-decide; the vLLM bridge mirrors this order. Both
+        paged kernels stop short of unified, at different points, and drafting
+        multiplies the query group into both limits. ASM is the one that must be
+        checked here rather than inside its runner: past its envelope
+        get_heuristic_kernel silently re-runs with mtp=1, a kernel built for
+        another query length, and computes a wrong answer instead of refusing.
+        """
+        over_gluon = gluon_decode_over_limit(max_qlen, self.num_heads, self.num_kv_heads)
+        over_asm = (
+            int(max_qlen) * (self.num_heads // self.num_kv_heads)
+            > PA_ASM_MAX_QUERY_GROUP_SIZE
+        )
+
         # Sliding-window layers must use triton (ASM paths don't support it)
         if self.sliding_window != -1:
-            return self.paged_attention_triton
+            return (
+                self.paged_attention_unified
+                if over_gluon
+                else self.paged_attention_triton
+            )
 
         atom_config = get_current_atom_config()
 
         if envs.ATOM_USE_UNIFIED_ATTN:
             if envs.ATOM_FORCE_ATTN_TRITON:
-                return self.paged_attention_triton
-            if atom_config.kv_cache_block_size == 256:
+                return self.paged_attention_unified
+            if atom_config.kv_cache_block_size == 256 and not over_asm:
                 return self.paged_attention_persistent_asm
+            return self.paged_attention_unified
+
+        if self.use_flash_layout or over_gluon:
+            return self.paged_attention_unified
+        if self.use_triton_attn:
             return self.paged_attention_triton
 
-        if self.use_triton_attn or self.use_flash_layout:
-            return self.paged_attention_triton
-
-        if use_pa_decode_bf16_asm():
+        if use_pa_decode_bf16_asm() and not over_asm:
             return self.paged_attention_persistent_asm
+        if over_asm:
+            return self.paged_attention_triton
         return self.paged_attention_asm
 
     def dispatch_backend(
@@ -922,7 +935,9 @@ class PagedAttentionImpl(nn.Module):
             if envs.ATOM_USE_UNIFIED_ATTN or self.use_flash_layout:
                 return self.prefill_attention_triton
             return self.prefill_attention
-        return self._dispatch_decode()
+        attn_metadata = fwd_ctx.attn_metadata
+        max_qlen = 1 if attn_metadata is None else attn_metadata.max_seqlen_q
+        return self._dispatch_decode(max_qlen)
 
     def forward(
         self,

--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -34,14 +34,9 @@ def use_pa_decode_bf16_asm() -> bool:
     )
 
 
-# Two independent limits the gluon decode kernel asserts on
-# (aiter pa_decode_gluon.py): the query length itself, and the query group.
-# Drafting multiplies both, so a model can hit either one first -- M3 sits
-# exactly on the group limit today (16 x 4 draft positions) while a gqa=8 model
-# reaches the length limit with its group still at 40. Both are checked against
-# the pow2 forms the kernel actually indexes its layout table with, not the raw
-# product, so the choice of backend accounts for them rather than reaching the
-# kernel and asserting.
+# Two limits the gluon decode kernel asserts on independently, both multiplied
+# by drafting: M3 sits exactly on the group one today (16 x 4 draft positions),
+# a gqa=8 model reaches the length one first.
 PA_GLUON_MAX_QUERY_LEN = 4
 PA_GLUON_MAX_QUERY_GROUP_SIZE = 64
 
@@ -503,10 +498,8 @@ class PagedAttentionImpl(nn.Module):
 
         num_seqs = attn_metadata.context_lens.shape[0]
 
-        # The kernel sizes its register layout from the pow2 forms, not the
-        # raw product (aiter pa_decode_gluon.py:383-389), and rounds a small
-        # group up to fill 16. Checking the raw product lets qlen=3 with
-        # gqa 17-21 through at 4*32=128, which has no arm in the table.
+        # pow2, not the raw product: that is what the kernel indexes its
+        # layout table with, and it rounds a small group up to fill 16.
         qlen_p2 = 1 << (attn_metadata.max_seqlen_q - 1).bit_length()
         group = self.num_heads // self.num_kv_heads
         group_p2 = qlen_p2 * max(16 // qlen_p2, 1 << (group - 1).bit_length())
@@ -514,10 +507,8 @@ class PagedAttentionImpl(nn.Module):
             attn_metadata.max_seqlen_q > PA_GLUON_MAX_QUERY_LEN
             or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
         )
-        # unified takes one descale for the whole tensor, so a per-token
-        # quantized cache cannot be expressed on this path. Refuse rather than
-        # run: the wrong descale is not an error anywhere downstream, it is just
-        # wrong numbers. The gluon branch below is what handles per-token.
+        # unified takes one descale for the whole tensor. Running a per-token
+        # cache through it is not an error downstream, just wrong numbers.
         if gluon_over_limit and k_scale is not None and k_scale.numel() > 1:
             raise NotImplementedError(
                 f"query length {attn_metadata.max_seqlen_q} / group {group_p2} "

--- a/atom/model_ops/base_attention.py
+++ b/atom/model_ops/base_attention.py
@@ -40,6 +40,30 @@ class Attention:
         return AttentionForAtom(*args, **kwargs)
 
 
+# Envelopes of the two paged decode kernels wrapped below. Both are multiplied
+# by drafting: MiniMax-M3 sits exactly on the gluon group one today (16 x 4 draft
+# positions), a gqa=8 model reaches the gluon length one first, and ASM tops out
+# lower than either -- past its limit get_heuristic_kernel silently re-runs with
+# mtp=1, a kernel built for another query length.
+PA_GLUON_MAX_QUERY_LEN = 4
+PA_GLUON_MAX_QUERY_GROUP_SIZE = 64
+PA_ASM_MAX_QUERY_GROUP_SIZE = 16
+
+
+def gluon_decode_over_limit(max_qlen: int, num_heads: int, num_kv_heads: int) -> bool:
+    """Whether decode is past what the gluon kernel takes.
+
+    pow2, not the raw product: that is what the kernel indexes its layout table
+    with, and it rounds a small group up to fill 16.
+    """
+    max_qlen = max(1, int(max_qlen))
+    qlen_p2 = 1 << (max_qlen - 1).bit_length()
+    group_p2 = qlen_p2 * max(
+        16 // qlen_p2, 1 << (num_heads // num_kv_heads - 1).bit_length()
+    )
+    return max_qlen > PA_GLUON_MAX_QUERY_LEN or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
+
+
 def run_pa_fwd_asm(
     q: torch.Tensor,
     k_cache: torch.Tensor,

--- a/atom/model_ops/minimax_m3/index_topk.py
+++ b/atom/model_ops/minimax_m3/index_topk.py
@@ -47,12 +47,14 @@ SCORE_CHUNK_CTAS_PER_CU = 8
 # short-context rows, which is not where a step spends its time.
 SCORE_NUM_STAGES = 3
 DECODE_SCORE_NUM_STAGES = 3
-# Bounds on the decode score split (_decode_score_chunks). MIN_BLOCKS is the
-# only one that binds; the other two are kept as escape hatches. A flat chunk
-# ceiling cannot work -- the best count depends on the context length, while
-# the best blocks per chunk is 2-4 across 32K/131K/315K.
-DECODE_SCORE_TARGET_GRID = 1 << 20
-DECODE_SCORE_MAX_CHUNKS = 1 << 16
+# Bounds on the decode score split, one per end of the batch range. MIN_BLOCKS
+# floors the blocks a chunk walks -- the query tile is loaded once outside the
+# block loop, so at one block per chunk that fixed cost is the whole cost.
+# TARGET_GRID caps total workgroups, which MIN_BLOCKS alone cannot: it ignores
+# batch, so the grid grows without limit (275 us at batch 128 vs 202 capped).
+# Both are fits, not derivations -- the best (batch x chunks) runs 8k-44k over
+# batch 16-128, and 1<<14 stays within 5% of the per-batch optimum there.
+DECODE_SCORE_TARGET_GRID = 1 << 14
 DECODE_SCORE_MIN_BLOCKS = 3
 # Physical 16-pages per logical 128-block for the page-16 SHUFFLE ASM/gluon cache
 # (must match sparse_attn.PAGES_PER_SPARSE_BLOCK). Used by the fused block-table
@@ -395,7 +397,8 @@ def _decode_score_chunks(batch: int, max_block: int) -> int:
     A count, not a size: the grid is (request, chunk), so this IS the second
     grid dim and it must stay shape-constant for a cuda graph to replay it.
     Enough chunks that a long context is not serialized inside a handful of
-    CTAs, capped so a large batch does not multiply into a pointless grid.
+    CTAs, floored so no chunk shrinks to a single block -- DECODE_SCORE_MIN_BLOCKS
+    is what bounds the split, and TARGET_GRID still caps the largest batches.
 
     The round trip through the size is not redundant. The caller turns this
     count back into a size with the same cdiv, and a count that does not divide
@@ -405,9 +408,7 @@ def _decode_score_chunks(batch: int, max_block: int) -> int:
     chunk non-empty, and both are still pure functions of launch-time bounds,
     so a cuda graph replays the grid it captured.
     """
-    target = max(
-        1, min(DECODE_SCORE_MAX_CHUNKS, DECODE_SCORE_TARGET_GRID // max(1, batch))
-    )
+    target = max(1, DECODE_SCORE_TARGET_GRID // max(1, batch))
     if max_block <= 0:
         # A grid dim still has to be positive. Capping `chunks` is not enough:
         # the round trip below divides by its own inner `cdiv`, zero here, and

--- a/atom/model_ops/minimax_m3/index_topk.py
+++ b/atom/model_ops/minimax_m3/index_topk.py
@@ -47,10 +47,13 @@ SCORE_CHUNK_CTAS_PER_CU = 8
 # short-context rows, which is not where a step spends its time.
 SCORE_NUM_STAGES = 3
 DECODE_SCORE_NUM_STAGES = 3
-# Grid the tiled decode score aims for, and the per-request chunk ceiling that
-# keeps a large batch from multiplying into a pointless one (_decode_score_chunks).
-DECODE_SCORE_TARGET_GRID = 2048
-DECODE_SCORE_MAX_CHUNKS = 64
+# Bounds on the decode score split (_decode_score_chunks). MIN_BLOCKS is the
+# only one that binds; the other two are kept as escape hatches. A flat chunk
+# ceiling cannot work -- the best count depends on the context length, while
+# the best blocks per chunk is 2-4 across 32K/131K/315K.
+DECODE_SCORE_TARGET_GRID = 1 << 20
+DECODE_SCORE_MAX_CHUNKS = 1 << 16
+DECODE_SCORE_MIN_BLOCKS = 3
 # Physical 16-pages per logical 128-block for the page-16 SHUFFLE ASM/gluon cache
 # (must match sparse_attn.PAGES_PER_SPARSE_BLOCK). Used by the fused block-table
 # emission in the topk kernels.
@@ -412,6 +415,10 @@ def _decode_score_chunks(batch: int, max_block: int) -> int:
         # wait in the collective that follows.
         return 1
     chunks = min(1 << (target.bit_length() - 1), max_block)
+    # Floor the blocks one chunk walks. The query tile is loaded once outside
+    # the block loop, so at one block per chunk that fixed cost is the whole
+    # cost -- every measured regression was a chunk down to a single block.
+    chunks = min(chunks, max(1, triton.cdiv(max_block, DECODE_SCORE_MIN_BLOCKS)))
     return triton.cdiv(max_block, triton.cdiv(max_block, chunks))
 
 

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -10,8 +10,8 @@ from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 
 from atom.config import get_current_atom_config
 from atom.model_ops.attention_mha import (
-    PA_GLUON_MAX_QUERY_GROUP_SIZE,
-    PA_GLUON_MAX_QUERY_LEN,
+    PA_ASM_MAX_QUERY_GROUP_SIZE,
+    gluon_decode_over_limit,
 )
 from atom.model_ops.attention_mla import MLAModules
 from atom.model_ops.base_attention import (
@@ -725,29 +725,25 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
 
     def _dispatch_decode_backend(self, num_decodes, max_qlen):
         # No fallback exists here: this bridge has no unified branch, and ASM
-        # tops out lower still (qlen * gqa <= 16), where an unmatched mtp picks
-        # a kernel built for another qlen and computes instead of asserting.
-        qlen_p2 = 1 << (max_qlen - 1).bit_length()
-        group = self.num_heads // self.num_kv_heads
-        group_p2 = qlen_p2 * max(16 // qlen_p2, 1 << (group - 1).bit_length())
-        if (
-            max_qlen > PA_GLUON_MAX_QUERY_LEN
-            or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
-        ):
+        # tops out lower still, where an unmatched mtp picks a kernel built for
+        # another qlen and computes instead of asserting.
+        if gluon_decode_over_limit(max_qlen, self.num_heads, self.num_kv_heads):
             raise NotImplementedError(
-                f"query length {max_qlen} / group {group_p2} is past the "
-                "gluon decode kernel, and this bridge has no fallback that "
-                "takes it"
+                f"query length {max_qlen} is past the gluon decode kernel, and "
+                "this bridge has no fallback that takes it"
             )
-        # use asm pa for models without setting gluon pa decode bs
         gluon_pa_decode_bs = _GLUON_PA_DECODE_BS_MAPPING.get(self.model_type, -1)
         if self.use_triton_attn:
             return self.paged_attention_triton
-        else:
-            if ATOM_USE_GLUON_PA_DECODE and num_decodes <= gluon_pa_decode_bs:
-                return self.paged_attention_triton
-            else:
-                return self.paged_attention_asm
+        if ATOM_USE_GLUON_PA_DECODE and num_decodes <= gluon_pa_decode_bs:
+            return self.paged_attention_triton
+        # Past ASM's envelope prefer the wider kernel: ASM would silently fall
+        # back to one built for a different qlen rather than refuse.
+        if int(max_qlen) * (self.num_heads // self.num_kv_heads) > (
+            PA_ASM_MAX_QUERY_GROUP_SIZE
+        ):
+            return self.paged_attention_triton
+        return self.paged_attention_asm
 
     def forward_impl(
         self,

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -724,12 +724,9 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
         )
 
     def _dispatch_decode_backend(self, num_decodes, max_qlen):
-        # Past the gluon decode kernel's limits there is nowhere to go on this
-        # bridge: it has no unified branch (the server-side impl does), and the
-        # ASM path tops out lower still at qlen * gqa <= 16 (asm_pa.cu:113) --
-        # M3 already fails to start on it at 64. Worse, ASM does not always
-        # assert: an unmatched mtp falls back to a kernel compiled for a
-        # different qlen and computes. Refuse here instead.
+        # No fallback exists here: this bridge has no unified branch, and ASM
+        # tops out lower still (qlen * gqa <= 16), where an unmatched mtp picks
+        # a kernel built for another qlen and computes instead of asserting.
         qlen_p2 = 1 << (max_qlen - 1).bit_length()
         group = self.num_heads // self.num_kv_heads
         group_p2 = qlen_p2 * max(16 // qlen_p2, 1 << (group - 1).bit_length())

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -739,9 +739,8 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
             return self.paged_attention_triton
         # Past ASM's envelope prefer the wider kernel: ASM would silently fall
         # back to one built for a different qlen rather than refuse.
-        if int(max_qlen) * (self.num_heads // self.num_kv_heads) > (
-            PA_ASM_MAX_QUERY_GROUP_SIZE
-        ):
+        asm_group = int(max_qlen) * (self.num_heads // self.num_kv_heads)
+        if asm_group > PA_ASM_MAX_QUERY_GROUP_SIZE:
             return self.paged_attention_triton
         return self.paged_attention_asm
 

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -8,11 +8,11 @@ from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
 from torch import nn
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 
+from atom.config import get_current_atom_config
 from atom.model_ops.attention_mha import (
     PA_GLUON_MAX_QUERY_GROUP_SIZE,
     PA_GLUON_MAX_QUERY_LEN,
 )
-from atom.config import get_current_atom_config
 from atom.model_ops.attention_mla import MLAModules
 from atom.model_ops.base_attention import (
     cp_mha_gather_cache,

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -8,6 +8,10 @@ from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
 from torch import nn
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 
+from atom.model_ops.attention_mha import (
+    PA_GLUON_MAX_QUERY_GROUP_SIZE,
+    PA_GLUON_MAX_QUERY_LEN,
+)
 from atom.config import get_current_atom_config
 from atom.model_ops.attention_mla import MLAModules
 from atom.model_ops.base_attention import (
@@ -719,7 +723,18 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
             suffix_lse=lse,
         )
 
-    def _dispatch_decode_backend(self, num_decodes):
+    def _dispatch_decode_backend(self, num_decodes, max_qlen=1):
+        # The gluon decode kernel asserts on two independent limits (aiter
+        # pa_decode_gluon.py): the query length, and the query group
+        # max_qlen * (q_heads / kv_heads). Drafting multiplies both, and a model
+        # can hit either first. Route to asm instead of reaching the assert --
+        # this mirrors the same check in model_ops/attention_mha.py.
+        if (
+            max_qlen > PA_GLUON_MAX_QUERY_LEN
+            or max_qlen * (self.num_heads // self.num_kv_heads)
+            > PA_GLUON_MAX_QUERY_GROUP_SIZE
+        ):
+            return self.paged_attention_asm
         # use asm pa for models without setting gluon pa decode bs
         gluon_pa_decode_bs = _GLUON_PA_DECODE_BS_MAPPING.get(self.model_type, -1)
         if self.use_triton_attn:
@@ -915,7 +930,9 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
         if num_decodes > 0:
             assert attn_metadata.decode_metadata is not None
 
-            decode_backend_func = self._dispatch_decode_backend(num_decodes)
+            decode_backend_func = self._dispatch_decode_backend(
+                num_decodes, attn_metadata.decode_metadata.max_query_len
+            )
             decode_backend_func(
                 q=query[:num_decode_tokens],
                 k_cache=new_key_cache,

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -723,18 +723,25 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
             suffix_lse=lse,
         )
 
-    def _dispatch_decode_backend(self, num_decodes, max_qlen=1):
-        # The gluon decode kernel asserts on two independent limits (aiter
-        # pa_decode_gluon.py): the query length, and the query group
-        # max_qlen * (q_heads / kv_heads). Drafting multiplies both, and a model
-        # can hit either first. Route to asm instead of reaching the assert --
-        # this mirrors the same check in model_ops/attention_mha.py.
+    def _dispatch_decode_backend(self, num_decodes, max_qlen):
+        # Past the gluon decode kernel's limits there is nowhere to go on this
+        # bridge: it has no unified branch (the server-side impl does), and the
+        # ASM path tops out lower still at qlen * gqa <= 16 (asm_pa.cu:113) --
+        # M3 already fails to start on it at 64. Worse, ASM does not always
+        # assert: an unmatched mtp falls back to a kernel compiled for a
+        # different qlen and computes. Refuse here instead.
+        qlen_p2 = 1 << (max_qlen - 1).bit_length()
+        group = self.num_heads // self.num_kv_heads
+        group_p2 = qlen_p2 * max(16 // qlen_p2, 1 << (group - 1).bit_length())
         if (
             max_qlen > PA_GLUON_MAX_QUERY_LEN
-            or max_qlen * (self.num_heads // self.num_kv_heads)
-            > PA_GLUON_MAX_QUERY_GROUP_SIZE
+            or group_p2 > PA_GLUON_MAX_QUERY_GROUP_SIZE
         ):
-            return self.paged_attention_asm
+            raise NotImplementedError(
+                f"query length {max_qlen} / group {group_p2} is past the "
+                "gluon decode kernel, and this bridge has no fallback that "
+                "takes it"
+            )
         # use asm pa for models without setting gluon pa decode bs
         gluon_pa_decode_bs = _GLUON_PA_DECODE_BS_MAPPING.get(self.model_type, -1)
         if self.use_triton_attn:

--- a/atom/plugin/vllm/attention/layer_mha.py
+++ b/atom/plugin/vllm/attention/layer_mha.py
@@ -9,13 +9,11 @@ from torch import nn
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 
 from atom.config import get_current_atom_config
-from atom.model_ops.attention_mha import (
-    PA_ASM_MAX_QUERY_GROUP_SIZE,
-    gluon_decode_over_limit,
-)
 from atom.model_ops.attention_mla import MLAModules
 from atom.model_ops.base_attention import (
+    PA_ASM_MAX_QUERY_GROUP_SIZE,
     cp_mha_gather_cache,
+    gluon_decode_over_limit,
     run_pa_decode_gluon,
     run_pa_fwd_asm,
 )
@@ -146,7 +144,11 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
             if cache_dtype == "fp8"
             else 1.0
         )
-        self.kv_scale = torch.tensor(self.kv_scale_float, dtype=torch.float32)
+        # On device: this is aliased into self.per_tensor_scale and reaches
+        # fused_qk_rope_reshape_and_cache, which dereferences it in the kernel.
+        self.kv_scale = torch.tensor(
+            self.kv_scale_float, dtype=torch.float32, device=self.device
+        )
         self.per_token_quant = True
         self.sinks = sinks
         self.sliding_window = (
@@ -424,8 +426,11 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
         # the max_qlen multiplier — mirroring server-mode `paged_attention_triton`.
         _, num_q_heads_total, head_size = q.shape
         _, num_kv_heads, _, _, _ = k_cache.shape
+        # Only reached through _dispatch_decode_backend, which asserts
+        # decode_metadata is present and reads the same field to pick this
+        # function -- so no default, and one read per step rather than two.
         decode_metadata = attn_metadata.decode_metadata
-        max_qlen = decode_metadata.max_query_len if decode_metadata is not None else 1
+        max_qlen = decode_metadata.max_query_len
         assert num_q_heads_total % num_kv_heads == 0
 
         seq_lens = attn_metadata.seq_lens[:num_decodes]
@@ -512,11 +517,11 @@ class AttentionForVllmMHA(nn.Module, AttentionLayerBase):
         attn_metadata: "AiterMhaMetadataForVllm",
         out: torch.Tensor,
     ):
+        # Same as paged_attention_triton: only reached through the decode
+        # dispatcher, which has already asserted decode_metadata is present.
         decode_metadata = attn_metadata.decode_metadata
-        max_qlen = decode_metadata.max_query_len if decode_metadata is not None else 1
-        qo_indptr = (
-            decode_metadata.query_start_loc if decode_metadata is not None else None
-        )
+        max_qlen = decode_metadata.max_query_len
+        qo_indptr = decode_metadata.query_start_loc
         run_pa_fwd_asm(
             q=q,
             k_cache=k_cache,

--- a/docs/model_ops_guide.md
+++ b/docs/model_ops_guide.md
@@ -146,11 +146,24 @@ The MHA `Attention` class handles standard models (Llama, Qwen3, Mixtral, etc.).
 | Phase | Condition | Method | AITER Kernel |
 |---|---|---|---|
 | Prefill | Always | `prefill_attention` | `aiter.flash_attn_varlen_func` |
+| Decode | `ATOM_USE_UNIFIED_ATTN` and `block_size == 256` | `paged_attention_persistent_asm` | `aiter.pa_persistent_fwd` |
+| Decode | past a paged kernel's envelope, or `ATOM_USE_UNIFIED_ATTN` / `use_flash_layout` | `paged_attention_unified` | `aiter.ops.triton.unified_attention` |
 | Decode | `use_triton_attn=True` | `paged_attention_triton` | `torch.ops.aiter.pa_decode_gluon` |
-| Decode | `block_size == 1024` | `paged_attention_persistent_asm` | `aiter.pa_persistent_fwd` |
 | Decode | Default | `paged_attention_asm` | `aiter.pa_fwd_asm` |
 
 The `use_triton_attn` flag is set when `sliding_window != -1` or `head_dim != 128`.
+
+Both paged kernels stop short of unified, at different points, and drafting
+multiplies the query group into both limits (`base_attention.py`):
+
+| Kernel | Envelope | Past it |
+|---|---|---|
+| gluon | `query_length <= 4` and `next_pow2(qlen) * max(16 // next_pow2(qlen), next_pow2(ratio)) <= 64`, where `ratio = q_heads / kv_heads` | no layout arm; Triton fails to compile |
+| `pa_fwd_asm` | `qlen x q_heads/kv_heads <= 16` | `get_heuristic_kernel` silently re-runs with `mtp=1` |
+
+`_dispatch_decode` is the single place that answers this; the runners do not
+re-decide. Unified carries one descale for the whole tensor, so a per-token
+quantized layer routed there raises rather than returning wrong numbers.
 
 ### Multi-head latent attention (`attention_mla.py`)
 

--- a/tests/test_minimax_m3_index_topk.py
+++ b/tests/test_minimax_m3_index_topk.py
@@ -23,6 +23,7 @@ pytest.importorskip("triton", reason="index_topk defines @triton.jit kernels")
 
 from atom.model_ops.minimax_m3.index_topk import (
     DECODE_SCORE_MAX_CHUNKS,
+    DECODE_SCORE_MIN_BLOCKS,
     DECODE_SCORE_TARGET_GRID,
     PREFILL_TOPK_MAX_BLOCK_SIZE_K,
     PREFILL_TOPK_MIN_BLOCK_SIZE_K,
@@ -77,7 +78,9 @@ class TestDecodeScoreChunks:
         # block and that none of them is empty by construction.
         n = _decode_score_chunks(batch, max_block)
         assert 1 <= n <= max_block
-        assert n <= DECODE_SCORE_MAX_CHUNKS
+        # MIN_BLOCKS is what bounds the count now; MAX_CHUNKS sits above
+        # `_require_packable`'s ceiling and can no longer bind.
+        assert n <= max(1, -(-max_block // DECODE_SCORE_MIN_BLOCKS))
         chunk_blocks = -(-max_block // n)
         assert chunk_blocks * n >= max_block
         assert chunk_blocks * (n - 1) < max_block
@@ -91,8 +94,8 @@ class TestDecodeScoreChunks:
         assert _decode_score_chunks(batch, 0) == 1
 
     def test_shrinks_with_batch(self):
-        # The cap exists so a large batch does not multiply into a pointless
-        # grid; monotonicity is what makes that statement true.
+        # A larger batch must not buy more chunks per request: the grid is
+        # (request, chunk), so that would multiply into a pointless grid.
         prev = _decode_score_chunks(1, 4096)
         for batch in (2, 4, 16, 64, 256, 4096):
             cur = _decode_score_chunks(batch, 4096)
@@ -100,10 +103,26 @@ class TestDecodeScoreChunks:
             prev = cur
 
     def test_grid_stays_near_the_target(self):
-        # (request, chunk) is the grid, so batch * chunks is what it sizes.
+        # KNOWN GAP: TARGET_GRID is raised out of the way, so it only binds at
+        # batch > 3 * TARGET_GRID / max_block. What still holds at every batch
+        # is the per-request count, which MIN_BLOCKS caps.
         for batch in (1, 8, 50, 64):
-            grid = batch * _decode_score_chunks(batch, 4096)
-            assert grid <= DECODE_SCORE_TARGET_GRID * 2
+            assert _decode_score_chunks(batch, 4096) <= -(-4096 // DECODE_SCORE_MIN_BLOCKS)
+
+    @pytest.mark.parametrize("max_block", [3, 64, 800, 2464, 8192, 65534])
+    @pytest.mark.parametrize("batch", [1, 8, 64])
+    def test_a_chunk_walks_at_least_min_blocks(self, batch, max_block):
+        """The floor is the whole point of the split rule: a chunk down to one
+        block pays the query-tile load, which sits outside the block loop, for
+        a single block of work. Deleting the clamp must turn this red."""
+        n = _decode_score_chunks(batch, max_block)
+        assert -(-max_block // n) >= DECODE_SCORE_MIN_BLOCKS
+
+    def test_the_floor_is_a_target_not_a_guarantee(self):
+        # Below MIN_BLOCKS worth of work there is nothing to floor: one chunk
+        # is already the whole row.
+        for max_block in (1, 2):
+            assert _decode_score_chunks(1, max_block) == 1
 
 
 class TestPackableBound:

--- a/tests/test_minimax_m3_index_topk.py
+++ b/tests/test_minimax_m3_index_topk.py
@@ -22,9 +22,7 @@ import torch
 pytest.importorskip("triton", reason="index_topk defines @triton.jit kernels")
 
 from atom.model_ops.minimax_m3.index_topk import (
-    DECODE_SCORE_MAX_CHUNKS,
     DECODE_SCORE_MIN_BLOCKS,
-    DECODE_SCORE_TARGET_GRID,
     PREFILL_TOPK_MAX_BLOCK_SIZE_K,
     PREFILL_TOPK_MIN_BLOCK_SIZE_K,
     SPARSE_BLOCK_SIZE,
@@ -102,14 +100,7 @@ class TestDecodeScoreChunks:
             assert cur <= prev
             prev = cur
 
-    def test_grid_stays_near_the_target(self):
-        # KNOWN GAP: TARGET_GRID is raised out of the way, so it only binds at
-        # batch > 3 * TARGET_GRID / max_block. What still holds at every batch
-        # is the per-request count, which MIN_BLOCKS caps.
-        for batch in (1, 8, 50, 64):
-            assert _decode_score_chunks(batch, 4096) <= -(-4096 // DECODE_SCORE_MIN_BLOCKS)
-
-    @pytest.mark.parametrize("max_block", [3, 64, 800, 2464, 8192, 65534])
+    @pytest.mark.parametrize("max_block", [3, 5, 64, 800, 2464, 8192, 65534])
     @pytest.mark.parametrize("batch", [1, 8, 64])
     def test_a_chunk_walks_at_least_min_blocks(self, batch, max_block):
         """The floor is the whole point of the split rule: a chunk down to one
@@ -118,11 +109,14 @@ class TestDecodeScoreChunks:
         n = _decode_score_chunks(batch, max_block)
         assert -(-max_block // n) >= DECODE_SCORE_MIN_BLOCKS
 
-    def test_the_floor_is_a_target_not_a_guarantee(self):
-        # Below MIN_BLOCKS worth of work there is nothing to floor: one chunk
-        # is already the whole row.
-        for max_block in (1, 2):
-            assert _decode_score_chunks(1, max_block) == 1
+    @pytest.mark.parametrize("max_block,want_chunks", [(1, 1), (2, 1), (4, 2)])
+    def test_the_floor_is_a_target_not_a_guarantee(self, max_block, want_chunks):
+        """Right above MIN_BLOCKS the floor cannot hand out a second full
+        chunk: max_block=4 splits into 2 chunks of 2, under the floor. Nothing
+        is wrong with that -- 2 blocks still amortize the query tile -- but the
+        floor is a target, so `test_a_chunk_walks_at_least_min_blocks` skips
+        this range rather than asserting something untrue about it."""
+        assert _decode_score_chunks(1, max_block) == want_chunks
 
 
 class TestPackableBound:

--- a/tests/test_minimax_m3_index_topk.py
+++ b/tests/test_minimax_m3_index_topk.py
@@ -23,6 +23,7 @@ pytest.importorskip("triton", reason="index_topk defines @triton.jit kernels")
 
 from atom.model_ops.minimax_m3.index_topk import (
     DECODE_SCORE_MIN_BLOCKS,
+    DECODE_SCORE_TARGET_GRID,
     PREFILL_TOPK_MAX_BLOCK_SIZE_K,
     PREFILL_TOPK_MIN_BLOCK_SIZE_K,
     SPARSE_BLOCK_SIZE,
@@ -76,12 +77,22 @@ class TestDecodeScoreChunks:
         # block and that none of them is empty by construction.
         n = _decode_score_chunks(batch, max_block)
         assert 1 <= n <= max_block
-        # MIN_BLOCKS is what bounds the count now; MAX_CHUNKS sits above
-        # `_require_packable`'s ceiling and can no longer bind.
+        # Two bounds, one per end of the batch range.
         assert n <= max(1, -(-max_block // DECODE_SCORE_MIN_BLOCKS))
+        assert batch * n <= max(DECODE_SCORE_TARGET_GRID, batch)
         chunk_blocks = -(-max_block // n)
         assert chunk_blocks * n >= max_block
         assert chunk_blocks * (n - 1) < max_block
+
+    def test_the_ceiling_binds_at_high_batch(self):
+        """The floor alone would return the same count at every batch.
+
+        Asserted against a literal rather than DECODE_SCORE_TARGET_GRID: a bound
+        read from the constant moves with it, so raising the constant back out
+        of range would satisfy the assertion instead of failing it.
+        """
+        assert _decode_score_chunks(8, 8192) > _decode_score_chunks(128, 8192)
+        assert _decode_score_chunks(128, 8192) * 128 <= 16384
 
     @pytest.mark.parametrize("batch", [1, 64])
     def test_an_empty_bound_still_gives_a_grid(self, batch):

--- a/tests/test_paged_attention_dispatch.py
+++ b/tests/test_paged_attention_dispatch.py
@@ -199,9 +199,7 @@ class TestDecodeRouting:
         )
 
     def test_sliding_window_without_the_env_uses_gluon(self, monkeypatch):
-        assert (
-            _route(monkeypatch, 4, sliding_window=128) == "paged_attention_triton"
-        )
+        assert _route(monkeypatch, 4, sliding_window=128) == "paged_attention_triton"
 
     def test_flash_layout_routes_to_unified(self, monkeypatch):
         assert (
@@ -218,9 +216,7 @@ class TestDecodeRouting:
     def test_use_triton_attn_diverts_off_asm(self, monkeypatch):
         """Same shape reaches ASM without the flag, so this arm is load-bearing."""
         assert _route(monkeypatch, 1) == "paged_attention_asm"
-        assert (
-            _route(monkeypatch, 1, use_triton_attn=True) == "paged_attention_triton"
-        )
+        assert _route(monkeypatch, 1, use_triton_attn=True) == "paged_attention_triton"
 
     def test_a_sentinel_query_length_routes_as_one(self, monkeypatch):
         """Clamped at the top, so both gates see the same value.

--- a/tests/test_paged_attention_dispatch.py
+++ b/tests/test_paged_attention_dispatch.py
@@ -17,6 +17,8 @@ bound -- a Triton compile error with nothing in it about speculative length.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 pytest.importorskip("triton", reason="base_attention defines @triton.jit kernels")
@@ -48,7 +50,7 @@ class TestGluonEnvelope:
                 False,
                 "M3 dense at tp4 with 3 draft tokens: 16*4=64, on the limit",
             ),
-            (5, 16, 1, True, "one more draft token: 80 rounds to 128, off the table"),
+            (5, 16, 1, True, "one more draft token: past both limits at once"),
             (4, 32, 2, False, "M3 dense at tp2 -- ratio is still 16"),
             (
                 5,
@@ -76,13 +78,12 @@ class TestGluonEnvelope:
         assert 3 * (17 // 1) <= PA_GLUON_MAX_QUERY_GROUP_SIZE
         assert gluon_decode_over_limit(3, 17, 1) is True
 
-    @pytest.mark.parametrize("max_qlen", [0, -1, -100])
+    # 0 and -1 pass with or without the clamp -- they are boundary shapes, not
+    # evidence. -5 and -100 are: unclamped their bit_length alone synthesises a
+    # 128- and 2048-wide group out of what is really one position.
+    @pytest.mark.parametrize("max_qlen", [0, -1, -5, -100])
     def test_non_positive_query_length_is_clamped(self, max_qlen):
-        """A sentinel or unset length must not synthesise a large group.
-
-        Without the clamp `(-100).bit_length()` alone yields a 128-wide query
-        tile and the call reports over-limit for what is really one position.
-        """
+        """A sentinel or unset length must not synthesise a large group."""
         assert gluon_decode_over_limit(max_qlen, 16, 1) is False
         assert gluon_decode_over_limit(max_qlen, 16, 1) == gluon_decode_over_limit(
             1, 16, 1
@@ -123,3 +124,122 @@ class TestEnvelopeConstants:
         asm_pa.cu:113-116 carries `# mtp * gqa <= 16` as a source comment.
         """
         assert PA_ASM_MAX_QUERY_GROUP_SIZE < PA_GLUON_MAX_QUERY_GROUP_SIZE
+
+
+class _Layer:
+    """Just the attributes _dispatch_decode reads.
+
+    It touches six of them plus two env flags and returns a bound method, so the
+    routing table can be driven without a device -- which the envelope tests
+    above cannot do, and which is the gap a sliding-window regression slipped
+    through once already.
+    """
+
+    def __init__(self, sliding_window=-1, num_heads=16, num_kv_heads=1, **flags):
+        self.sliding_window = sliding_window
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.use_triton_attn = flags.get("use_triton_attn", False)
+        self.use_flash_layout = flags.get("use_flash_layout", False)
+        for name in (
+            "paged_attention_unified",
+            "paged_attention_triton",
+            "paged_attention_asm",
+            "paged_attention_persistent_asm",
+        ):
+            setattr(self, name, name)
+
+
+def _route(monkeypatch, max_qlen, block_size=128, unified=False, force=False, **kw):
+    from atom.model_ops import attention_mha as mha
+
+    monkeypatch.setattr(mha.envs, "ATOM_USE_UNIFIED_ATTN", unified)
+    monkeypatch.setattr(mha.envs, "ATOM_FORCE_ATTN_TRITON", force)
+    monkeypatch.setattr(
+        mha,
+        "get_current_atom_config",
+        lambda: SimpleNamespace(kv_cache_block_size=block_size),
+    )
+    return mha.PagedAttentionImpl._dispatch_decode(_Layer(**kw), max_qlen)
+
+
+class TestDecodeRouting:
+    """Which backend _dispatch_decode picks, for the shapes that reach it."""
+
+    def test_m3_dense_production_shape_stays_on_gluon(self, monkeypatch):
+        """TP4, 3 draft tokens. The shape this change is measured on."""
+        assert _route(monkeypatch, 4) == "paged_attention_triton"
+
+    def test_no_drafting_still_reaches_asm(self, monkeypatch):
+        assert _route(monkeypatch, 1) == "paged_attention_asm"
+
+    def test_past_gluon_falls_back_to_unified(self, monkeypatch):
+        assert _route(monkeypatch, 5) == "paged_attention_unified"
+
+    def test_past_asm_but_within_gluon_takes_gluon(self, monkeypatch):
+        """4 x 16 = 64 clears gluon and is four times ASM's envelope.
+
+        Without the check it would reach run_pa_fwd_asm, where an unmatched mtp
+        silently re-runs with mtp=1 rather than refusing.
+        """
+        assert _route(monkeypatch, 4) == "paged_attention_triton"
+        assert _route(monkeypatch, 1, num_heads=64) == "paged_attention_triton"
+
+    @pytest.mark.parametrize("max_qlen", [1, 4])
+    def test_sliding_window_honours_unified_env(self, monkeypatch, max_qlen):
+        """The env has to reach the sliding-window branch too.
+
+        It returns before the ATOM_USE_UNIFIED_ATTN block below it, so dropping
+        the flag from this one expression silently moves sliding-window layers
+        onto a kernel whose output dtype the caller has already fixed as fp8.
+        """
+        assert (
+            _route(monkeypatch, max_qlen, sliding_window=128, unified=True)
+            == "paged_attention_unified"
+        )
+
+    def test_sliding_window_without_the_env_uses_gluon(self, monkeypatch):
+        assert (
+            _route(monkeypatch, 4, sliding_window=128) == "paged_attention_triton"
+        )
+
+    def test_flash_layout_routes_to_unified(self, monkeypatch):
+        assert (
+            _route(monkeypatch, 1, use_flash_layout=True) == "paged_attention_unified"
+        )
+
+    def test_force_triton_takes_unified(self, monkeypatch):
+        """ATOM_FORCE_ATTN_TRITON short-circuits the block-256 ASM route."""
+        assert (
+            _route(monkeypatch, 1, block_size=256, unified=True, force=True)
+            == "paged_attention_unified"
+        )
+
+    def test_use_triton_attn_diverts_off_asm(self, monkeypatch):
+        """Same shape reaches ASM without the flag, so this arm is load-bearing."""
+        assert _route(monkeypatch, 1) == "paged_attention_asm"
+        assert (
+            _route(monkeypatch, 1, use_triton_attn=True) == "paged_attention_triton"
+        )
+
+    def test_a_sentinel_query_length_routes_as_one(self, monkeypatch):
+        """Clamped at the top, so both gates see the same value.
+
+        Unclamped, `0 * ratio > 16` is false and this would reach ASM instead.
+        """
+        assert _route(monkeypatch, 0, num_heads=64) == _route(
+            monkeypatch, 1, num_heads=64
+        )
+
+    def test_persistent_asm_is_not_bounded_by_the_run_pa_fwd_envelope(
+        self, monkeypatch
+    ):
+        """pa_persistent_fwd is a different kernel with its own table.
+
+        4 x 16 = 64 is past run_pa_fwd_asm's 16, but that says nothing about
+        the persistent path, so the block-256 route must still be taken.
+        """
+        assert (
+            _route(monkeypatch, 4, block_size=256, unified=True)
+            == "paged_attention_persistent_asm"
+        )

--- a/tests/test_paged_attention_dispatch.py
+++ b/tests/test_paged_attention_dispatch.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+"""Envelopes of the two paged decode kernels.
+
+Launch policy only -- `gluon_decode_over_limit` is integer arithmetic and needs
+no device. It still needs triton and aiter to be importable, because it lives
+beside the kernel wrappers it describes and `atom.model_ops.base_attention`
+pulls both at import. The CPU CI runner installs neither (`pre-checks.yaml`
+installs cpu torch and pytest), so this file self-skips there, the same way
+every other attention test in this directory does. Its coverage comes from a
+GPU environment.
+
+What is worth asserting here is the coupling to aiter, since nothing else
+watches it: the gluon kernel picks its register layout from a table keyed on
+next_pow2(query_group_size), and past the last arm the variable is simply never
+bound -- a Triton compile error with nothing in it about speculative length.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("triton", reason="base_attention defines @triton.jit kernels")
+pytest.importorskip("aiter", reason="base_attention imports the AITER runtime")
+
+from atom.model_ops.base_attention import (  # noqa: E402
+    PA_ASM_MAX_QUERY_GROUP_SIZE,
+    PA_GLUON_MAX_QUERY_GROUP_SIZE,
+    PA_GLUON_MAX_QUERY_LEN,
+    gluon_decode_over_limit,
+)
+
+# aiter pa_decode_gluon.py:134-168 -- the arms `register_bases` is defined for,
+# plus a separate path below 16. There is no 128 arm and no else.
+AITER_GLUON_GROUP_ARMS = (16, 32, 64)
+
+
+class TestGluonEnvelope:
+    """Shapes the gluon decode kernel takes, and the ones it cannot."""
+
+    @pytest.mark.parametrize(
+        "max_qlen, num_heads, num_kv_heads, over, why",
+        [
+            (1, 16, 1, False, "M3 dense at tp4, no drafting"),
+            (4, 16, 1, False, "M3 dense at tp4 with 3 draft tokens: 16*4=64, on the limit"),
+            (5, 16, 1, True, "one more draft token: 80 rounds to 128, off the table"),
+            (4, 32, 2, False, "M3 dense at tp2 -- ratio is still 16"),
+            (5, 8, 1, True, "gqa=8 reaches the query-length limit before the group one"),
+            (3, 17, 1, True, "ratio 17 rounds to 32, 3 rounds to 4: 128, no arm for it"),
+            (2, 64, 1, True, "ratio 64 doubled by two query positions"),
+        ],
+    )
+    def test_known_shapes(self, max_qlen, num_heads, num_kv_heads, over, why):
+        assert gluon_decode_over_limit(max_qlen, num_heads, num_kv_heads) is over, why
+
+    def test_rounds_up_rather_than_using_the_raw_product(self):
+        """17 heads over 1 kv head at qlen 3 is 51 -- under the raw 64 limit, but
+        the kernel indexes its table with next_pow2, and 128 has no arm."""
+        assert 3 * (17 // 1) <= PA_GLUON_MAX_QUERY_GROUP_SIZE
+        assert gluon_decode_over_limit(3, 17, 1) is True
+
+    @pytest.mark.parametrize("max_qlen", [0, -1, -100])
+    def test_non_positive_query_length_is_clamped(self, max_qlen):
+        """A sentinel or unset length must not synthesise a large group.
+
+        Without the clamp `(-100).bit_length()` alone yields a 128-wide query
+        tile and the call reports over-limit for what is really one position.
+        """
+        assert gluon_decode_over_limit(max_qlen, 16, 1) is False
+        assert gluon_decode_over_limit(max_qlen, 16, 1) == gluon_decode_over_limit(
+            1, 16, 1
+        )
+
+    def test_monotone_in_query_length(self):
+        """Once a shape is past the envelope, longer cannot bring it back."""
+        seen_over = False
+        for qlen in range(1, 12):
+            over = gluon_decode_over_limit(qlen, 16, 1)
+            assert not (seen_over and not over), f"qlen={qlen} came back under"
+            seen_over |= over
+        assert seen_over, "16 heads should leave the envelope within 12 positions"
+
+
+class TestEnvelopeConstants:
+    """The constants against the kernel sources they were read from."""
+
+    def test_gluon_group_limit_is_the_last_layout_arm(self):
+        assert PA_GLUON_MAX_QUERY_GROUP_SIZE == max(AITER_GLUON_GROUP_ARMS)
+
+    def test_every_reachable_group_has_an_arm(self):
+        """Anything reported as safe must land on an arm, not between two."""
+        for qlen in range(1, PA_GLUON_MAX_QUERY_LEN + 1):
+            for ratio in (1, 2, 4, 8, 16, 32, 64):
+                if gluon_decode_over_limit(qlen, ratio, 1):
+                    continue
+                qlen_p2 = 1 << (qlen - 1).bit_length()
+                group_p2 = qlen_p2 * max(
+                    16 // qlen_p2, 1 << (ratio - 1).bit_length()
+                )
+                assert group_p2 in AITER_GLUON_GROUP_ARMS, (
+                    f"qlen={qlen} ratio={ratio} passes as safe but needs a "
+                    f"{group_p2}-wide layout, which aiter does not define"
+                )
+
+    def test_asm_envelope_is_inside_gluon(self):
+        """ASM tops out lower, so a shape it declines still has somewhere to go.
+
+        asm_pa.cu:113-116 carries `# mtp * gqa <= 16` as a source comment.
+        """
+        assert PA_ASM_MAX_QUERY_GROUP_SIZE < PA_GLUON_MAX_QUERY_GROUP_SIZE

--- a/tests/test_paged_attention_dispatch.py
+++ b/tests/test_paged_attention_dispatch.py
@@ -22,7 +22,7 @@ import pytest
 pytest.importorskip("triton", reason="base_attention defines @triton.jit kernels")
 pytest.importorskip("aiter", reason="base_attention imports the AITER runtime")
 
-from atom.model_ops.base_attention import (  # noqa: E402
+from atom.model_ops.base_attention import (
     PA_ASM_MAX_QUERY_GROUP_SIZE,
     PA_GLUON_MAX_QUERY_GROUP_SIZE,
     PA_GLUON_MAX_QUERY_LEN,
@@ -41,11 +41,29 @@ class TestGluonEnvelope:
         "max_qlen, num_heads, num_kv_heads, over, why",
         [
             (1, 16, 1, False, "M3 dense at tp4, no drafting"),
-            (4, 16, 1, False, "M3 dense at tp4 with 3 draft tokens: 16*4=64, on the limit"),
+            (
+                4,
+                16,
+                1,
+                False,
+                "M3 dense at tp4 with 3 draft tokens: 16*4=64, on the limit",
+            ),
             (5, 16, 1, True, "one more draft token: 80 rounds to 128, off the table"),
             (4, 32, 2, False, "M3 dense at tp2 -- ratio is still 16"),
-            (5, 8, 1, True, "gqa=8 reaches the query-length limit before the group one"),
-            (3, 17, 1, True, "ratio 17 rounds to 32, 3 rounds to 4: 128, no arm for it"),
+            (
+                5,
+                8,
+                1,
+                True,
+                "gqa=8 reaches the query-length limit before the group one",
+            ),
+            (
+                3,
+                17,
+                1,
+                True,
+                "ratio 17 rounds to 32, 3 rounds to 4: 128, no arm for it",
+            ),
             (2, 64, 1, True, "ratio 64 doubled by two query positions"),
         ],
     )
@@ -93,9 +111,7 @@ class TestEnvelopeConstants:
                 if gluon_decode_over_limit(qlen, ratio, 1):
                     continue
                 qlen_p2 = 1 << (qlen - 1).bit_length()
-                group_p2 = qlen_p2 * max(
-                    16 // qlen_p2, 1 << (ratio - 1).bit_length()
-                )
+                group_p2 = qlen_p2 * max(16 // qlen_p2, 1 << (ratio - 1).bit_length())
                 assert group_p2 in AITER_GLUON_GROUP_ARMS, (
                     f"qlen={qlen} ratio={ratio} passes as safe but needs a "
                     f"{group_p2}-wide layout, which aiter does not define"


### PR DESCRIPTION
## Motivation

The sparse-indexer score kernel (`_decode_index_score_tiled_kernel`) is the largest single item in a conc=1 decode step — **1.93 ms/step, 20.5%** — and runs on a quarter of the GPU.

```python
DECODE_SCORE_TARGET_GRID = 2048
DECODE_SCORE_MAX_CHUNKS  = 64          # binds for every batch <= 32
```

At 315K context and batch=1 that is 64 workgroups — **25% of 256 CUs**, each walking 39 blocks serially, while the heuristic itself aims for 2048. Exactly the regime where we trail vLLM on conc=1/2 interactivity.

Result: **+17~19% interactivity** end to end, output bit-identical.

## Technical Details

A flat chunk ceiling cannot work, because the best chunk count follows the context length while the best *blocks per chunk* does not:

| context | blocks | best chunks (batch≥8) | blocks/chunk |
| --- | ---: | ---: | ---: |
| 32K | 256 | 64 | **4** |
| 131K | 1024 | 512 | **2** |
| 315K | 2461 | 821 | **3** |

Every measured regression is a chunk down to **one block**: the query tile is loaded once *outside* the block loop, so at one block that fixed cost is the whole cost.

But a floor alone ignores batch — it yields 2731 chunks at every batch and the grid grows without limit (275 μs at batch 128 against 202 capped). So the two constants split the batch range:

```python
DECODE_SCORE_TARGET_GRID = 1 << 14     # ceiling on total workgroups; binds from batch 8 up
DECODE_SCORE_MIN_BLOCKS  = 3           # floor on blocks per chunk; binds below that
# DECODE_SCORE_MAX_CHUNKS deleted -- provably dead under the floor
```

The grid stays a pure function of `(batch, max_block)`, so **CUDA graph replays the grid it captured**.

**Bundled fix** (`fix(attn): keep decode off the gluon kernel past its query-length and group limits`): the gluon decode kernel asserts on `query_length <= 4` and `max_seqlen_q * (q_heads / kv_heads) <= 64`. Drafting multiplies both, and a model can reach either first — M3 sits exactly on the group limit today (16 × 4 draft positions), a gqa=8 model hits the length limit with its group still at 40. Backend selection now accounts for both, and refuses outright when the layer is per-token quantized: the unified fallback carries one descale for the whole tensor, so running it there would be wrong numbers rather than an error.

Two consequences worth stating:

- **`kv_scale` moves to the device.** The new query-group term is the first env-independent way into the unified branch (previously it needed `ATOM_USE_UNIFIED_ATTN` or `use_flash_layout`, neither on by default). `k_descale` is forwarded unchanged to `k_descale_ptr` at every launch site — no `.to(device)`, no `None` substitution — so a host tensor would be dereferenced in the kernel.
- **`PA_ASM_MAX_QUERY_GROUP_SIZE = 16` reroutes existing models** from `paged_attention_asm` to gluon whenever `max_qlen * (q_heads / kv_heads) > 16`; M3 at TP4 with a 4-token draft is itself in that set. The bound has upstream backing (`asm_pa.cu:113-116`: `// # mtp * gqa <= 16`). **The reroute's performance delta was not measured** — it is accepted because past the envelope `get_heuristic_kernel` silently re-runs with `mtp=1`, a kernel built for another query length.

## Test

MI355X (gfx950), TP4, MXFP4 weights + fp8 KV/index cache.

**Kernel**, capture semantics (μs). Decode runs under CUDA graph and capture takes `max_seqlen_k` from `max_model_len` (`aiter_attention.py:1334`), so production sizes the grid from the model limit, not the live context — measured with the two decoupled (`--model-len 1048576`), real context per row, 2 repeats:

| batch | 1 | 2 | 8 | 16 | 24 | 32 | 64 | 128 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| before | 110.6 | 110.6 | 123.1 | — | — | 193.7 | 244.0 | 374.9 |
| after | **27.9** | **34.0** | **72.9** | **132.8** | **189** | **195.7** | **195.9** | **202.0** |

Rows 32–128 use the longest context each batch's KV pool admits. The old rule shrank the split as batch grew (64 → 32 → 16), bounding total CTAs but starving parallelism — 374.9 μs at batch 128 is the worst point measured anywhere.

This also reconciles the profile: the kernel measured 129 μs/call in production, 2.6× an eager-semantics microbench, and the capture number accounts for it.

**End-to-end** (`tp4_eagle3`, real agentic corpus at 315K, 1800 s/point):

| | tok/s/chip | intvty_p90 |
| --- | --- | --- |
| conc=1 | 4,403 → **4,601** (**+4.50%**) | 233.1 → **273.3** (**+17.23%**) |
| conc=2 | 4,751 → **4,856** (**+2.21%**) | 226.1 → **270.0** (**+19.41%**) |

The gap is expected: the change shortens one kernel inside the decode step, which lands on interactivity, while throughput also carries prefill and TTFT.

**Exactness** — 3 contexts × 4 batches × 2 query lengths = 24 shapes; `topk_idx`, `sparse_bt`, `sparse_ctx` all bit-identical to baseline, while the chunk count over the same shapes does change.

**Accuracy** — gsm8k under the CI recipe verbatim (TP8, 32K), flexible-extract **0.9409** ± 0.0065 against a 0.9363 baseline and 0.93 threshold.

**Unit tests** — `tests/test_paged_attention_dispatch.py`, 28 cases over the envelope and the routing table it feeds: the named shapes, `next_pow2` rounding, non-positive query lengths, the constants against the kernel sources, and each arm of `_dispatch_decode` driven through a fake layer. Two worth calling out — `test_every_reachable_group_has_an_arm` asserts every shape reported safe lands on a layout arm aiter actually defines, which nothing else watches; `test_sliding_window_honours_unified_env` covers the arm that returns before the `ATOM_USE_UNIFIED_ATTN` block and so has to carry the flag itself. Revert power was checked, not assumed: every routing case turns red under a named revert of the line it guards. **These skip on the CPU CI runner**, which installs neither triton nor aiter; every other attention test in `tests/` skips there for the same reason.

## Known Limitations

- **A per-token-quantized MHA layer under `ATOM_USE_UNIFIED_ATTN=1` now refuses to start.** `unified_attention` carries one descale for the whole tensor, so that combination previously served traffic with the wrong numbers; it raises `NotImplementedError` at the first prefill instead. No known config is hit — the only `ATOM_USE_UNIFIED_ATTN=1` entries in `.github/benchmark/` and `recipes/` are sglang kimi_k3 (MLA, never reaches `PagedAttentionImpl`) and two `--kv_cache_dtype bf16` recipes, which produce no scale tensor — but it is a behaviour change, not only a new guard.
- **Neither constant is derived.** The measured best `batch × chunks` runs 8k–44k over batch 16–128, so no single `TARGET_GRID` hits every point; `1<<14` lands within 5% of the per-batch optimum there. Landing exactly would mean segmenting on target blocks-per-chunk, a larger change.
- **batch 256 still regresses** (394 μs floor-only, 214 with the ceiling, 235 for the old rule). Reaching it needs every request under 30K tokens: M3 does not compress KV, and a decoding sequence's KV must stay GPU-resident, so the TP4 pool of 7.66M tokens bounds `batch × context` whatever the offload setup — CPU offload raises how many idle sessions stay warm, not how many sequences decode at once. At the 315–375K contexts this workload runs, that is conc 24. Batch 128 is the tuning target as headroom, not because 256 is reachable.
- Under CUDA graph the split is sized from `max_model_len`, so a short request in a long deployment launches chunks that return immediately. Measured at the extreme (4K context, grid sized for 1M): still net positive through batch 32.
- `MIN_BLOCKS=3` was measured at 32K / 131K / 315K; shorter contexts should be re-verified, not assumed.
- Measured on TP4 only. The rule takes no TP argument and index-K is MQA, so per-rank traffic is TP-invariant; the optimum would move only if `idx_heads × query positions > 16` pushes `BLOCK_SIZE_N` to 32 (TP1 with ≥7 draft tokens, TP2 with ≥15).
- The kernel microbench uses a synthetic contiguous block table; production tables are fragmented, which is why the end-to-end A/B decides.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
