### PR TITLE
Bound the all2all receive buffer by what the group sent, and hand a TBO ubatch the map its gather needs

### DIFF
--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -2330,6 +2330,7 @@ class ModelRunner:
         num_tokens_across_dp = None if sync is None else sync.num_tokens_across_dp
         tbo_collective_active = forward_mode.tbo_collective_active
         ub_max_tokens_across_dp = None if sync is None else sync.ub_max_tokens_across_dp
+        ub_tokens_across_dp = None if sync is None else sync.ub_tokens_across_dp
         running_tokens_are_unified = forward_mode.running_tokens_are_unified
 
         if not tbo_collective_active:
@@ -2399,6 +2400,7 @@ class ModelRunner:
             spec_decode_metadata=spec_decode_metadata,
             ubatch_slices=ubatch_slices,
             ub_max_tokens_across_dp=ub_max_tokens_across_dp,
+            ub_tokens_across_dp=ub_tokens_across_dp,
         )
 
     def prepare_sample(
@@ -3811,11 +3813,24 @@ class ModelRunner:
                         )
                     # Create ubatch slices for TBO capture (need > 2 requests)
                     ubatch_slices = None
+                    ub_tokens_across_dp = None
                     if is_tbo and self.config.enable_tbo_decode and bs > 2:
                         ubatch_slices = maybe_create_ubatch_slices(
                             num_reqs=bs,
                             num_tokens=num_tokens,
                         )
+                        # The rebuild above's symmetry, one level down: every
+                        # rank splits this bucket the same way, so a ubatch's
+                        # per-rank counts are its own repeated. Stated, because
+                        # a capture context declares its shape where a real step
+                        # reduces one, and no consumer can tell an absent
+                        # reduction from a uniform answer.
+                        if ubatch_slices and num_tokens_across_dp is not None:
+                            dp = len(num_tokens_across_dp)
+                            ub_tokens_across_dp = tuple(
+                                (s.token_slice.stop - s.token_slice.start,) * dp
+                                for s in ubatch_slices
+                            )
 
                     set_forward_context(
                         attn_metadata=attn_metadata,
@@ -3824,6 +3839,7 @@ class ModelRunner:
                         num_tokens=num_tokens,
                         num_tokens_across_dp=num_tokens_across_dp,
                         ubatch_slices=ubatch_slices,
+                        ub_tokens_across_dp=ub_tokens_across_dp,
                         in_hipgraph=True,
                     )
 

--- a/atom/model_ops/attentions/backends.py
+++ b/atom/model_ops/attentions/backends.py
@@ -770,12 +770,18 @@ class CommonAttentionBuilder(PoolRowsMixin, AttentionMetadataBuilder[T], Generic
         ctx = self._upload_prefill_mirrors(
             scheduled_bs, running_bs, scheduled_tokens, has_cached, cached_lens
         )
-        if has_cached:
+        if has_cached or tbo_enabled():
             # Layer-invariant, so built once here rather than in every layer's
             # prefix gather. On the device: `total_kv` has no upper bound.
             # `context_lens` is `running_bs` wide and its padded tail is zero,
             # so it still sums to exactly `total_kv` -- which is handed over so
             # the build does not stop the device to measure itself.
+            # Built with no prefix of its own under TBO, because `has_cached`
+            # can turn on AFTER the split: the ubatch whose first request
+            # straddles it re-attaches the half its partner wrote. Its K
+            # geometry is then `cached + all_new` per request -- the request
+            # range `split_attn_metadata` already slices out of this -- so the
+            # only way to get that slice wrong is to have nothing to slice.
             ctx["batch_id_per_k_token"] = build_batch_ids_device(
                 ctx["context_lens"], total=total_kv
             )

--- a/atom/model_ops/fused_moe/modular_kernel.py
+++ b/atom/model_ops/fused_moe/modular_kernel.py
@@ -1,16 +1,17 @@
 from abc import ABC, abstractmethod
-
+from collections.abc import Callable
 from dataclasses import dataclass
-from atom.model_ops.fused_moe.config import FusedMoEQuantConfig
-from atom.model_ops.fused_moe.utils import disable_inplace
-from atom.utils.tbo.ubatching import tbo_overlap_enabled
-from atom.utils.forward_context import get_forward_context
-import torch
-from typing import Callable, Optional, final
 from enum import Enum
+from typing import final
+
+import torch
 from aiter import ActivationType, QuantType
 from aiter.fused_moe import fused_moe
-from aiter.dist.parallel_state import get_dp_group
+
+from atom.model_ops.fused_moe.config import FusedMoEQuantConfig
+from atom.model_ops.fused_moe.utils import disable_inplace
+from atom.utils.forward_context import get_forward_context
+from atom.utils.tbo.ubatching import tbo_overlap_enabled
 
 
 class FusedMoEActivationFormat(Enum):
@@ -320,25 +321,30 @@ class FusedMoEModularKernel(torch.nn.Module):
     ):
         """Trim the mori dispatch buffer's dead tail before fused_moe.
 
-        Default (native/sglang/rtp) policy: under a uniform all-ranks-decode
-        batch, trim to the static running_tokens*dp bound so the shape is
-        consistent across cudagraph capture/replay. mori dispatch dedups per
-        destination rank, so a rank receives at most running_tokens per source
-        rank -- the bound must not multiply by topk. atom-vllm needs a different,
-        exact received-token trim for DP+EP mixed batches and overrides this
-        method via a plugin patch -- keep this body frontend-agnostic.
+        The bound is what the GROUP sent -- mori dedups per destination, so each
+        source rank contributes at most its own count, and never that times
+        topk. `running_tokens * dp_size` is the same number only while the group
+        is uniform; a TBO ubatch splits per-rank, and on the smaller rank the
+        product trims BELOW the `expert_num_tokens` fused_moe is driven by,
+        which walks moe_sorting's zero-fill off a workspace sized from the
+        trimmed width. A sum is the group's count however unevenly it was
+        reached, so nothing here excludes a ragged step either.
+
+        atom-vllm needs a different, exact received-token trim for DP+EP mixed
+        batches and overrides this method via a plugin patch -- keep this body
+        frontend-agnostic.
         """
         context = get_forward_context().context
         if context is None:
             return dispatch_a1, dispatch_scale, dispatch_ids, dispatch_weights
 
