### PR TITLE
M3 cpu offload cache optimization

### DIFF
--- a/atom/kv_transfer/offload/cache_policy.py
+++ b/atom/kv_transfer/offload/cache_policy.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Opt-in scan-resistant eviction for LMCache's CPU tier."""
+
+from collections import OrderedDict
+from typing import Any
+
+from lmcache.v1.storage_backend.cache_policy.lru import LRUCachePolicy
+
+
+class SLRUCachePolicy(LRUCachePolicy):
+    """Protect reused chunks; single-use chunks compete in probationary LRU.
+
+    Protection covers at most half the resident chunks. ATOM M3 PAGE chunks
+    have a fixed byte size, so this also bounds the protected byte budget.
+    The CPU backend owns synchronization and calls these methods under its
+    cache lock. A pinned or referenced chunk is never an eviction candidate.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._probationary: OrderedDict[Any, None] = OrderedDict()
+        self._protected: OrderedDict[Any, None] = OrderedDict()
+
+    def update_on_hit(self, key: Any, cache_dict: OrderedDict) -> None:
+        """Promote a reused chunk and age out excess protection."""
+        super().update_on_hit(key, cache_dict)
+        self._probationary.pop(key, None)
+        self._protected[key] = None
+        self._protected.move_to_end(key)
+        while len(self._protected) > len(cache_dict) // 2:
+            demoted, _ = self._protected.popitem(last=False)
+            self._probationary[demoted] = None
+
+    def update_on_put(self, key: Any) -> None:
+        """Admit new data without displacing protected data's priority."""
+        super().update_on_put(key)
+        self._protected.pop(key, None)
+        self._probationary[key] = None
+        self._probationary.move_to_end(key)
+
+    def update_on_force_evict(self, key: Any) -> None:
+        """Forget a chunk explicitly removed by the storage backend."""
+        self._probationary.pop(key, None)
+        self._protected.pop(key, None)
+
+    def get_evict_candidates(
+        self, cache_dict: OrderedDict, num_candidates: int = 1
+    ) -> list:
+        """Choose from probation without scanning the protected segment.
+
+        Normal pressure removals do not issue a policy callback. Drop stale
+        keys lazily, but retain selected candidates until they are actually
+        removed: a caller may retry or decide not to evict them. With evictable
+        probationary entries this is amortized O(1) per victim; pinned entries
+        still require scanning because pin changes have no policy callback.
+        """
+        if num_candidates <= 0:
+            return []
+        candidates = []
+        for queue in (self._probationary, self._protected):
+            stale = []
+            for key in queue:
+                cache = cache_dict.get(key)
+                if cache is None:
+                    stale.append(key)
+                elif cache.can_evict:
+                    candidates.append(key)
+                    if len(candidates) == num_candidates:
+                        break
+            for key in stale:
+                queue.pop(key, None)
+            if len(candidates) == num_candidates:
+                break
+        return candidates
+
+
+def register_slru_policy() -> None:
+    """Register ATOM_SLRU through LMCache's public policy registry."""
+    from lmcache.v1.storage_backend.cache_policy import POLICY_MAPPING
+
+    POLICY_MAPPING["ATOM_SLRU"] = SLRUCachePolicy

