### PR TITLE
fix: close the engine in the examples, and let the release golden diff fail

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -208,14 +208,11 @@ jobs:
           echo ""
           echo "========== Comparing output with golden outputs =========="
           # Ignore whitespace and EOL differences in the diff
-          diff -u -B -w --strip-trailing-cr atom_release_output.txt .github/workflows/golden_outputs.txt || true
-          DIFF_EXIT_CODE=$?
-          
-          if [ $DIFF_EXIT_CODE -ne 0 ]; then
+          if diff -u -B -w --strip-trailing-cr atom_release_output.txt .github/workflows/golden_outputs.txt; then
+            echo "Output matches golden outputs."
+          else
             echo "Output does not match golden outputs."
             exit 1
-          else
-            echo "Output matches golden outputs."
           fi
 
       - name: Re-login to Docker Hub before push

--- a/atom/examples/profile_offline.py
+++ b/atom/examples/profile_offline.py
@@ -112,6 +112,8 @@ def main():
             else:
                 print(f"Output: {generated_text}\n")
 
+    llm.close()
+
 
 if __name__ == "__main__":
     main()

--- a/atom/examples/simple_inference.py
+++ b/atom/examples/simple_inference.py
@@ -89,6 +89,7 @@ def main():
         print(f"Completion: {output['text']!r}")
 
     llm.print_mtp_statistics()
+    llm.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two independent bugs that happened to hide each other. Both are one-liners; the evidence for each is below.

## 1. The examples never shut the engine down

`atom/examples/simple_inference.py` and `atom/examples/profile_offline.py` call `create_engine()` and never `close()`. `atom/examples/multimodal_inference.py:138` already gets this right — this PR just brings the other two in line.

Without the call, once `generate()` returns the main process falls straight into Python's `multiprocessing.util._exit_function`, which `join()`s the ModelRunner workers. Those workers are still parked in `AsyncIOProc.busy_loop()` waiting for an `"exit"` RPC, and the only place that broadcasts it is `EngineCore.exit()` (`engine_core.py:248`), reached through `LLMEngine.close()` — which nobody called. Parent waits for the children, children wait for a message that never comes.

`atexit` in `async_proc.py` only registers `_cleanup_shared_memory`, so nothing rescues the normal exit path.

py-spy on a process that had been wedged for 4.6 hours:

```
MainThread (idle):
    poll (multiprocessing/popen_fork.py:27)
    wait (multiprocessing/popen_fork.py:43)
    join (multiprocessing/process.py:149)
    _exit_function (multiprocessing/util.py:360)

TP1 / TP2 / TP3 (active+gil, spinning):
    acquire_read (aiter/dist/shm_broadcast.py:469)
    dequeue (aiter/dist/shm_broadcast.py:543)
    get_func (async_proc.py:256)
    busy_loop (async_proc.py:234)
```

The last completion goes down with it — it is still in the stdout buffer when the process wedges, so the run prints one fewer completion than it was given prompts.

A/B in the same container, same model, one line different (Llama-3-8B-Instruct, tp1, `--temperature 0 --max-tokens 32`):

| | stock | with `llm.close()` |
|---|---|---|
| wall time | 420s (killed by timeout) | 50s |
| exit code | 124 | 0 |
| completions | 5 of 6 | 6 of 6 |
| `No available shared memory broadcast block` warnings | 6 | 0 |
| `All EngineCores shut down` | no | yes |

DeepSeek-V4-Flash on tp4 behaves the same way — 2m34s and 6 of 6 with the fix, against earlier runs that wedged for 91 minutes and 4.6 hours respectively. Four separate ROCm 10 golden runs each produced 5 completions and never shut down.

## 2. The release golden comparison can never fail

`.github/workflows/docker-release.yaml`:

```bash
diff ... || true
DIFF_EXIT_CODE=$?
if [ $DIFF_EXIT_CODE -ne 0 ]; then
  echo "Output does not match golden outputs."
  exit 1
else
  echo "Output matches golden outputs."
fi
```

`|| true` makes the compound command always succeed, so `DIFF_EXIT_CODE` is always `0` and the `exit 1` branch is unreachable. The step reports "Output matches golden outputs." regardless of what `diff` actually found.

Minimal repro:

```console
$ printf 'a\nb\n' > g1.txt; printf 'a\n' > g2.txt
$ diff -u g1.txt g2.txt >/dev/null || true
$ echo $?
0
```

The intent is unambiguous — the `if` block exists and wants to fail on mismatch — so this is rewritten as a plain `if diff ...; then ... else ... exit 1; fi`.

This is also what kept the first bug invisible: a lost completion changes the output, the golden diff would have caught it, and the diff was neutered.

## Note on a related step

`atom-test.yaml` has a correctly written golden comparison (it does `exit 1` on mismatch), but both it and the inference step above it are currently `if: false` with a `TODO: skip for all test until it's fixed`. Left untouched here — re-enabling those is a separate decision.


---

### Verified on gfx950, and a second missing argument worth folding in

Both changes here were exercised while bringing the ROCm 10 images up on
an MI355X (gfx950) node (MI355X / gfx950). Four models — DeepSeek-V4-Pro,
GLM-5.2-MXFP4, MiniMax-M3-MXFP4, Kimi-K2.6-MXFP4 — pass the full set of
checks (exit 0, one completion per prompt, no shared-memory warning, a clean
`All EngineCores shut down`) on both the ROCm 10.0 and the 10.1 nightly
image. Every one of those runs needed the `llm.close()` this PR adds; without
it the process simply never exits.

While doing that, a second omission surfaced in the same two files:

```python
-    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    tokenizer = AutoTokenizer.from_pretrained(args.model, trust_remote_code=True)
```

`simple_inference.py:62` and `profile_offline.py:58` carry the same line. The
engine already receives `trust_remote_code` (it shows up in `Engine kwargs`
and the model initializes fine), but this tokenizer load is separate and does
not, so for a model whose tokenizer is custom code the run stops at an
interactive prompt:

```
Do you wish to run the custom code? [y/N]
Traceback ... EOFError: EOF when reading a line
```

The prompt comes from a multiprocessing child whose stdin is closed, so it
cannot be answered and nothing gets past it — the run sat at zero progress
until the hour-long timeout fired, having already loaded 247 GB of weights.
It only bites models whose `tokenizer_config.json` carries an `auto_map`:
Kimi-K2.6 does (`TikTokenTokenizer`), DeepSeek-V4-Pro does not, which is why
three of the four models never showed it. Adding the argument took that run
from a 60-minute hang to a pass.

Worth carrying here rather than in its own PR, since it is the same class of
bug in the same two files this PR is already touching.