-        dp_size = get_dp_group().world_size
-        # running_tokens keeps the trimmed shape consistent capture-to-replay.
-        total_valid_tokens = context.running_tokens * dp_size
-        tokens_unified = getattr(
-            context, "running_tokens_are_unified", not context.is_prefill
+        across_dp = context.running_tokens_across_dp
+        assert across_dp is not None, (
+            "an all2all MoE needs the group's per-rank counts to bound what its "
+            "dispatch delivered; this step reached it with none reduced"
         )
-        if total_valid_tokens < dispatch_a1.shape[0] and tokens_unified:
+        total_valid_tokens = sum(across_dp)
+        if total_valid_tokens < dispatch_a1.shape[0]:
             dispatch_a1 = dispatch_a1[:total_valid_tokens]
             dispatch_ids = dispatch_ids[:total_valid_tokens]
             dispatch_weights = dispatch_weights[:total_valid_tokens]
@@ -360,15 +366,15 @@ class FusedMoEModularKernel(torch.nn.Module):
         expert_map: torch.Tensor | None = None,
         expert_mask: torch.Tensor | None = None,
         apply_router_weight_on_input: bool = False,
-        w1_scale: Optional[torch.Tensor] = None,
-        w2_scale: Optional[torch.Tensor] = None,
-        a1_scale: Optional[torch.Tensor] = None,
-        a2_scale: Optional[torch.Tensor] = None,
-        bias1: Optional[torch.Tensor] = None,
-        bias2: Optional[torch.Tensor] = None,
-        hidden_pad: Optional[int] = 0,
-        intermediate_pad: Optional[int] = 0,
-        moe_extra_args: Optional[dict] = None,
+        w1_scale: torch.Tensor | None = None,
+        w2_scale: torch.Tensor | None = None,
+        a1_scale: torch.Tensor | None = None,
+        a2_scale: torch.Tensor | None = None,
+        bias1: torch.Tensor | None = None,
+        bias2: torch.Tensor | None = None,
+        hidden_pad: int | None = 0,
+        intermediate_pad: int | None = 0,
+        moe_extra_args: dict | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
 
         if inplace and self.shared_experts is None and not disable_inplace():

--- a/atom/model_ops/fused_moe/mori_v2_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_v2_prepare_finalize.py
@@ -42,7 +42,6 @@ from typing import Any
 import torch
 import torch.distributed as dist
 from aiter import ActivationType, QuantType
-from aiter.dist.parallel_state import get_dp_group
 from aiter.ops.flydsl.moe_common import GateMode
 
 import atom.model_ops.fused_moe.modular_kernel as mk
@@ -531,40 +530,38 @@ class MoriV2ModularKernel(mk.FusedMoEModularKernel):
 
     Both transports get the same grid shrink. The dispatch arena is padded to a
     huge static token_num (ws * max_num_inp_token_per_rank) while the received
-    tokens occupy only the first ``total_recv`` rows, so under a uniform
-    all-ranks-decode batch it is capped at the static ``running_tokens*topk*dp``
-    bound (the V1/base policy): the grid-bound aiter kernels (route-ksplit
-    preshuffle, gather-reduce) then launch a grid sized to the decode bucket
-    instead of the full arena, and the single-block route/psum kernels shrink too.
+    tokens occupy only the first ``total_recv`` rows, so it is capped at the
+    static ``sum(running_tokens_across_dp)*topk`` bound (the V1/base policy):
+    the grid-bound aiter kernels (route-ksplit preshuffle, gather-reduce) then
+    launch a grid sized to what the group actually sent instead of the full
+    arena, and the single-block route/psum kernels shrink too.
     Gather slices the buffers here; the fused path passes the bound down as
     ``recv_token_bound`` because it never sees them.
     """
 
-    def _decode_recv_bound(self, topk_ids: torch.Tensor, arena_rows: int) -> int | None:
-        """Static recv-row bound for a uniform decode batch, else None (no shrink).
+    def _recv_bound(self, topk_ids: torch.Tensor, arena_rows: int) -> int | None:
+        """Recv-row bound for this step, or None when it does not shrink.
 
         Correctness / capture-safety:
-          * ``running_tokens`` is a python int, fixed per captured graph, so the
-            bound is static across capture/replay and no GPU->CPU sync is needed
-            (unlike reading the device ``total_recv``).
-          * Under uniform decode each of ``dp`` ranks holds ``running_tokens``,
-            each routed to ``topk`` experts; worst case every route lands on this
-            rank, so ``total_recv <= running_tokens*topk*dp``. The bound therefore
-            never drops a valid row, and the aiter kernels' device-side
-            ``num_valid_routes`` guard still skips the exact within-buffer tail
-            [total_recv, bound).
-          * Mixed/prefill batches keep the full arena, matching the base-class
-            guard.
+          * The counts are python ints, fixed per captured graph, so the bound is
+            static across capture/replay and no GPU->CPU sync is needed (unlike
+            reading the device ``total_recv``).
+          * The group holds ``sum(running_tokens_across_dp)`` rows, each routed
+            to ``topk`` experts; worst case every route lands on this rank, so
+            ``total_recv <= that_sum * topk``. The bound therefore never drops a
+            valid row, and the aiter kernels' device-side ``num_valid_routes``
+            guard still skips the exact within-buffer tail [total_recv, bound).
+            Why the sum and not ``running_tokens * dp``: see the base method.
         """
         context = get_forward_context().context
         if context is None:
             return None
-        tokens_unified = getattr(
-            context, "running_tokens_are_unified", not context.is_prefill
+        across_dp = context.running_tokens_across_dp
+        assert across_dp is not None, (
+            "an all2all MoE needs the group's per-rank counts to bound what its "
+            "dispatch delivered; this step reached it with none reduced"
         )
-        if not tokens_unified:
-            return None
-        bound = context.running_tokens * topk_ids.shape[1] * get_dp_group().world_size
+        bound = sum(across_dp) * topk_ids.shape[1]
         return bound if bound < arena_rows else None
 
     def _maybe_trim_dispatch_output(
@@ -576,7 +573,7 @@ class MoriV2ModularKernel(mk.FusedMoEModularKernel):
         topk_ids: torch.Tensor,
         expert_tokens_meta,
     ):
-        bound = self._decode_recv_bound(topk_ids, dispatch_a1.shape[0])
+        bound = self._recv_bound(topk_ids, dispatch_a1.shape[0])
         if bound is not None:
             dispatch_a1 = dispatch_a1[:bound]
             dispatch_ids = dispatch_ids[:bound]
@@ -617,7 +614,7 @@ class MoriV2ModularKernel(mk.FusedMoEModularKernel):
             bias2=kwargs.get("bias2"),
             a1_scale=kwargs.get("a1_scale"),
             a2_scale=kwargs.get("a2_scale"),
-            recv_token_bound=self._decode_recv_bound(
+            recv_token_bound=self._recv_bound(
                 topk_ids,
                 self.prepare_finalize.num_dispatchers() * mega.max_tokens_per_rank,
             ),

--- a/atom/utils/forward_context.py
+++ b/atom/utils/forward_context.py
@@ -498,6 +498,12 @@ class Context:
     # stood for "dp-attention is off", and readers needing the strong claim --
     # `_can_use_dp_sharded_head` above all -- silently got the weak one.
     running_tokens_are_unified: bool = True
+    # `running_tokens` for every rank, unreduced; this rank's entry IS
+    # `running_tokens`. Consumers reduce it, because they want different
+    # reductions: padding each rank up to the group is a MAX, an all2all's
+    # receive width holds what every rank sent and is a SUM. None where no DP
+    # reduction produced one, which is where the two coincide.
+    running_tokens_across_dp: tuple[int, ...] | None = None
     # The step's whole shape decision. Set by `prepare_model` via
     # `ForwardMode.decide`; None only on a capture context, which declares its
     # shape rather than reading one.
@@ -529,6 +535,7 @@ class Context:
         running_tokens: int = 0,
         is_draft: bool = False,
         running_tokens_are_unified: bool = True,
+        running_tokens_across_dp: tuple[int, ...] | None = None,
         forward_mode: ForwardMode | None = None,
         input_ids: torch.Tensor | None = None,
         ubatch_token_offset: int = 0,
@@ -543,6 +550,7 @@ class Context:
         self.running_tokens = running_tokens
         self.is_draft = is_draft
         self.running_tokens_are_unified = running_tokens_are_unified
+        self.running_tokens_across_dp = running_tokens_across_dp
         self.forward_mode = forward_mode
         self.input_ids = input_ids
         self.ubatch_token_offset = ubatch_token_offset
@@ -770,6 +778,10 @@ class ForwardContext:
     # per-ubatch all_reduce. Shape: tuple of length N == len(ubatch_slices).
     # None when DP is off or when TBO is not active this step.
     ub_max_tokens_across_dp: tuple | None = None
+    # The same counts UNREDUCED: per ubatch, every rank's. The MAX above is one
+    # reduction of it and an all2all's receive width wants the SUM, so consumers
+    # take their own. Same None conditions as the MAX.
+    ub_tokens_across_dp: tuple | None = None
 
     # Cached current_stream() captured at set_forward_context() time, so
     # downstream code (V4 attention / MoE / metadata builder) doesn't have
@@ -894,6 +906,7 @@ def set_forward_context(
     ubatch_slices: list[Any] | None = None,
     in_hipgraph: bool = False,
     ub_max_tokens_across_dp: tuple | None = None,
+    ub_tokens_across_dp: tuple | None = None,
 ) -> None:
     global _forward_context
     dp_metadata: DPMetadata | None = None
@@ -905,6 +918,14 @@ def set_forward_context(
             num_tokens_across_dp,
         )
 
+    # Mirrored here rather than at each caller: the two going out of step is how
+    # an all2all comes to bound its receive buffer by one rank's count. Assigned
+    # unconditionally, because the capture loop reuses one Context across
+    # buckets and a set-only write would leave the last table behind.
+    context.running_tokens_across_dp = (
+        None if num_tokens_across_dp is None else tuple(num_tokens_across_dp.tolist())
+    )
+
     _forward_context = ForwardContext(
         attn_metadata=attn_metadata,
         no_compile_layers=atom_config.compilation_config.static_forward_context,
@@ -914,6 +935,7 @@ def set_forward_context(
         spec_decode_metadata=spec_decode_metadata,
         ubatch_slices=ubatch_slices,
         ub_max_tokens_across_dp=ub_max_tokens_across_dp,
+        ub_tokens_across_dp=ub_tokens_across_dp,
         main_stream=(torch.cuda.current_stream() if _CUDA_AVAILABLE else None),
         in_hipgraph=in_hipgraph,
     )  # _forward_context.attn_metadata = attn_metadata

--- a/atom/utils/tbo/ubatch_wrapper.py
+++ b/atom/utils/tbo/ubatch_wrapper.py
@@ -145,6 +145,7 @@ class UBatchWrapper(nn.Module):
                 ub_num_reqs,
                 ub_running_tokens=ub_running_tokens_list[i],
                 dp_metadata=ub_dp_metadata[i] if ub_dp_metadata is not None else None,
+                running_tokens_across_dp=self._ub_tokens_across_dp(ctx, N, i),
             )
             forward_contexts.append(ub_ctx)
             ub_token_slice = (
@@ -270,6 +271,7 @@ class UBatchWrapper(nn.Module):
                 i,
                 ub_running_tokens=ub_running_bs * max_q,
                 dp_metadata=ub_dp_metadata[i] if ub_dp_metadata is not None else None,
+                running_tokens_across_dp=self._ub_tokens_across_dp(ctx, N, i),
             )
             forward_contexts.append(ub_ctx)
             ub_inputs.append(
@@ -450,6 +452,15 @@ class UBatchWrapper(nn.Module):
         return metas
 
     @staticmethod
+    def _ub_tokens_across_dp(ctx: ForwardContext, N: int, i: int):
+        """Ubatch ``i``'s per-rank token counts, or None if none were reduced.
+
+        Passed down because inside a ubatch only this rank's split is in reach.
+        """
+        rows = ctx.ub_tokens_across_dp
+        return None if rows is None or len(rows) != N else rows[i]
+
+    @staticmethod
     def _decode_ub_running_bs(
         ctx: ForwardContext, i: int, N: int, full_running_bs: int
     ) -> int:
@@ -520,6 +531,7 @@ class UBatchWrapper(nn.Module):
         actual_num_reqs: int | None = None,
         ub_running_tokens: int | None = None,
         dp_metadata=None,
+        running_tokens_across_dp: tuple[int, ...] | None = None,
     ) -> ForwardContext:
         """Build a ForwardContext for a single micro-batch."""
         ub_num_reqs = ub_slice.request_slice.stop - ub_slice.request_slice.start
@@ -556,6 +568,7 @@ class UBatchWrapper(nn.Module):
             scheduled_tokens=ub_num_tokens,
             running_bs=ub_running_bs,
             running_tokens=running_tokens,
+            running_tokens_across_dp=running_tokens_across_dp,
             is_draft=ctx.context.is_draft,
             # Carry over per-ubatch slice of input_ids for hash MoE (PCP+TBO mode).
             # run_model stores local (1/pcp) ids; each ubatch takes its token_slice.

--- a/atom/utils/tbo/ubatching.py
+++ b/atom/utils/tbo/ubatching.py
@@ -189,6 +189,11 @@ class DPSyncResult:
     tbo_collective_active: bool
     # (ub0_max, ub1_max) across DP — only set when tbo_collective_active.
     ub_max_tokens_across_dp: tuple[int, int] | None
+    # The same two rows UNREDUCED, per ubatch. The MAX above is one reduction of
+    # this and an all2all's receive width takes the SUM, so the row is what
+    # travels and each consumer reduces it. (The MAX stays a field only because
+    # it is a ForwardContext constructor kwarg the sglang bridge passes.)
+    ub_tokens_across_dp: tuple[tuple[int, ...], ...] | None
     # DP-MAX of the per-seq decode length — only set when ``max_seqlen_q`` was
     # passed in (a block drafter under DP). Folded into this packed all_gather so
     # the graph-shape sync no longer needs its own separate all_reduce (halves
@@ -230,8 +235,8 @@ def sync_dp_metadata(
       row 2 : is_prefill (0/1)         -> any_rank_has_prefill (OR)
       row 3 : meets_min_tokens (0/1)   -> OR  -> any rank reached the min-token bar [TBO only]
       row 4 : can_split (0/1)          -> AND -> every rank can split              [TBO only]
-      row 5 : ub0_tokens               -> ub_max_tokens_across_dp[0]              [TBO only]
-      row 6 : ub1_tokens               -> ub_max_tokens_across_dp[1]              [TBO only]
+      row 5 : ub0_tokens               -> ub_{max,total}_tokens_across_dp[0]      [TBO only]
+      row 6 : ub1_tokens               -> ub_{max,total}_tokens_across_dp[1]      [TBO only]
       row k+0 : max_seqlen_q           -> max_seqlen_q_across_dp (MAX)  [DSpark only]
 
     Rows 0 and 1 are the same batch in ATOM's two units; both ride this one
@@ -273,6 +278,7 @@ def sync_dp_metadata(
     any_rank_has_prefill = bool(sync[2].any())
     tbo_collective_active = False
     ub_max_tokens_across_dp: tuple[int, int] | None = None
+    ub_tokens_across_dp: tuple[tuple[int, ...], ...] | None = None
     if tbo_on:
         # OR(meets_min_tokens): one rank reaching the min-token bar turns TBO on
         # for all. AND(can_split): but EVERY rank must be structurally splittable, else
@@ -290,10 +296,8 @@ def sync_dp_metadata(
             uniform_mode = prefill_rank_count == 0 or prefill_rank_count == dp_size
             tbo_collective_active = uniform_mode
         if tbo_collective_active:
-            ub_max_tokens_across_dp = (
-                int(sync[5].max()),
-                int(sync[6].max()),
-            )
+            ub_tokens_across_dp = (tuple(sync[5].tolist()), tuple(sync[6].tolist()))
+            ub_max_tokens_across_dp = tuple(max(row) for row in ub_tokens_across_dp)
 
     max_seqlen_q_across_dp: int | None = None
     if dspark_on:
@@ -305,6 +309,7 @@ def sync_dp_metadata(
         any_rank_has_prefill=any_rank_has_prefill,
         tbo_collective_active=tbo_collective_active,
         ub_max_tokens_across_dp=ub_max_tokens_across_dp,
+        ub_tokens_across_dp=ub_tokens_across_dp,
         max_seqlen_q_across_dp=max_seqlen_q_across_dp,
     )
 

--- a/scripts/wait_infer_drain.sh
+++ b/scripts/wait_infer_drain.sh
@@ -98,6 +98,13 @@ count_in() {
     echo "${c:-0}"
 }
 
+count_excluding() {
+    local pat=$1 file=$2 c
+    { [ -z "$file" ] || [ ! -r "$file" ]; } && { echo 0; return; }
+    c=$(grep -cvE "$pat" "$file" 2>/dev/null | head -1)
+    echo "${c:-0}"
+}
+
 mtime_of() {
     local file=$1
     [ -z "$file" ] || [ ! -r "$file" ] && { echo 0; return; }
@@ -106,9 +113,16 @@ mtime_of() {
 
 FAULT_PATTERN='stopped, reason|MEMORY_VIOLATION|ASSERT_TRAP|proc died unexpectedly|Memory access fault by GPU'
 
+# Server-log lines that must not count as progress. aiter prints this one from
+# a rank that is ALREADY blocked on the broadcast ring, so reading it as
+# liveness inverts its meaning -- and it repeats every 60s, exactly the default
+# STUCK_POLLS*POLL quiet window, so it resets the counter one poll before it can
+# fire and the hang only ever surfaces at MAX_MIN.
+IDLE_NOISE_PATTERN='No available shared memory broadcast block'
+
 prev_outputs=0
 prev_mtime=0
-prev_server_mtime=0
+prev_server_lines=0
 stuck=0
 server_log=""
 # Whether we've ever observed the workload python process. Until this flips
@@ -170,29 +184,32 @@ for ((i=1; i<=ITERS; i++)); do
     #   2. Caller LOG_FILE mtime advancing (covers client logs / offline
     #      stdout where engine marker is absent: benchmark tqdm,
     #      simple_inference, etc. — but tqdm may not flush during warmup).
-    #   3. Server log mtime advancing (universal "server is busy" signal:
-    #      uvicorn HTTP access logs, scheduler trace, request arrival —
-    #      grows during warmup even before any output ships, so it
-    #      prevents false HANG during long warmup phases).
+    #   3. Server log GROWING IN LINES, ignoring IDLE_NOISE_PATTERN (universal
+    #      "server is busy" signal: uvicorn HTTP access logs, scheduler trace,
+    #      request arrival — grows during warmup even before any output ships,
+    #      so it prevents false HANG during long warmup phases). Counted by
+    #      line rather than by mtime because mtime cannot tell what was
+    #      written, and a wedge that keeps one periodic logger alive would
+    #      otherwise read as progress.
     cur_outputs=$(count_in "Engine Core: output send" "$server_log")
     delta_out=$(( cur_outputs - prev_outputs ))
     cur_mtime=$(mtime_of "$LOG_FILE")
     delta_mtime=$(( cur_mtime - prev_mtime ))
-    cur_server_mtime=$(mtime_of "$server_log")
-    delta_server_mtime=$(( cur_server_mtime - prev_server_mtime ))
+    cur_server_lines=$(count_excluding "$IDLE_NOISE_PATTERN" "$server_log")
+    delta_server_lines=$(( cur_server_lines - prev_server_lines ))
 
     # Client still running?
     client_alive=$(pgrep -af "$CLIENT_PATTERN" 2>/dev/null | grep -v grep | wc -l)
 
-    echo "[t=$((i*POLL))s] outputs=${cur_outputs} (+${delta_out}) mtime+${delta_mtime}s srv_mtime+${delta_server_mtime}s clients=${client_alive} stuck=${stuck}/${STUCK_POLLS}"
+    echo "[t=$((i*POLL))s] outputs=${cur_outputs} (+${delta_out}) mtime+${delta_mtime}s srv+${delta_server_lines}ln clients=${client_alive} stuck=${stuck}/${STUCK_POLLS}"
 
-    if [ "$delta_out" -eq 0 ] && [ "$delta_mtime" -eq 0 ] && [ "$delta_server_mtime" -eq 0 ]; then
+    if [ "$delta_out" -eq 0 ] && [ "$delta_mtime" -eq 0 ] && [ "$delta_server_lines" -eq 0 ]; then
         stuck=$(( stuck + 1 ))
     else
         stuck=0
         prev_outputs=$cur_outputs
         prev_mtime=$cur_mtime
-        prev_server_mtime=$cur_server_mtime
+        prev_server_lines=$cur_server_lines
     fi
 
     # Drained cleanly: client gone AND no new output this poll → done.

--- a/tests/test_mori_dispatch_trim_bound.py
+++ b/tests/test_mori_dispatch_trim_bound.py
@@ -1,16 +1,25 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
-"""The mori dispatch trim bound must not multiply by top-k.
+"""The mori dispatch trim bound: the group's SUM, and not multiplied by top-k.
+
+Two properties, and they fail in opposite directions.
 
 mori's IntraNode/AsyncLL dispatch kernel deduplicates per destination rank: a
 source token whose several top-k experts all resolve to the same rank is written
 into that rank's receive buffer exactly once (see the "Deduplicate" block in
 mori intranode.hpp, which skips any top-k slot whose destPe already appeared in
-an earlier slot of the same token). So a single rank's receive buffer holds at
-most `running_tokens` tokens per source rank -> `running_tokens * dp_size` total, never
-`running_tokens * topk * dp_size`. The topk-inflated bound sat above the real
-valid-token count, making the trim a no-op and leaving fused_moe reading
-uninitialized tail rows.
+an earlier slot of the same token). So a rank's receive buffer holds at most
+each source rank's own token count, never that times `topk`. A topk-inflated
+bound sits ABOVE the real valid-token count, making the trim a no-op and leaving
+fused_moe reading uninitialized tail rows.
+
+The counts summed are every rank's, because that is what a receive buffer holds.
+`this_rank * dp_size` is the same number only while the group is uniform; a TBO
+ubatch splits per-rank, and on the smaller rank the product falls BELOW the rows
+mori delivered. That bound trims the buffer under the `expert_num_tokens`
+fused_moe is driven by, and moe_sorting's zero-fill -- sized on the host from
+the trimmed width but bounded on the device by that count -- runs off the end of
+its workspace.
 """
 
 from types import SimpleNamespace
@@ -24,14 +33,22 @@ import torch
 import atom.model_ops.fused_moe.modular_kernel as mk
 
 
-def _trim(monkeypatch, *, running_tokens, dp_size, topk, recv_rows):
-    context = SimpleNamespace(
-        running_tokens=running_tokens, is_prefill=False, running_tokens_are_unified=True
+def _context(across_dp, *, running_tokens=None, dp_rank=0):
+    return SimpleNamespace(
+        running_tokens=(
+            across_dp[dp_rank] if running_tokens is None else running_tokens
+        ),
+        running_tokens_across_dp=tuple(across_dp),
+        is_prefill=False,
+        running_tokens_are_unified=True,
     )
+
+
+def _trim(monkeypatch, *, across_dp, topk, recv_rows, dp_rank=0):
+    context = _context(across_dp, dp_rank=dp_rank)
     monkeypatch.setattr(
         mk, "get_forward_context", lambda: SimpleNamespace(context=context)
     )
-    monkeypatch.setattr(mk, "get_dp_group", lambda: SimpleNamespace(world_size=dp_size))
     kernel = mk.FusedMoEModularKernel.__new__(mk.FusedMoEModularKernel)
     hidden = 8
     a1 = torch.arange(recv_rows * hidden, dtype=torch.float32).reshape(
@@ -46,16 +63,13 @@ def _trim(monkeypatch, *, running_tokens, dp_size, topk, recv_rows):
     )
 
 
-def test_trims_to_graph_bs_times_dp_size_not_topk(monkeypatch):
-    running_tokens, dp_size, topk = 4, 8, 6
+def test_trims_to_the_group_total_not_topk(monkeypatch):
+    across_dp = (4,) * 8
+    topk = 6
     a1, scale, ids, weights = _trim(
-        monkeypatch,
-        running_tokens=running_tokens,
-        dp_size=dp_size,
-        topk=topk,
-        recv_rows=512,
+        monkeypatch, across_dp=across_dp, topk=topk, recv_rows=512
     )
-    expected = running_tokens * dp_size  # 32, NOT 32*topk=192
+    expected = sum(across_dp)  # 32, NOT 32*topk=192
     assert a1.shape[0] == expected
     assert ids.shape[0] == expected
     assert weights.shape[0] == expected
@@ -63,39 +77,73 @@ def test_trims_to_graph_bs_times_dp_size_not_topk(monkeypatch):
 
 
 def test_topk_does_not_change_the_bound(monkeypatch):
-    running_tokens, dp_size = 4, 8
+    across_dp = (4,) * 8
     rows = {
-        topk: _trim(
-            monkeypatch,
-            running_tokens=running_tokens,
-            dp_size=dp_size,
-            topk=topk,
-            recv_rows=512,
-        )[0].shape[0]
+        topk: _trim(monkeypatch, across_dp=across_dp, topk=topk, recv_rows=512)[
+            0
+        ].shape[0]
         for topk in (1, 2, 6, 9)
     }
-    assert set(rows.values()) == {running_tokens * dp_size}
+    assert set(rows.values()) == {sum(across_dp)}
+
+
+def test_the_smaller_rank_of_an_uneven_split_keeps_the_peer_s_rows(monkeypatch):
+    """The regression: a TBO ubatch leaves the two ranks at different counts.
+
+    `this_rank * dp_size` is 12426 on the smaller rank while mori delivers rows
+    for both -- 13918 at worst. Trimming to the product cuts the buffer below
+    what arrived; the sum does not.
+    """
+    across_dp = (6213, 7346)
+    a1, _, _, _ = _trim(monkeypatch, across_dp=across_dp, topk=4, recv_rows=32768)
+    assert a1.shape[0] == sum(across_dp) == 13559
+    assert a1.shape[0] > across_dp[0] * len(across_dp)  # 12426, the old bound
+
+
+def test_a_ragged_step_trims_too(monkeypatch):
+    """A prefill used to be excluded, and went back with the per-rank bound.
+
+    The exclusion was never about prefill: it was that one rank's count is the
+    group's only when the group is uniform. A sum is the group's count however
+    unevenly the group reached it, so there is nothing left to exclude -- and
+    the arena a prefill used to carry whole is the larger part of this shrink.
+    """
+    across_dp = (900, 1100)
+    context = SimpleNamespace(
+        running_tokens=across_dp[0],
+        running_tokens_across_dp=across_dp,
+        is_prefill=True,
+        running_tokens_are_unified=False,
+    )
+    monkeypatch.setattr(
+        mk, "get_forward_context", lambda: SimpleNamespace(context=context)
+    )
+    kernel = mk.FusedMoEModularKernel.__new__(mk.FusedMoEModularKernel)
+    trimmed = kernel._maybe_trim_dispatch_output(
+        torch.zeros(32768, 8),
+        None,
+        torch.zeros(32768, 4, dtype=torch.int32),
+        torch.ones(32768, 4),
+        torch.zeros(3, 4, dtype=torch.int32),
+        expert_tokens_meta=None,
+    )
+    assert trimmed[0].shape[0] == sum(across_dp) == 2000
 
 
 def test_no_trim_when_bound_exceeds_buffer(monkeypatch):
     # fused_moe is driven by num_local_tokens; the buffer must never be cut
     # below the bound.
-    a1, _, _, _ = _trim(monkeypatch, running_tokens=64, dp_size=8, topk=4, recv_rows=16)
+    a1, _, _, _ = _trim(monkeypatch, across_dp=(64,) * 8, topk=4, recv_rows=16)
     assert a1.shape[0] == 16
 
 
 def test_exact_dispatch_output_bypasses_mori_trim(monkeypatch):
     """An EP-wide exact RCCL buffer must not be cut to the smaller DP bound."""
     running_tokens, dp_size, ep_size, topk = 32, 2, 8, 6
-    context = SimpleNamespace(
-        running_tokens=running_tokens,
-        is_prefill=False,
-        running_tokens_are_unified=True,
-    )
+    context = _context((running_tokens,) * dp_size)
     monkeypatch.setattr(
         mk, "get_forward_context", lambda: SimpleNamespace(context=context)
     )
-    monkeypatch.setattr(mk, "get_dp_group", lambda: SimpleNamespace(world_size=dp_size))
 
     kernel = mk.FusedMoEModularKernel.__new__(mk.FusedMoEModularKernel)
     kernel.prepare_finalize = SimpleNamespace(needs_dispatch_output_trim=lambda: False)
@@ -114,3 +162,28 @@ def test_exact_dispatch_output_bypasses_mori_trim(monkeypatch):
     )
 
     assert [tensor.shape[0] for tensor in trimmed] == [recv_rows] * 4
+
+
+def test_a_step_with_no_reduced_counts_is_an_error(monkeypatch):
+    """Silence here is what the bug looked like: no counts, so no bound, so a
+    width taken from whatever single number was to hand."""
+    context = SimpleNamespace(
+        running_tokens=64,
+        running_tokens_across_dp=None,
+        is_prefill=False,
+        running_tokens_are_unified=True,
+    )
+    monkeypatch.setattr(
+        mk, "get_forward_context", lambda: SimpleNamespace(context=context)
+    )
+    kernel = mk.FusedMoEModularKernel.__new__(mk.FusedMoEModularKernel)
+    a1 = torch.zeros(512, 8)
+    with pytest.raises(AssertionError, match="per-rank counts"):
+        kernel._maybe_trim_dispatch_output(
+            a1,
+            None,
+            torch.zeros(512, 4, dtype=torch.int32),
+            torch.ones(512, 4),
+            torch.zeros(3, 4, dtype=torch.int32),
+            expert_tokens_meta=None,
+        )


### PR DESCRIPTION
## What breaks

`gpt-oss-120b`, TP2 + `--enable-dp-attention` + `--enable-expert-parallel` + `--enable-tbo all`, faults within ~20s of real traffic:

```
Memory access fault by GPU node-2 ... Reason: Write access to a read-only page.
```

Under rocm-debug-agent the faulting wave names the kernel:

```
aiter::opus_moe_sorting_entry<MoeSortingClearWorkspaceKernel<...<true, 1024, 1>>>
  (stopped, reason: MEMORY_VIOLATION)  x16 waves
```

Two independent bugs on the same path. Neither needs `--level 3`; both reproduce under `--enforce-eager --level 0`.

## 1. The all2all receive buffer is bounded by one rank's count

`_maybe_trim_dispatch_output` cut mori's dispatch arena to `running_tokens * dp_size`. That equals what the group sent only while the group is uniform. A TBO ubatch splits per-rank, and on the smaller rank the product lands **under** the rows mori delivered, so the buffer is trimmed below the `expert_num_tokens` `fused_moe` is driven by.

aiter's `moe_sorting` then sizes its workspace on the host from `topk_ids.shape[0]` while its clear kernel re-derives the row count on the device from `num_local_tokens[0]`, so the zero-fill runs off the allocation. aiter states the contract in `moe_sorting_opus.h`:

```c
opus::index_t tokens; // if p_local_tokens is not nullptr, this indicate the
                      // max possible tokens used for ws/LDS calculation
```

Instrumented on the faulting step: buffer trimmed to **12426**, mori delivered **13193**. The DP reduce had the right answer — per-ubatch counts `(6213, 7346)` — and it was discarded, because `_compute_ub_running_tokens` is handed `dp_size=1` on the all2all path (`dp_gather_scatter` is False) and its `dp_size > 1` guard then drops the negotiated value for the local one.

**Fix:** carry the per-rank counts rather than a reduction of them. The packed DP `all_gather` already produced the rows, so `DPSyncResult` keeps them unreduced and `Context.running_tokens_across_dp` hands them down; the MoE sums, the ubatch ladder maxes, both off one source. No new collective.

Absent counts are asserted, not defaulted. That assert is what found the CUDAGraph capture path, where a context declares its shape instead of reducing one — the symmetry is now stated where the capture already rebuilds `num_tokens_across_dp` for the same reason.

A ragged step no longer needs excluding: a sum is the group's count however unevenly the group reached it. Prefill therefore trims too instead of carrying the whole arena — observed dispatch widths fall from a constant 32768 to 1024–16384.

## 2. A TBO ubatch reaches the prefix gather with no k-token map

`_attach_tbo_token_split_straddle_prefix` re-attaches the half a partner ubatch already wrote as a cached prefix, turning `has_cached` on **after** the split — and `has_cached` is the gate that opens the prefix gather. The builder pairs `batch_id_per_k_token` with `has_cached` under one `if`, so a parent with no cache built none, and `cp_mha_gather_cache` was handed `None`.

`None` reaches a Triton kernel as an untyped argument and fails to **compile**. The ubatch thread dies, its partner waits on the ring, the ModelRunner tears down into `destroy_process_group`, and the peer rank never joins it — the server wedges with nothing surfaced to the client. py-spy on the two workers:

```
DP1TP0 MainThread: destroy_process_group  <- model_runner.py:974 exit()
DP0TP0 MainThread: shm_broadcast.acquire_read   (waiting for the next command)
```

**Fix:** build it whenever TBO is on. The array `split_attn_metadata` slices by request range is already the re-attached ubatch's geometry (`cached + all_new` per request), so the slice needs no rebuild — the only way to get it wrong is to have nothing to slice.

## 3. `wait_infer_drain.sh` read the hang's own diagnostic as liveness

Server-log **mtime** growth counted as progress. A wedged rank prints `No available shared memory broadcast block found in 60.0 seconds` once a minute, and at the default `STUCK_POLLS*POLL == 60s` that lands exactly antiphase: the counter climbs to 5/6 and is cleared, forever. The wedge above only surfaced at `MAX_MIN`.

Now counts server-log lines excluding that warning. mtime cannot say what was written, so any wedge leaving one periodic logger alive defeats it; this was merely the first. Measured against the live wedge: `HANG` at **70s**, where the old version had been looping for 570s.

## Verification

| | |
|---|---|
| GSM8K flexible-extract (gpt-oss-120b TP2, 1319 samples) | **0.8992 / 0.8999 / 0.9037 / 0.9098** — baseline 0.90, threshold 0.88 |
| Faults / MEMORY_VIOLATION / asserts | 0 (previously 20–370s to fault, every run) |
| Unit tests | 3 failed / 5752 passed; `main` gives the same 3 (`TestWoADequantFnFnuzGate`, a test double missing `_is_gfx1250`) |
| ruff / black | per-file counts identical to `main` |

Three new properties in `tests/test_mori_dispatch_trim_bound.py`, each revert-run verified — restoring the old bound reddens only the uneven-split test, restoring the uniformity gate reddens only the ragged-step test.

## Notes for review

- `_decode_recv_bound` → `_recv_bound`: it no longer excludes prefill, so the name no longer says decode.
- `ub_max_tokens_across_dp` is now derivable from `ub_tokens_across_dp` and is kept only because it is a `ForwardContext` constructor kwarg the sglang bridge passes. Removing it means updating that bridge, which `tests/plugin` does not cover and this box cannot run — left out deliberately.
- `--enable-tbo all` off does not start on this box for an unrelated reason: `gptoss_bf16_tuned_gemm.csv` has no `N=100544` row, so lm_head's GEMM falls back to hipBLASLt inside CUDAGraph capture and raises `hipErrorCapturedEvent`. TBO happens to keep lm_head out of capture. Separate issue, not touched here.