--- a/atom/kv_transfer/offload/config.py
+++ b/atom/kv_transfer/offload/config.py
@@ -356,23 +356,36 @@ def build_lmcache_config(
 
     Raises:
         ValueError: If the local-disk path, capacity, or CPU staging capacity
-            is incomplete.
+            is incomplete, or asynchronous loading is requested.
     """
     from lmcache.v1.config import LMCacheEngineConfig
 
     cfg = LMCacheEngineConfig.from_env()
+    # Preserve the legacy rank-0 default; explicit overrides can opt into
+    # all-rank lookup ([]) so every shard gets matching touches and pins.
+    if getattr(cfg, "lookup_server_worker_ids", None) is None:
+        cfg.lookup_server_worker_ids = [0]
     apply_extra_overrides(cfg, kv_transfer_config)
+    # Async lookup has a separate polling/cancellation contract. This
+    # connector currently implements only synchronous lookup; do not let an
+    # unsupported mode issue duplicate lookups or release late-arriving pins.
+    if getattr(cfg, "enable_async_loading", False):
+        raise ValueError(
+            "ATOM LMCache offload does not support enable_async_loading=True; "
+            "set LMCACHE_ENABLE_ASYNC_LOADING=false and remove any conflicting "
+            "lmcache.enable_async_loading override."
+        )
+    if str(getattr(cfg, "cache_policy", "")).strip().upper() == "ATOM_SLRU":
+        from atom.kv_transfer.offload.cache_policy import register_slru_policy
+
+        cfg.cache_policy = "ATOM_SLRU"
+        register_slru_policy()
     # cufile GDS has no NVMe-GDS hardware here and hangs on init; force off.
     if getattr(cfg, "use_gds", False):
         cfg.use_gds = False
-    # TP>1 fix: only rank 0 serves/answers the ZMQ lookup. Without this the
-    # client queries all ranks and takes min() over results; we observed rank!=0
-    # engine.lookup returning 0 even though that rank stored the chunk
-    # (contains()=True) -> min(0, hit)=0 -> the scheduler never sees the hit and
-    # always recomputes. Our connector saves on ALL ranks in lockstep, so rank 0
-    # is authoritative for "is it offloaded?"; each rank still loads its own KV
-    # shard, and _do_load is all-or-nothing (re-prefills if a shard is missing).
-    cfg.lookup_server_worker_ids = [0]
+    # Legacy rank-0 lookup avoids cold-rank false negatives. Under capacity
+    # pressure it cannot guarantee residency or pins on other shards; callers
+    # may explicitly request all ranks, whose minimum is the loadable prefix.
     validate_lmcache_storage_config(cfg)
     return cfg
 
@@ -407,7 +420,7 @@ def lmcache_replica_world_size(config) -> int:
 
     Worker ids index this replica-local grid rather than the global one.
     LMCache selects its lookup servers by worker id
-    (``cfg.lookup_server_worker_ids``, pinned to ``[0]`` above), so global
+    (``cfg.lookup_server_worker_ids``, defaulting to ``[0]``), so global
     numbering would leave every replica except the first without a server.
     Replica-local ids are also the right cache-key component: id ``i`` means
     "shard i of the model", which holds the same bytes in every replica, so

--- a/atom/kv_transfer/offload/dense/connector.py
+++ b/atom/kv_transfer/offload/dense/connector.py
@@ -372,6 +372,7 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         self._load_lifecycles: dict[str, object] = {}
         self._active_load_operations: dict[str, tuple[object, LoadOperationId]] = {}
         self._lookup_in_step: list[str] = []
+        self._lookup_results: dict[str, tuple[object, int]] = {}
         self._handoff_loads: set[str] = set()
         # Unaligned handoff is always on: when the HBM prefix-cache hit is not
         # chunk-aligned, recompute the misaligned head up to the next chunk
@@ -428,8 +429,24 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         self._begin_load_lifecycle(seq)
         num_prompt = seq.num_prompt_tokens
         token_ids = list(seq.token_ids[:num_prompt])
+        sid = str(seq.id)
+        pending = self._lookup_results.get(sid)
+        if pending is not None and pending[0] is not seq:
+            # An older lifecycle still owns this worker-side pin. Its cleanup
+            # must be dispatched before the ID can acquire a new lease.
+            return 0, False
         try:
-            hit = self._lookup_client.lookup(token_ids, lookup_id=str(seq.id))
+            if pending is None:
+                if sid not in self._lookup_in_step:
+                    self._lookup_in_step.append(sid)
+                self._lookup_results[sid] = (seq, 0)
+                hit = self._lookup_client.lookup(token_ids, lookup_id=sid)
+                if hit is None:
+                    self._lookup_results.pop(sid, None)
+                else:
+                    self._lookup_results[sid] = (seq, int(hit))
+            else:
+                hit = pending[1]
         except Exception:
             logger.exception("LMCache offload lookup failed for seq %s", seq.id)
             return 0, False
@@ -463,17 +480,9 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         self._hit_save_floors[sid] = self._chunk_floor(hit)
         need = hit - int(seq.num_cached_tokens)
         if need <= 0:
-            if self._lookup_client is not None:
-                try:
-                    self._lookup_client.clear_lookup_status(sid)
-                except Exception:
-                    logger.debug(
-                        "LMCache offload: lookup status cleanup failed for req=%s",
-                        sid,
-                        exc_info=True,
-                    )
+            self._clear_pending_load(sid)
+            self._hit_save_floors[sid] = self._chunk_floor(hit)
             return 0, False
-        self._lookup_in_step.append(sid)
         self._load_specs[sid] = LoadSpec(
             hbm_cached_tokens=int(seq.num_cached_tokens),
             lmcache_cached_tokens=hit,
@@ -519,9 +528,8 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         self._handoff_loads.discard(sid)
         self._load_save_floors.pop(sid, None)
         self._hit_save_floors.pop(sid, None)
-        self._lookup_in_step = [
-            req_id for req_id in self._lookup_in_step if req_id != sid
-        ]
+        # clear_lookup_status only clears the client's memo; it does not
+        # release worker pins. Keep the ID for the next metadata dispatch.
         if self._lookup_client is not None:
             try:
                 self._lookup_client.clear_lookup_status(sid)
@@ -635,7 +643,11 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
                     load_operation=load_operation,
                 )
             )
-        meta.lookup_requests_in_step = list(self._lookup_in_step)
+        meta.lookup_requests_in_step = [
+            sid
+            for sid in self._lookup_in_step
+            if sid in loading_sids or sid not in self._load_specs
+        ]
         # Saves: store fully computed prompt chunks. Under scheduler-side
         # chunked prefill, seq.num_cached_tokens advances after each prefill
         # chunk's forward has completed; use it as the D2H-safe frontier.
@@ -691,6 +703,8 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
             self._save_inflight[sid] = save_operation
             self._save_rr_last = sid
         dispatched = set(meta.lookup_requests_in_step)
+        for sid in dispatched:
+            self._lookup_results.pop(sid, None)
         self._lookup_in_step = [
             sid for sid in self._lookup_in_step if sid not in dispatched
         ]
@@ -715,7 +729,7 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         """
 
     def has_pending_work(self) -> bool:
-        """True while a load still needs dispatch or a save is unreported.
+        """True while a load/cleanup is dispatchable or a save is unreported.
 
         Feeds ``EngineCore.has_pending_kv_work()``, so it reads only state
         that clears itself: ``_reqs_need_recv`` is emptied by every
@@ -724,8 +738,16 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         Saves that are queued but not yet dispatched are covered there by the
         scheduler's ``deferred_free_blocks``, which ``should_defer_free``
         keeps populated for exactly those requests.
+
+        A pre-allocation lookup belongs to a waiting request. Keep its pin,
+        but do not advertise idle work until allocation or cancellation makes
+        a load or cleanup dispatchable in ``build_connector_meta``.
         """
-        return bool(self._reqs_need_recv) or bool(self._save_inflight)
+        return (
+            bool(self._reqs_need_recv)
+            or bool(self._save_inflight)
+            or any(sid not in self._load_specs for sid in self._lookup_in_step)
+        )
 
     def save_finished(self, req_id) -> None:
         sid = str(req_id.req_id if isinstance(req_id, SaveOperationId) else req_id)

--- a/atom/model_engine/block_manager.py
+++ b/atom/model_engine/block_manager.py
@@ -131,7 +131,12 @@ class BlockManager:
         # The compressed KV blocks. Same class the sliding window uses for its
         # own index space — hash eviction has to happen at the same moment in
         # both or a prefix hit could be honoured by one pool and not the other.
-        self.kv = BlockPool(num_blocks, on_evict=self._record_evicted)
+        self.kv = BlockPool(
+            num_blocks,
+            on_evict=self._record_evicted,
+            cache_policy=envs.ATOM_PREFIX_CACHE_POLICY,
+            protected_ratio=envs.ATOM_PREFIX_CACHE_PROTECTED_RATIO,
+        )
         # Per-request cache slot pool. Used by attention types with a
         # stateful per-request buffer (GDN recurrent state, V4 compressor
         # state). The backing tensor is pre-allocated by ModelRunner and

--- a/atom/model_engine/block_pool.py
+++ b/atom/model_engine/block_pool.py
@@ -58,6 +58,11 @@ class BlockPool:
     freed again, which is the LRU order inverted for exactly the blocks being
     reused most. Removing it costs O(1) here and O(n) from a deque, on a path
     that runs once per hit block.
+
+    Optional ``slru`` puts blocks claimed for reuse into a bounded protected
+    queue on release. New content remains probationary until claimed, so a
+    stream of one-off prefixes cannot evict the whole hot set. Vacant blocks
+    still go first; referenced blocks are never candidates in either policy.
     """
 
     def __init__(
@@ -65,7 +70,18 @@ class BlockPool:
         num_blocks: int,
         on_evict: Callable[[int], None] | None = None,
         max_blocks: int | None = None,
+        cache_policy: str = "lru",
+        protected_ratio: float = 0.5,
     ):
+        cache_policy = cache_policy.strip().lower()
+        if cache_policy not in {"lru", "slru"}:
+            raise ValueError(f"unknown prefix cache policy: {cache_policy!r}")
+        if not 0 < protected_ratio < 1:
+            raise ValueError("protected_ratio must be between 0 and 1")
+        self.cache_policy = cache_policy
+        self.protected_ratio = protected_ratio
+        self._protected: OrderedDict[int, None] = OrderedDict()
+        self._reused: set[int] = set()
         # `max_blocks` is how far `extend` may go, and so how many Block
         # objects exist. It is the pool's share of a fixed plane rather than
         # its current size; a pool with a pinned boundary passes neither and
@@ -180,6 +196,8 @@ class BlockPool:
         # only ever decided from its hash — so the split has to be redrawn
         # here rather than left to drift.
         self._cached.clear()
+        self._protected.clear()
+        self._reused.clear()
         self._vacant = sorted(self._free)
         heapify(self._vacant)
 
@@ -192,6 +210,8 @@ class BlockPool:
         callers that count evictions must not count those.
         """
         block = self.blocks[block_id]
+        self._protected.pop(block_id, None)
+        self._reused.discard(block_id)
         dropped = False
         if block.hash != -1 and self._hash_to_block_id.get(block.hash) == block_id:
             del self._hash_to_block_id[block.hash]
@@ -223,6 +243,11 @@ class BlockPool:
             if block_id in self._free and self.blocks[block_id].hash != -1:
                 self._free.discard(block_id)
                 return block_id
+        while self._protected:
+            block_id, _ = self._protected.popitem(last=False)
+            if block_id in self._free and self.blocks[block_id].hash != -1:
+                self._free.discard(block_id)
+                return block_id
         return -1
 
     def pop(self) -> int:
@@ -241,6 +266,7 @@ class BlockPool:
         """
         self._free.discard(block_id)
         self._cached.pop(block_id, None)
+        self._protected.pop(block_id, None)
 
     def allocate(self, block_id: int) -> Block:
         """Take `block_id` for fresh content, evicting whatever it held."""
@@ -261,6 +287,8 @@ class BlockPool:
         every other request that could still hit it.
         """
         block = self.blocks[block_id]
+        if self.cache_policy == "slru" and block.hash != -1:
+            self._reused.add(block_id)
         if block_id in self._used:
             block.ref_count += 1
         else:
@@ -282,7 +310,11 @@ class BlockPool:
         self._used.remove(block_id)
         self._free.add(block_id)
         if block.hash != -1:
-            self._cached[block_id] = None
+            if block_id in self._reused:
+                self._protected[block_id] = None
+                self._trim_protected()
+            else:
+                self._cached[block_id] = None
             return
         heappush(self._vacant, block_id)
         # Stale entries are skipped, not removed, so the heap can outgrow the
@@ -291,6 +323,14 @@ class BlockPool:
         if len(self._vacant) > 2 * self.num_blocks + 2:
             self._vacant = [b for b in self._free if self.blocks[b].hash == -1]
             heapify(self._vacant)
+
+    def _trim_protected(self) -> None:
+        # Bound protection so new prefixes can compete for cache space.
+        limit = int(self.num_blocks * self.protected_ratio)
+        while len(self._protected) > limit:
+            block_id, _ = self._protected.popitem(last=False)
+            self._reused.discard(block_id)
+            self._cached[block_id] = None
 
     def reserve_units(self, count: int, owner: Hashable) -> list[int] | None:
         """Reserve arbitrary PAGE-sized units for raw storage."""
@@ -369,6 +409,7 @@ class BlockPool:
                 return None
             self._adopt(destination, top)
         self.num_blocks -= 1
+        self._trim_protected()
         return BlockRetirement(top, destination)
 
     def _adopt(self, destination: int, source: int) -> None:
@@ -385,6 +426,9 @@ class BlockPool:
         if self._unindex(destination):
             self.blocks_retired += 1
         src, dst = self.blocks[source], self.blocks[destination]
+        if source in self._reused:
+            self._reused.discard(source)
+            self._reused.add(destination)
         dst.ref_count, dst.hash, dst.token_ids = src.ref_count, src.hash, src.token_ids
         if src.hash != -1 and self._hash_to_block_id.get(src.hash) == source:
             self._hash_to_block_id[src.hash] = destination

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -1803,6 +1803,13 @@ class Scheduler:
         seq.status = SequenceStatus.FINISHED
         seq.leave_reason = "aborted"
         self._rejected.append(seq)
+        if not has_inflight_load and self._connector_flag("is_offload"):
+            # A lookup can pin CPU KV before HBM allocation succeeds. No load
+            # is in flight yet, but the connector still owns cleanup work.
+            # Already-dispatched loads retain the completion-driven path below.
+            self.kv_connector.cancel_pending_load(seq)
+            self.deferred_free_blocks[seq.id] = seq
+            self._maybe_release_deferred(seq)
         if not has_inflight_load or not self._connector_flag("is_offload"):
             self._uncount_inflight_load(seq)
             return

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -23,6 +23,11 @@ from collections.abc import Callable
 from typing import Any
 
 environment_variables: dict[str, Callable[[], Any]] = {
+    # Protect reused KV prefixes from one-off prefill scans. Opt-in.
+    "ATOM_PREFIX_CACHE_POLICY": lambda: os.getenv("ATOM_PREFIX_CACHE_POLICY", "lru"),
+    "ATOM_PREFIX_CACHE_PROTECTED_RATIO": lambda: float(
+        os.getenv("ATOM_PREFIX_CACHE_PROTECTED_RATIO", "0.5")
+    ),
     # --- Data Parallelism ---
     "ATOM_DP_RANK": lambda: int(os.getenv("ATOM_DP_RANK", "0")),
     "ATOM_DP_RANK_LOCAL": lambda: int(os.getenv("ATOM_DP_RANK_LOCAL", "0")),

--- a/recipes/MiniMax-M3-Cache-Policies.md
+++ b/recipes/MiniMax-M3-Cache-Policies.md
@@ -1,0 +1,61 @@
+# MiniMax-M3 CPU-offload cache policies
+
+Improve prefix reuse under CPU-only offload without changing model weights,
+KV precision, context length, or cache-hit accounting.
+
+## Changes
+
+- **All-rank lookup:** honor explicit lookup-worker configuration. Each TP
+  rank updates its own cache recency and pins its KV shard; the minimum hit
+  length across ranks is the common restorable prefix. This avoids trusting
+  rank 0 when another rank has already evicted its shard.
+- **Pin lifecycle:** release unused lookup pins on misses, errors, skipped
+  loads, and cancellation, including aborts before HBM allocation. Retain
+  pins for pending loads and avoid duplicate lookup ownership or idle-drain
+  loops with no dispatchable work.
+- **Optional SLRU:** new data enters probation; reused data enters protection.
+  Evict probationary data first, demoting older protected entries when the
+  limit is exceeded. HBM protection is capped at the configured fraction of
+  total pool blocks; CPU protection targets half the resident chunks.
+  Protected data remains evictable, but referenced/pinned data does not.
+  Separate CPU queues avoid scanning the protected segment for every
+  probationary eviction; pinned entries may still require scanning.
+
+## Configuration
+
+Set these before starting a TP4 server with LMCache offload enabled:
+
+```bash
+export ATOM_PREFIX_CACHE_POLICY=slru
+export ATOM_PREFIX_CACHE_PROTECTED_RATIO=0.5
+export LMCACHE_CACHE_POLICY=ATOM_SLRU
+export LMCACHE_LOOKUP_SERVER_WORKER_IDS=0,1,2,3
+```
+
+Without explicit settings, HBM/CPU retain LRU and lookup defaults to rank 0.
+The shared pin-lifecycle fix applies independently of SLRU. Only synchronous
+lookup is supported: enabling `LMCACHE_ENABLE_ASYNC_LOADING` is rejected at
+startup.
+
+## Results and validation
+
+MiniMax-M3 FP4, TP4, FP8 KV, 48 concurrency, 1800s profiling,
+256 GiB CPU cache per rank, no NVMe, and synthetic acceptance 0.5933.
+Both runs enabled HBM/CPU SLRU and the pin fix; **only lookup scope changed**.
+
+| Metric | Rank 0 only | All-rank |
+|---|---:|---:|
+| Total prompt cache hit rate | 82.86% | 95.48% |
+| Total throughput (tokens/s) | 86,770.56 | 171,373.84 |
+| Total throughput per GPU (tokens/s/GPU) | 21,692.64 | 42,843.46 |
+| P90 ITL (ms) | 66.94 | 24.35 |
+
+These are final AIPerf exports; the all-rank submission was valid. The
+comparison demonstrates the lookup-scope benefit, **not SLRU's independent
+contribution**. GPU measurements predate the rebase and review fixes and
+have not been rerun.
+
+**604 regression tests passed; 1 known environment-dependent test was
+deselected** because it assumes LMCache is absent. Coverage includes cache
+retention, pin safety, allocation-wait cancellation, async-mode rejection,
+and bounded probationary-eviction scans.

--- a/tests/test_block_pool.py
+++ b/tests/test_block_pool.py
@@ -35,6 +35,112 @@ def published(pool: BlockPool, block_id: int, h: int) -> int:
 
 
 class TestHandOutOrder:
+    @pytest.mark.parametrize("policy", ["SLRU", " slru ", " SlRu ", " LRU "])
+    def test_policy_names_are_normalized(self, policy):
+        pool = BlockPool(num_blocks=4, cache_policy=policy)
+        assert pool.cache_policy == policy.strip().lower()
+
+    @pytest.mark.parametrize("policy,retained", [("lru", False), ("slru", True)])
+    def test_reused_prefix_survives_a_stream_of_one_off_suffixes(
+        self, policy, retained
+    ):
+        pool = BlockPool(num_blocks=8, cache_policy=policy)
+        for h in range(100, 108):
+            published(pool, pool.pop(), h)
+        # Claims correspond to a later request actually reusing the full prefix.
+        prefix = [pool.lookup(h) for h in range(100, 104)]
+        for block_id in prefix:
+            pool.claim(block_id)
+        for block_id in reversed(prefix):
+            pool.free(block_id)
+        for h in range(200, 216):
+            published(pool, pool.pop(), h)
+        assert all(pool.lookup(h) >= 0 for h in range(100, 104)) is retained
+        assert pool.num_free == 8
+
+    def test_slru_demotion_allows_the_hot_set_to_change(self):
+        pool = BlockPool(num_blocks=4, cache_policy="slru")
+        for h in range(4):
+            published(pool, pool.pop(), h)
+        for h in range(4):
+            block_id = pool.lookup(h)
+            pool.claim(block_id)
+            pool.free(block_id)
+        published(pool, pool.pop(), 10)
+        published(pool, pool.pop(), 11)
+        assert pool.lookup(0) == pool.lookup(1) == -1
+        assert pool.lookup(2) >= 0 and pool.lookup(3) >= 0
+
+    def test_slru_never_evicts_referenced_blocks_and_clears_protection(self):
+        pool = BlockPool(num_blocks=4, cache_policy="slru")
+        for h in range(4):
+            published(pool, pool.pop(), h)
+        held = pool.lookup(0)
+        pool.claim(held)
+        for h in range(10, 20):
+            published(pool, pool.pop(), h)
+        assert pool.lookup(0) == held
+        assert pool.block(held).ref_count == 1
+        pool.free(held)
+        pool.clear_index()
+        for h in range(30, 34):
+            published(pool, pool.pop(), h)
+        assert pool.num_indexed == pool.num_free == 4
+
+    def test_slru_relocation_and_shrink_preserve_live_content(self):
+        pool = BlockPool(num_blocks=4, cache_policy="slru")
+        for h in range(4):
+            published(pool, pool.pop(), h)
+        pool.claim(3)
+        retirement = pool.retire_top()
+        assert retirement is not None
+        assert pool.lookup(3) == retirement.moved_to
+        assert pool.block(retirement.moved_to).ref_count == 1
+        pool.free(retirement.moved_to)
+        assert pool.num_blocks == pool.num_free == 3
+        for h in range(10, 15):
+            published(pool, pool.pop(), h)
+        assert pool.lookup(3) == retirement.moved_to
+
+    @pytest.mark.parametrize("policy", ["lru", "slru"])
+    def test_claim_free_allocate_churn_keeps_ownership_consistent(self, policy):
+        import random
+
+        rng = random.Random(42)
+        pool = BlockPool(num_blocks=16, cache_policy=policy)
+        holders = {}
+        for h in range(500):
+            action = rng.randrange(3)
+            if action == 0 and holders:
+                block_id = rng.choice(list(holders))
+                pool.free(block_id)
+                holders[block_id] -= 1
+                if not holders[block_id]:
+                    del holders[block_id]
+            elif action == 1 and pool.num_indexed:
+                candidates = [i for i in range(h) if pool.lookup(i) >= 0]
+                if candidates:
+                    block_id = pool.lookup(rng.choice(candidates))
+                    pool.claim(block_id)
+                    holders[block_id] = holders.get(block_id, 0) + 1
+            elif pool.num_free:
+                block_id = pool.pop()
+                assert block_id not in holders
+                pool.allocate(block_id)
+                pool.publish(block_id, h, toks(h))
+                holders[block_id] = 1
+            assert pool.num_used == len(holders)
+            assert pool.num_free + pool.num_used == 16
+            for block_id, count in holders.items():
+                assert pool.block(block_id).ref_count == count
+
+    @pytest.mark.parametrize(
+        "policy,ratio", [("unknown", 0.5), ("slru", 0), ("slru", 1)]
+    )
+    def test_invalid_policy_configuration_is_rejected(self, policy, ratio):
+        with pytest.raises(ValueError):
+            BlockPool(4, cache_policy=policy, protected_ratio=ratio)
+
     def test_a_block_holding_nothing_goes_before_a_cached_one(self):
         pool = BlockPool(num_blocks=4)
         # 0 and 1 become cached, in that order; 2 and 3 were never used.

--- a/tests/test_dense_offload_connector.py
+++ b/tests/test_dense_offload_connector.py
@@ -22,6 +22,7 @@ from atom.kv_transfer.offload.metadata import (
     SaveSpec,
 )
 from atom.model_engine.scheduler import Scheduler
+from atom.model_engine.sequence import SequenceStatus
 
 
 def _config(role="offload"):
@@ -423,3 +424,185 @@ def test_dense_lookup_unpin_passes_one_string_id():
     finally:
         worker._save_executor.shutdown(wait=True)
         worker._load_executor.shutdown(wait=True)
+
+
+@pytest.mark.parametrize("outcome", ["hbm_hit", "small_hit", "cancel", "miss", "error"])
+def test_unused_lookup_releases_worker_pin(monkeypatch, outcome):
+    scheduler = _scheduler(monkeypatch, "kv_consumer")
+    worker = DenseOffloadConnector(_config("kv_consumer"))
+    pins = set()
+    calls = []
+
+    def lookup(_tokens, lookup_id):
+        pins.add(lookup_id)
+        calls.append(lookup_id)
+        if outcome == "error":
+            raise RuntimeError("lookup transport failed after a worker pinned")
+        return 0 if outcome == "miss" else 16
+
+    scheduler._lookup_client = SimpleNamespace(
+        lookup=lookup, clear_lookup_status=lambda _sid: None
+    )
+    worker._engine = SimpleNamespace(lookup_unpin=pins.discard)
+    seq = _load_seq(52, num_prompt_tokens=24)
+    if outcome == "hbm_hit":
+        seq.num_cached_tokens = 16
+    try:
+        scheduler.get_num_new_matched_tokens(seq)
+        if outcome == "cancel":
+            scheduler.cancel_pending_load(seq)
+        elif outcome == "small_hit":
+            scheduler.update_state_after_alloc(seq)
+        else:
+            # Repeated scheduler probes must not acquire another pin lease.
+            scheduler.get_num_new_matched_tokens(seq)
+        assert calls == ["52"]
+        assert scheduler.has_pending_work()
+        metadata = scheduler.build_connector_meta()
+        assert metadata.lookup_requests_in_step == ["52"]
+        worker.start_load_kv(metadata)
+        assert pins == set()
+        assert not scheduler.has_pending_work()
+    finally:
+        worker.close()
+
+
+def test_pending_load_keeps_pin_until_cancelled(monkeypatch):
+    scheduler = _scheduler(monkeypatch, "kv_consumer")
+    scheduler._lookup_client = SimpleNamespace(
+        lookup=lambda *_args, **_kwargs: 16,
+        clear_lookup_status=lambda _sid: None,
+    )
+    seq = _load_seq(53, num_prompt_tokens=24)
+    assert scheduler.get_num_new_matched_tokens(seq) == (16, True)
+    # A pre-allocation lookup is owned by the waiting request, not dispatchable
+    # idle work. It must retain its pin without keeping the idle drain alive.
+    assert not scheduler.has_pending_work()
+    assert scheduler.build_connector_meta().lookup_requests_in_step == []
+    scheduler.cancel_pending_load(seq)
+    assert scheduler.has_pending_work()
+    assert scheduler.build_connector_meta().lookup_requests_in_step == ["53"]
+    assert scheduler.build_connector_meta().lookup_requests_in_step == []
+
+
+def test_scheduler_abort_before_allocation_releases_lookup_pin(
+    monkeypatch, scheduler, seq_factory
+):
+    connector = _scheduler(monkeypatch, "kv_consumer")
+    worker = DenseOffloadConnector(_config("kv_consumer"))
+    pins = set()
+    calls = []
+
+    def lookup(_tokens, lookup_id):
+        calls.append(lookup_id)
+        pins.add(lookup_id)
+        return 16
+
+    connector._lookup_client = SimpleNamespace(
+        lookup=lookup, clear_lookup_status=lambda _sid: None
+    )
+    worker._engine = SimpleNamespace(lookup_unpin=pins.discard)
+    scheduler.kv_connector = connector
+    seq = seq_factory(list(range(24)))
+    scheduler.add(seq)
+    allocation_attempts = []
+
+    def cannot_allocate(value):
+        allocation_attempts.append(value.id)
+        return -1
+
+    monkeypatch.setattr(scheduler.block_manager, "can_allocate", cannot_allocate)
+    sid = str(seq.id)
+    try:
+        scheduler.schedule()
+        assert list(scheduler.waiting) == [seq]
+        assert calls == [sid]
+        assert allocation_attempts == [seq.id]
+        assert pins == {sid}
+        assert sid in connector._load_specs
+        assert not getattr(seq, "_counted_as_inflight_load", False)
+        assert connector.build_connector_meta().lookup_requests_in_step == []
+
+        seq.status = SequenceStatus.ABORTED
+        batch, scheduled = scheduler.schedule()
+        assert seq.status == SequenceStatus.FINISHED
+        assert scheduler._num_parked_remote_kv == 0
+        assert sid not in connector._load_specs
+        assert sid not in connector._load_lifecycles
+        assert scheduler.deferred_free_blocks == {}
+        assert scheduled == {}
+        # schedule() already dispatched cleanup into this empty batch.
+        meta = batch.connector_meta_output
+        assert meta.requests == []
+        assert meta.lookup_requests_in_step == [sid]
+        worker.start_load_kv(meta)
+        assert pins == set()
+        assert connector._lookup_results == {}
+        assert not connector.has_pending_work()
+        assert connector.build_connector_meta().lookup_requests_in_step == []
+    finally:
+        worker.close()
+
+
+def test_lookup_id_reuse_does_not_consume_an_old_pin(monkeypatch):
+    scheduler = _scheduler(monkeypatch, "kv_consumer")
+    calls = []
+    scheduler._lookup_client = SimpleNamespace(
+        lookup=lambda _tokens, lookup_id: calls.append(lookup_id) or 16,
+        clear_lookup_status=lambda _sid: None,
+    )
+    old = _load_seq(54, num_prompt_tokens=24)
+    new = _load_seq(54, num_prompt_tokens=32)
+    scheduler.get_num_new_matched_tokens(old)
+    scheduler.cancel_pending_load(old)
+    assert scheduler.get_num_new_matched_tokens(new) == (0, False)
+    assert calls == ["54"]
+    assert scheduler.build_connector_meta().lookup_requests_in_step == ["54"]
+    assert scheduler.get_num_new_matched_tokens(new) == (16, True)
+    assert calls == ["54", "54"]
+
+
+def test_hbm_catches_up_after_a_pending_cpu_lookup(monkeypatch):
+    scheduler = _scheduler(monkeypatch, "kv_consumer")
+    scheduler._lookup_client = SimpleNamespace(
+        lookup=lambda *_args, **_kwargs: 16,
+        clear_lookup_status=lambda _sid: None,
+    )
+    seq = _load_seq(55, num_prompt_tokens=24)
+    assert scheduler.get_num_new_matched_tokens(seq) == (16, True)
+    seq.num_cached_tokens = 16
+    assert scheduler.get_num_new_matched_tokens(seq) == (0, False)
+    metadata = scheduler.build_connector_meta()
+    assert metadata.lookup_requests_in_step == ["55"]
+    assert metadata.requests == []
+
+
+def test_cpu_pin_is_retained_until_retrieve_finishes(monkeypatch):
+    scheduler = _scheduler(monkeypatch, "kv_consumer")
+    scheduler._min_load_tokens = 0
+    scheduler._lookup_client = SimpleNamespace(
+        lookup=lambda *_args, **_kwargs: 16,
+        clear_lookup_status=lambda _sid: None,
+    )
+    seq = _load_seq(56, num_prompt_tokens=24)
+    scheduler.get_num_new_matched_tokens(seq)
+    scheduler.update_state_after_alloc(seq)
+    metadata = scheduler.build_connector_meta()
+    pins = {"56"}
+
+    def retrieve(_tokens, *, mask, **_kwargs):
+        assert pins == {"56"}
+        return mask.clone()
+
+    worker = DenseOffloadConnector(_config("kv_consumer"))
+    worker.chunk_size = 8
+    worker._engine = SimpleNamespace(retrieve=retrieve, lookup_unpin=pins.discard)
+    try:
+        worker.start_load_kv(metadata)
+        worker.close()
+        assert pins == set()
+        assert worker.get_finished().finished_loading == {
+            metadata.requests[0].load_operation
+        }
+    finally:
+        worker.close()

--- a/tests/test_offload_cache_policy.py
+++ b/tests/test_offload_cache_policy.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from collections import OrderedDict
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("lmcache")
+
+from atom.kv_transfer.offload.cache_policy import SLRUCachePolicy, register_slru_policy
+
+
+def test_reused_cpu_prefix_survives_scan():
+    policy = SLRUCachePolicy()
+    cache = OrderedDict()
+    for key in range(8):
+        cache[key] = SimpleNamespace(can_evict=True)
+        policy.update_on_put(key)
+    # LMCache touches a prefix in reverse order so the head stays newest.
+    for key in reversed(range(4)):
+        policy.update_on_hit(key, cache)
+    for key in range(10, 30):
+        (victim,) = policy.get_evict_candidates(cache)
+        del cache[victim]
+        cache[key] = SimpleNamespace(can_evict=True)
+        policy.update_on_put(key)
+    assert all(key in cache for key in range(4))
+    assert len(cache) == 8
+
+
+def test_cpu_policy_respects_pins_and_can_evict_protected_data():
+    policy = SLRUCachePolicy()
+    cache = OrderedDict((key, SimpleNamespace(can_evict=True)) for key in range(4))
+    for key in cache:
+        policy.update_on_put(key)
+    policy.update_on_hit(0, cache)
+    policy.update_on_hit(1, cache)
+    cache[2].can_evict = cache[3].can_evict = False
+    assert policy.get_evict_candidates(cache, 3) == [0, 1]
+    for value in cache.values():
+        value.can_evict = False
+    assert policy.get_evict_candidates(cache) == []
+
+
+def test_cpu_hot_set_can_change_and_explicit_removal_is_safe():
+    policy = SLRUCachePolicy()
+    cache = OrderedDict((key, SimpleNamespace(can_evict=True)) for key in range(4))
+    for key in cache:
+        policy.update_on_put(key)
+    for key in range(4):
+        policy.update_on_hit(key, cache)
+    assert policy.get_evict_candidates(cache, 2) == [0, 1]
+    del cache[2]
+    policy.update_on_force_evict(2)
+    assert set(policy.get_evict_candidates(cache, 10)) == {0, 1, 3}
+
+
+def test_cpu_policy_is_available_through_lmcache_registry():
+    from lmcache.v1.storage_backend.cache_policy import get_cache_policy
+
+    register_slru_policy()
+    assert isinstance(get_cache_policy("ATOM_SLRU"), SLRUCachePolicy)
+
+
+@pytest.mark.parametrize("all_ranks", [False, True])
+def test_offload_configuration_keeps_lookup_scope_explicit(monkeypatch, all_ranks):
+    from lmcache.v1.config import LMCacheEngineConfig
+
+    from atom.kv_transfer.offload.config import build_lmcache_config
+
+    monkeypatch.setattr(
+        LMCacheEngineConfig,
+        "from_env",
+        lambda: SimpleNamespace(
+            cache_policy="LRU",
+            lookup_server_worker_ids=None,
+            local_cpu=True,
+            max_local_cpu_size=256,
+            local_disk=None,
+            max_local_disk_size=0,
+        ),
+    )
+    extra = {"lmcache.cache_policy": "ATOM_SLRU"}
+    if all_ranks:
+        extra["lmcache.lookup_server_worker_ids"] = []
+    cfg = build_lmcache_config({"kv_connector_extra_config": extra})
+    assert cfg.lookup_server_worker_ids == ([] if all_ranks else [0])
+    assert cfg.max_local_cpu_size == 256
+    assert cfg.local_disk is None
+
+
+def test_all_rank_lookup_env_reaches_the_lmcache_factory(monkeypatch):
+    from atom.kv_transfer.offload.config import build_lmcache_config
+
+    monkeypatch.setenv("LMCACHE_LOOKUP_SERVER_WORKER_IDS", "0,1,2,3")
+    cfg = build_lmcache_config()
+    assert cfg.get_lookup_server_worker_ids(use_mla=False, world_size=4) == [0, 1, 2, 3]
+
+
+@pytest.mark.parametrize("source", ["env", "extra"])
+def test_async_loading_is_rejected_before_lookup_factory(monkeypatch, source):
+    from atom.kv_transfer.offload.config import build_lmcache_config
+
+    monkeypatch.setenv(
+        "LMCACHE_ENABLE_ASYNC_LOADING", "true" if source == "env" else "false"
+    )
+    config = (
+        {"kv_connector_extra_config": {"lmcache.enable_async_loading": True}}
+        if source == "extra"
+        else None
+    )
+    with pytest.raises(ValueError, match="LMCACHE_ENABLE_ASYNC_LOADING"):
+        build_lmcache_config(config)
+
+
+def test_sync_loading_remains_supported(monkeypatch):
+    from atom.kv_transfer.offload.config import build_lmcache_config
+
+    monkeypatch.setenv("LMCACHE_ENABLE_ASYNC_LOADING", "false")
+    assert build_lmcache_config().enable_async_loading is False
+
+
+@pytest.mark.parametrize("source", ["env", "extra"])
+def test_slru_config_normalizes_case_and_whitespace(monkeypatch, source):
+    from lmcache.v1.storage_backend.cache_policy import get_cache_policy
+
+    from atom.kv_transfer.offload.config import build_lmcache_config
+
+    monkeypatch.setenv("LMCACHE_ENABLE_ASYNC_LOADING", "false")
+    monkeypatch.setenv(
+        "LMCACHE_CACHE_POLICY", " atom_slru " if source == "env" else "LRU"
+    )
+    config = (
+        {"kv_connector_extra_config": {"lmcache.cache_policy": " Atom_Slru "}}
+        if source == "extra"
+        else None
+    )
+    cfg = build_lmcache_config(config)
+    assert cfg.cache_policy == "ATOM_SLRU"
+    assert isinstance(get_cache_policy(cfg.cache_policy), SLRUCachePolicy)
+
+
+@pytest.mark.parametrize("size", [8, 1024, 10000])
+def test_probationary_eviction_does_not_scan_protected_segment(size):
+    class CountedCache(OrderedDict):
+        visits = 0
+
+        def items(self):
+            for item in super().items():
+                self.visits += 1
+                yield item
+
+        def get(self, key, default=None):
+            self.visits += 1
+            return super().get(key, default)
+
+    cache = CountedCache()
+    policy = SLRUCachePolicy()
+    for key in range(size):
+        cache[key] = SimpleNamespace(can_evict=True)
+        policy.update_on_put(key)
+    for key in range(size // 2):
+        policy.update_on_hit(key, cache)
+    for key in range(size, size + size // 2):
+        (victim,) = policy.get_evict_candidates(cache)
+        del cache[victim]  # Normal backend eviction does not issue a callback.
+        cache[key] = SimpleNamespace(can_evict=True)
+        policy.update_on_put(key)
+
+    # Steady-state puts sit behind the protected half in the backend mapping.
+    # Each eviction should only inspect one stale entry and its next victim.
+    for key in range(2 * size, 3 * size):
+        cache.visits = 0
+        (victim,) = policy.get_evict_candidates(cache)
+        assert cache.visits <= 2
+        assert victim >= size
+        del cache[victim]
+        cache[key] = SimpleNamespace(can_evict=True)
+        policy.update_on_put(key)
+    assert all(key in cache for key in range(size // 2))
+
+
+def test_candidate_selection_survives_retry_pin_and_reinsertion():
+    policy = SLRUCachePolicy()
+    cache = OrderedDict((key, SimpleNamespace(can_evict=True)) for key in range(4))
+    for key in cache:
+        policy.update_on_put(key)
+    assert policy.get_evict_candidates(cache) == [0]
+    # Merely selecting a victim must not forget it if the caller does not evict.
+    assert policy.get_evict_candidates(cache) == [0]
+    cache[0].can_evict = False
+    assert policy.get_evict_candidates(cache) == [1]
+    cache[0].can_evict = True
+    assert policy.get_evict_candidates(cache) == [0]
+    del cache[0]
+    cache[0] = SimpleNamespace(can_evict=True)
+    policy.update_on_put(0)
+    assert policy.get_evict_candidates(cache) == [1]
+    del cache[1]
+    policy.update_on_force_evict(1)
+    assert policy.get_evict_candidates(cache, 10) == [2, 3, 0]
+    assert policy.get_evict_candidates(cache, 0) == []
+    assert policy.get_evict_candidates(cache, -1) == []
+
+
+def test_stale_entries_in_both_queues_are_removed_lazily():
+    policy = SLRUCachePolicy()
+    cache = OrderedDict((key, SimpleNamespace(can_evict=True)) for key in range(6))
+    for key in cache:
+        policy.update_on_put(key)
+    policy.update_on_hit(0, cache)
+    policy.update_on_hit(1, cache)
+    del cache[0]
+    del cache[2]
+    for key in (3, 4, 5):
+        cache[key].can_evict = False
+    assert policy.get_evict_candidates(cache, 10) == [1]
+    assert 0 not in policy._protected
+    assert 2 not in policy._probationary


### PR DESCRIPTION
## Motivation

Improve MiniMax-M3 prefix-cache reuse under 48-concurrency, CPU-only KV offload.

The previous configuration forced LMCache lookup to rank 0. Under capacity pressure, rank 0 could report a hit while another TP rank had already evicted the corresponding KV shard. An incomplete cross-rank restore then forced the request to fall back to prefill.

## Technical Details

- Honor explicit LMCache lookup-worker configuration instead of unconditionally overriding it with rank 0. The tested M3 configuration sets `LMCACHE_LOOKUP_SERVER_WORKER_IDS=0,1,2,3` so all TP shards participate in lookup, recency updates, and pinning. The minimum hit length across ranks represents a prefix that can be restored by every rank.
- Fix lookup-pin lifecycle handling for misses, exceptions, HBM-satisfied requests, skipped loads, and cancellation. Reuse pending lookup results to avoid duplicate pin acquisition, while retaining pins for actual loads until retrieval completes.
- Add opt-in segmented LRU (SLRU) policies for HBM and CPU caches to protect reused prefixes from one-off prefill scans. CPU SLRU uses separate ordered probationary/protected queues, avoiding repeated scans of the protected segment during probationary eviction.
- Cancel lookup ownership when a waiting request is aborted before HBM allocation; dispatch worker cleanup and release request bookkeeping. Pre-allocation lookups retain pins without advertising non-dispatchable idle work.
- Reject `LMCACHE_ENABLE_ASYNC_LOADING=true` (including connector extra-config overrides) at startup. This connector supports synchronous lookup only; it does not implement the async polling/cancellation protocol.
- Normalize HBM policy names and the `ATOM_SLRU` option for case and surrounding whitespace.
- Add regression coverage and documentation for the cache policies and 48C/1800s benchmark comparison.

The shared defaults remain unchanged: HBM/CPU eviction stays LRU and lookup defaults to rank 0 unless explicitly configured. The pin-lifecycle fix applies to the shared DenseOffloadScheduler path independently of the SLRU switches.

## Test Plan

- Run the block-pool, block-manager, dense-offload, LMCache configuration/connector, cache-policy, offload-shell, Scheduler, and MultiConnector regression suites on the main-based branch.
- Compare rank-0-only lookup with all-rank lookup using MiniMax-M3 FP4, TP4, FP8 KV, 48 concurrent requests, 1800 seconds of profiling, CPU cache capacity of 256 GiB per rank, no NVMe, and `SYNTH_ACC_RATE=0.5933`.
- Keep both SLRU policies, the pin-lifecycle fix, and the workload unchanged between the two benchmark runs; change only lookup scope.

## Test Result

### AIPerf comparison

| Metric | Rank 0 only | All-rank |
|---|---:|---:|
| Total prompt cache hit rate | 82.86% | **95.48%** |
| Total throughput (tokens/s) | 86,770.56 | **171,373.84** |
| P90 ITL (ms) | 66.94 | **24.35** |

All-rank lookup improved the total prompt cache hit rate by **12.62 percentage points** and increased total throughput by approximately **1.98x**. With TP4, the all-rank result corresponds to **42,843.46 total tokens/s/GPU**. The final AIPerf submission was valid (`submission_valid=true`).

This comparison isolates the lookup-scope change within the tested configuration. It does **not** establish the independent benefit of SLRU, since both runs enabled SLRU and the pin-lifecycle fix.

### Regression validation and measurement scope

**604 tests passed; 1 known environment-dependent test was deselected.** The excluded test assumes LMCache is absent and also fails on the original checkout in this production container, where LMCache is installed. Black, Ruff, and diff checks passed.

Regression coverage now includes the real lookup-hit → HBM-allocation-wait → abort → worker-unpin path, async-mode rejection through environment and extra config, and deterministic eviction-scan bounds at 8 / 1,024 / 10,000 resident chunks. Candidate retries, pin/unpin transitions, reinsertion, and stale queue cleanup are also covered.

The performance comparison was measured before rebasing onto main and before these review fixes. The updated branch passed regression tests; GPU performance has not been remeasured.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
