### PR TITLE
ci(benchmark): move the 1k/1k grid off the nightly onto a weekly cron

### DIFF
--- a/.github/benchmark/models.json
+++ b/.github/benchmark/models.json
@@ -1,6 +1,7 @@
 {
   "default_scenarios": [
     {
+      "cadence": "weekly",
       "isl": 1024,
       "osl": 1024,
       "concurrency": [4, 8, 16, 32, 64, 128, 256, 512],

--- a/.github/scripts/build_benchmark_matrix.py
+++ b/.github/scripts/build_benchmark_matrix.py
@@ -7,7 +7,9 @@ concurrency list; see ``catalog.build_cell_configs``) to ``$GITHUB_OUTPUT`` as
 ``configs_json`` plus a ``has_cells`` flag.
 
 Behaviour by event:
-- ``schedule``      -> all models, catalog ``default_scenarios`` (nightly grid).
+- ``schedule``      -> all models, catalog ``default_scenarios`` filtered by
+  ``CADENCE`` (the workflow derives it from which cron fired: the nightly grid,
+  or the weekly one).
 - ``workflow_dispatch`` -> only models whose checkbox is ticked, workload from
   the ``param_lists`` input. Also validates that the dispatch model checkboxes
   stay in sync with the catalog prefixes (fails fast on drift).
@@ -65,6 +67,12 @@ def main() -> int:
     event = os.environ.get("EVENT_NAME", "")
     inputs = json.loads(os.environ.get("INPUTS_JSON") or "{}")
 
+    # Which slice of `default_scenarios` this run wants. Set by the workflow off
+    # the cron that fired; unset means no filter. Only the schedule path reads
+    # it -- a dispatch always carries `param_lists`, which replaces the catalog
+    # scenarios outright.
+    cadence = os.environ.get("CADENCE") or None
+
     if event == "schedule":
         model_filter = None
         param_lists = None
@@ -84,16 +92,31 @@ def main() -> int:
         param_lists = inputs.get("param_lists") or DEFAULT_PARAM_LISTS
 
     configs = build_cell_configs(
-        CATALOG, param_lists=param_lists, model_filter=model_filter
+        CATALOG,
+        param_lists=param_lists,
+        model_filter=model_filter,
+        cadence=cadence,
     )
+    if event == "schedule" and not configs:
+        # A cron that resolves to nothing means the catalog and the workflow's
+        # cadence labels disagree. Fail loudly: `has_cells=false` would skip the
+        # whole run in silence and read as a healthy no-op.
+        print(
+            f"ERROR: no cells for cadence {cadence!r}; the cron in "
+            f"atom-benchmark.yaml and the scenario `cadence` tags in {CATALOG} "
+            "are out of sync.",
+            file=sys.stderr,
+        )
+        return 1
     _emit(configs)
 
     n_cells = sum(len(json.loads(c["concurrency"])) for c in configs)
     n_models = len({c["prefix"] for c in configs})
     n_total = len(load_variants(CATALOG))
     print(
-        f"Event={event}: {n_cells} cells across {n_models} models "
-        f"-> {len(configs)} matrix configs ({n_total} variants in catalog)",
+        f"Event={event} cadence={cadence or 'all'}: {n_cells} cells across "
+        f"{n_models} models -> {len(configs)} matrix configs "
+        f"({n_total} variants in catalog)",
         file=sys.stderr,
     )
     return 0

--- a/.github/scripts/catalog.py
+++ b/.github/scripts/catalog.py
@@ -67,6 +67,9 @@ from typing import Any
 DEFAULT_CONC_MAX = 256
 DEFAULT_CONC_MIN = 0
 DEFAULT_RATIO = 0.8
+# How often a scenario runs. Untagged means nightly, so adding a scenario keeps
+# the old behaviour and only an explicit tag moves it off the nightly grid.
+DEFAULT_CADENCE = "nightly"
 
 
 def _load_catalog(path: str | Path) -> dict[str, Any]:
@@ -143,13 +146,22 @@ def _resolve_scenarios(
     model: dict[str, Any],
     variant: dict[str, Any],
     default_scenarios: list[dict[str, Any]],
+    cadence: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Pick the scenario list for a variant and filter it by its conc band."""
+    """Pick the scenario list for a variant, filtered by cadence and conc band.
+
+    `cadence` None keeps every scenario (what a dispatch and the tests want);
+    a value keeps only scenarios carrying it, with untagged ones reading as
+    `DEFAULT_CADENCE`. A model's or variant's own `scenarios` are filtered the
+    same way, so an override is nightly unless it says otherwise.
+    """
     scenarios = variant.get("scenarios") or model.get("scenarios") or default_scenarios
     cmin = variant.get("conc_min", DEFAULT_CONC_MIN)
     cmax = variant.get("conc_max", DEFAULT_CONC_MAX)
     resolved: list[dict[str, Any]] = []
     for sc in scenarios:
+        if cadence is not None and sc.get("cadence", DEFAULT_CADENCE) != cadence:
+            continue
         concs = [c for c in sc["concurrency"] if cmin <= c <= cmax]
         if concs:
             resolved.append({**sc, "concurrency": concs})
@@ -195,6 +207,7 @@ def build_cells(
     path: str | Path,
     param_lists: str | None = None,
     model_filter: set[str] | None = None,
+    cadence: str | None = None,
 ) -> list[dict[str, Any]]:
     """Expand the catalog into fully-resolved benchmark cells.
 
@@ -218,7 +231,9 @@ def build_cells(
                 param_lists, rec["conc_min"], rec["conc_max"]
             )
         else:
-            scenarios = _resolve_scenarios(model, variant, default_scenarios)
+            scenarios = _resolve_scenarios(
+                model, variant, default_scenarios, cadence=cadence
+            )
         for sc in scenarios:
             ratio = sc.get("random_range_ratio", DEFAULT_RATIO)
             ratio_str = _fmt_ratio(ratio)
@@ -265,6 +280,7 @@ def build_cell_configs(
     path: str | Path,
     param_lists: str | None = None,
     model_filter: set[str] | None = None,
+    cadence: str | None = None,
 ) -> list[dict[str, Any]]:
     """Group cells into first-level matrix configs: one per (variant, scenario).
 
@@ -281,7 +297,12 @@ def build_cell_configs(
     is rebuilt per concurrency inside the template from
     ``{prefix}{suffix}-{isl}-{osl}-{conc}-{ratio_str}`` (unchanged naming contract).
     """
-    cells = build_cells(path, param_lists=param_lists, model_filter=model_filter)
+    cells = build_cells(
+        path,
+        param_lists=param_lists,
+        model_filter=model_filter,
+        cadence=cadence,
+    )
 
     configs: dict[tuple, dict[str, Any]] = {}
     for c in cells:

--- a/.github/workflows/atom-benchmark.yaml
+++ b/.github/workflows/atom-benchmark.yaml
@@ -1,13 +1,27 @@
 name: ATOM Benchmark
 
+# The run title IS the cadence label: the baseline lookup below matches on it to
+# keep the nightly and weekly comparison chains apart. Both crons live in this
+# workflow, so without that a weekly run would become the next nightly's
+# baseline and silently blank out its whole regression table.
+run-name: >-
+  ${{ github.event_name == 'schedule'
+      && (github.event.schedule == '37 4 * * 0' && 'weekly' || 'nightly')
+      || format('manual ({0})', github.actor) }}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 on:
   schedule:
-    # Nightly at 00:12 Beijing time (16:12 UTC)
+    # Nightly at 00:12 Beijing time (16:12 UTC). Runs the 8k/1k grid only.
     - cron: '12 16 * * *'
+    # Weekly at 12:37 Beijing time on Sunday (04:37 UTC). Runs the 1k/1k grid,
+    # which is half the catalog's cells and was making the nightly too long.
+    # Daytime and on a weekend, well clear of the 15:00-19:00 UTC cron cluster
+    # the other benchmark workflows sit in.
+    - cron: '37 4 * * 0'
   workflow_dispatch:
     inputs:
       publish_to_dashboard:
@@ -104,6 +118,11 @@ permissions:
   contents: write
   issues: write
 
+env:
+  # Which slice of the catalog to build, and which chain to take a baseline
+  # from. A manual run compares against the nightly, as it always has.
+  CADENCE: ${{ github.event_name == 'schedule' && github.event.schedule == '37 4 * * 0' && 'weekly' || 'nightly' }}
+
 jobs:
   # Single source of the benchmark matrix. Expands the structured catalog
   # (.github/benchmark/models.json) into fully-resolved per-run "cells" — one
@@ -124,6 +143,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUTS_JSON: ${{ toJson(inputs) }}
+          CADENCE: ${{ env.CADENCE }}
         run: python3 .github/scripts/build_benchmark_matrix.py
 
   # Top-level fan-out: one matrix entry per (model variant × scenario) config.
@@ -192,19 +212,29 @@ jobs:
           merge-multiple: true
           path: .
 
-      - name: Download baseline from previous nightly run
+      - name: Download baseline from previous run of the same cadence
         id: baseline
         run: |
-          # Use the most recent completed nightly run (regardless of success/failure)
+          # Use the most recent completed run (regardless of success/failure)
           # because even failed runs have valid per-model benchmark artifacts.
           # Only requiring --status=success misses baselines when any single job fails.
+          #
+          # Matched on the run title, which `run-name` sets to the cadence: the
+          # nightly and weekly crons run different grids out of this one
+          # workflow, so comparing across them would leave every cell without a
+          # counterpart. A manual run reads CADENCE as `nightly` and so keeps
+          # comparing against the nightly, as before.
+          #
+          # limit=20 spans more than a week of nightlies, so a weekly run can
+          # still reach the previous weekly seven runs back.
           PREV_RUN_ID=$(gh run list \
             --workflow="ATOM Benchmark" \
             --branch=main \
             --event=schedule \
-            --limit=5 \
-            --json databaseId,status \
-            --jq '[.[] | select(.status == "completed")][0].databaseId // empty')
+            --limit=20 \
+            --json databaseId,status,displayTitle \
+            | jq -r --arg cadence "$CADENCE" \
+                '[.[] | select(.status == "completed" and .displayTitle == $cadence)][0].databaseId // empty')
 
           if [ -n "$PREV_RUN_ID" ] && [ "$PREV_RUN_ID" != "${{ github.run_id }}" ]; then
             echo "Downloading baseline from run #$PREV_RUN_ID"

--- a/tests/test_benchmark_catalog.py
+++ b/tests/test_benchmark_catalog.py
@@ -246,3 +246,101 @@ def test_build_cell_configs_one_config_per_server_key():
         for c in configs
     ]
     assert len(keys) == len(set(keys))
+
+
+def _workflow():
+    yaml = pytest.importorskip("yaml")
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def test_cadence_splits_the_nightly_without_losing_cells():
+    """The two crons must partition the catalog: every cell runs on exactly one.
+
+    The point of the split is a shorter nightly, so a cell silently belonging to
+    neither cadence would stop being benchmarked at all and nothing would say so.
+    """
+    everything = catalog.build_cells(CATALOG)
+    nightly = catalog.build_cells(CATALOG, cadence="nightly")
+    weekly = catalog.build_cells(CATALOG, cadence="weekly")
+
+    assert nightly and weekly, "both cadences must produce cells"
+    assert len(nightly) + len(weekly) == len(everything)
+
+    def keys(cells):
+        return {
+            (c["prefix"], c["suffix"], c["isl"], c["osl"], c["conc"]) for c in cells
+        }
+
+    assert keys(nightly) | keys(weekly) == keys(everything)
+    assert not (keys(nightly) & keys(weekly)), "a cell runs on one cadence only"
+
+
+def test_nightly_dropped_1k1k_and_weekly_is_exactly_that():
+    """The split as configured: 1k/1k moved off the nightly, nothing else did."""
+    nightly = {
+        (c["isl"], c["osl"]) for c in catalog.build_cells(CATALOG, cadence="nightly")
+    }
+    weekly = {
+        (c["isl"], c["osl"]) for c in catalog.build_cells(CATALOG, cadence="weekly")
+    }
+
+    assert (1024, 1024) not in nightly
+    assert weekly == {(1024, 1024)}
+
+
+def test_untagged_scenarios_stay_nightly():
+    """Adding a scenario must not need a `cadence` field to keep working.
+
+    A model's or variant's own `scenarios` override the defaults, and none of
+    them carries a tag today -- they have to land on the nightly, not vanish.
+    """
+    cat = catalog._load_catalog(CATALOG)
+    tagged = {
+        sc.get("cadence", catalog.DEFAULT_CADENCE) for sc in cat["default_scenarios"]
+    }
+    assert catalog.DEFAULT_CADENCE in tagged, "the default must remain reachable"
+
+    overrides = [
+        m["prefix"]
+        for m in cat["models"]
+        if m.get("scenarios") or any(v.get("scenarios") for v in m.get("variants", []))
+    ]
+    nightly = {c["prefix"] for c in catalog.build_cells(CATALOG, cadence="nightly")}
+    for prefix in overrides:
+        assert prefix in nightly, f"{prefix} overrides scenarios but runs on no cron"
+
+
+def test_every_cron_produces_cells():
+    """Each cadence the workflow can ask for must resolve to a real grid.
+
+    `build_benchmark_matrix` fails the run on an empty schedule matrix, so a
+    typo'd tag would take the whole nightly down -- catch it here instead.
+    """
+    on = _workflow().get("on", _workflow().get(True))
+    crons = [c["cron"] for c in on["schedule"]]
+    assert len(crons) == 2, "expected a nightly and a weekly cron"
+
+    for cadence in ("nightly", "weekly"):
+        assert catalog.build_cells(CATALOG, cadence=cadence), cadence
+
+
+def test_weekly_cron_matches_the_cadence_expressions():
+    """The weekly cron string is repeated in `run-name` and `env.CADENCE`.
+
+    If they drift, a weekly run is titled `nightly`, and the baseline lookup --
+    which matches on that title -- hands the next nightly a 1k/1k-only run to
+    compare against. Every cell then reports no baseline, and nothing errors.
+    """
+    wf = _workflow()
+    on = wf.get("on", wf.get(True))
+    crons = [c["cron"] for c in on["schedule"]]
+    weekly_crons = [c for c in crons if c.strip().endswith("0")]
+    assert len(weekly_crons) == 1, f"expected one weekly cron, got {weekly_crons}"
+    weekly = weekly_crons[0]
+
+    for field, text in (
+        ("run-name", wf["run-name"]),
+        ("env.CADENCE", wf["env"]["CADENCE"]),
+    ):
+        assert weekly in text, f"{field} does not reference the weekly cron {weekly!r}"
+        assert "weekly" in text and "nightly" in text, field


### PR DESCRIPTION
The nightly was 319 cells and half of them were 1k/1k. Tag that scenario `cadence: weekly` and give the workflow a second cron for it: the nightly drops to 162 cells, the 1k/1k grid's 157 run Sunday 12:37 Beijing (04:37 UTC) -- daytime on a weekend, clear of the 15:00-19:00 UTC cluster the other benchmark workflows sit in.

| Cadence | Cell Count | Config Count | ISL/OSL |
|---|---:|---:|---|
| all | 319 | 52 | `1024/1024` + `8192/1024` |
| nightly | 162 | 27 |  `8192/1024` |
| weekly | 157 | 25 |  `1024/1024` |

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
