### PR TITLE
feat(mesh-ci): report p90 latency and AIPerf raw metrics in benchmark summary and support kimi-k3 agentic ci

### DIFF
--- a/.github/benchmark/models_atomesh.yaml
+++ b/.github/benchmark/models_atomesh.yaml
@@ -398,12 +398,13 @@ models:
         # One concurrency per job keeps the prefix/state caches independent.
         - <<: &kimi_k3_agentic_tp8
             topology: 1p1d
+            display_topology: 1P1D-TP8-DSPARK7
             pd_worker_layout: multi_node
             nodes: "${ATOMESH_1P1D_NODES}"
             isl: [1048576]
             osl: 1024
             server:
-              common_args:
+              common_args: &kimi_k3_agentic_dspark7_args
                 gpu_memory_utilization: 0.88
                 max_num_seqs: 32
                 max_num_batched_tokens: 8192
@@ -432,10 +433,18 @@ models:
         - <<: *kimi_k3_agentic_tp8
           name: kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c4
           concurrency: [4]
+          server:
+            common_args:
+              <<: *kimi_k3_agentic_dspark7_args
+              state_checkpoint_slots: 64
+          env:
+            common:
+              ATOM_ENABLE_REPLAYSSM: "1"
 
         - &kimi_k3_agentic_dcp8_lmcache
           <<: *kimi_k3_agentic_tp8
           name: kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c8
+          display_topology: 1P1D-TP8-DCP8-DSPARK3
           concurrency: [8]
           server:
             common_args: &kimi_k3_agentic_dspark3_args
@@ -481,6 +490,7 @@ models:
         - &kimi_k3_agentic_no_dspark
           <<: *kimi_k3_agentic_dcp8_lmcache
           name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c32
+          display_topology: 1P1D-TP8-DCP8
           concurrency: [32]
           server:
             common_args: &kimi_k3_agentic_no_dspark_args

--- a/.github/benchmark/models_atomesh.yaml
+++ b/.github/benchmark/models_atomesh.yaml
@@ -272,11 +272,12 @@ models:
               decode:
                 MAX_JOBS: "16"
                 HIP_VISIBLE_DEVICES: "4,5,6,7"
-            benchmark:
+            benchmark: &agentic_1m_aiperf
               kind: aiperf_agentic
               aiperf_commit: b7b16cf851885567988a643282266bce74e34437
               scenario: inferencex-agentx-mvp
               public_dataset: semianalysis_cc_traces_weka_062126
+              apply_chat_template: true
               max_context_length: 1048576
               num_dataset_entries: 393
               benchmark_duration: 3600
@@ -366,6 +367,166 @@ models:
       limit: null
       model_type: local-completions
       endpoint: completions
+
+  Kimi-K3-MXFP4:
+    backend: atom
+    model_path: "${ATOMESH_MODEL_ROOT}/Kimi-K3"
+    precision: MXFP4
+    env:
+      common:
+        PYTHONNOUSERSITE: "1"
+        PYTHONHASHSEED: "0"
+        AITER_SITUV2_A4W4: "1"
+        AITER_QUICK_REDUCE_QUANTIZATION: INT4
+        AITER_FLYDSL_STAGE2_FP8: "1"
+        ATOM_MLA_MAX_SPLIT_PER_BATCH: "256"
+        ATOM_STATE_CHECKPOINT_DEMAND: "0"
+        ATOM_ENABLE_REPLAYSSM: "0"
+      prefill: {}
+      decode: {}
+    server:
+      common_args:
+        trust_remote_code: true
+        kv_cache_dtype: fp8
+        block_size: 128
+        enable_prefix_caching: true
+        max_model_len: ""
+        state_checkpoint_interval_tokens: -1
+        online_quant_config: '{"global_quant_config":"ptpc_fp8","exclude_layer":["lm_head","model.embed_tokens","*self_attn.[qkv]_conv1d*","*block_sparse_moe.experts*","*block_sparse_moe.routed_expert_*","*vision_tower*","*mm_projector*"]}'
+    suites:
+      nightly:
+        # One concurrency per job keeps the prefix/state caches independent.
+        - <<: &kimi_k3_agentic_tp8
+            topology: 1p1d
+            pd_worker_layout: multi_node
+            nodes: "${ATOMESH_1P1D_NODES}"
+            isl: [1048576]
+            osl: 1024
+            server:
+              common_args:
+                gpu_memory_utilization: 0.88
+                max_num_seqs: 32
+                max_num_batched_tokens: 8192
+                method: dspark
+                draft_model: "${ATOMESH_MODEL_ROOT}/Kimi-K3-DSpark"
+                num_speculative_tokens: 7
+                spec_decode_acceptance_length: 3.84
+            prefill:
+              workers: 1
+              tp: 8
+            decode:
+              workers: 1
+              tp: 8
+              cudagraph: none
+            benchmark:
+              <<: *agentic_1m_aiperf
+              aiperf_commit: 754356e9a39acc6cc6afb242d123bb57c3fb6f75
+            run_eval: false
+          name: kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c1
+          concurrency: [1]
+
+        - <<: *kimi_k3_agentic_tp8
+          name: kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c2
+          concurrency: [2]
+
+        - <<: *kimi_k3_agentic_tp8
+          name: kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c4
+          concurrency: [4]
+
+        - &kimi_k3_agentic_dcp8_lmcache
+          <<: *kimi_k3_agentic_tp8
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c8
+          concurrency: [8]
+          server:
+            common_args: &kimi_k3_agentic_dspark3_args
+              gpu_memory_utilization: 0.88
+              max_num_seqs: 32
+              max_num_batched_tokens: 4096
+              method: dspark
+              draft_model: "${ATOMESH_MODEL_ROOT}/Kimi-K3-DSpark"
+              num_speculative_tokens: 3
+              spec_decode_acceptance_length: 3.00
+              state_checkpoint_slots: 96
+          prefill:
+            workers: 1
+            tp: 8
+            dcp: 8
+          decode:
+            workers: 1
+            tp: 8
+            dcp: 8
+            cudagraph: none
+          env:
+            common:
+              ATOM_ENABLE_REPLAYSSM: "1"
+            prefill: &kimi_k3_agentic_lmcache100_env
+              LMCACHE_LOCAL_CPU: "True"
+              LMCACHE_MAX_LOCAL_CPU_SIZE: "100"
+              LMCACHE_CHUNK_SIZE: "1024"
+              LMCACHE_ENABLE_OUTPUT_PATH_MODE: "1"
+              LMCACHE_ENABLE_LAYOUT_FILE_MODE: "1"
+              OFFLOAD_KV_FOR_HYBRID: "1"
+              OFFLOAD_PROFILE: "1"
+              PREFILL_KV_TRANSFER_CONFIG: >-
+                {"kv_connector":"multi","connectors":[{"kv_connector":"mooncake","kv_role":"kv_producer","proxy_ip":"${ROLE_IP}","handshake_port":6301},{"kv_connector":"lmcache_offload","kv_role":"offload"}]}
+
+        - <<: *kimi_k3_agentic_dcp8_lmcache
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c12
+          concurrency: [12]
+          server:
+            common_args:
+              <<: *kimi_k3_agentic_dspark3_args
+              max_num_seqs: 24
+
+        - &kimi_k3_agentic_no_dspark
+          <<: *kimi_k3_agentic_dcp8_lmcache
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c32
+          concurrency: [32]
+          server:
+            common_args: &kimi_k3_agentic_no_dspark_args
+              gpu_memory_utilization: 0.86
+              max_num_seqs: 64
+              max_num_batched_tokens: 8192
+          env:
+            common:
+              ATOM_ENABLE_REPLAYSSM: "0"
+            prefill:
+              <<: *kimi_k3_agentic_lmcache100_env
+              LMCACHE_MAX_LOCAL_CPU_SIZE: "96"
+              OFFLOAD_STATE: "1"
+              OFFLOAD_STATE_CPU_SIZE: "32"
+              OFFLOAD_STATE_STAGING_GROUPS: "8"
+              OFFLOAD_STATE_MIN_LOAD_TOKENS: "0"
+              OFFLOAD_GPU_STAGING_CHUNKS: "32"
+
+        - <<: *kimi_k3_agentic_no_dspark
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c40
+          concurrency: [40]
+          server:
+            common_args:
+              <<: *kimi_k3_agentic_no_dspark_args
+              max_num_seqs: 80
+
+        - <<: *kimi_k3_agentic_no_dspark
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c56
+          concurrency: [56]
+          server:
+            common_args:
+              <<: *kimi_k3_agentic_no_dspark_args
+              gpu_memory_utilization: 0.88
+              max_num_seqs: 72
+              max_num_batched_tokens: 4096
+          run_eval: true
+          eval_concurrency: [56]
+
+    accuracy:
+      task: gsm8k
+      fewshot: 5
+      limit: null
+      model_type: local-chat-completions
+      endpoint: chat/completions
+      max_gen_toks: 16384
+      apply_chat_template: true
 
   Kimi-K2.5-MXFP4:
     backend: atom

--- a/.github/benchmark/models_atomesh.yaml
+++ b/.github/benchmark/models_atomesh.yaml
@@ -186,6 +186,11 @@ models:
         AITER_USE_FLYDSL_MOE_SORTING: "1"
       prefill: {}
       decode: {}
+    service:
+      prefill:
+        cudagraph_mode: FULL_AND_PIECEWISE
+      decode:
+        cudagraph_mode: FULL_AND_PIECEWISE
     server:
       common_args:
         trust_remote_code: true
@@ -194,8 +199,7 @@ models:
         gpu_memory_utilization: 0.8
         max_num_batched_tokens: 16384
         max_model_len: 16384
-        cudagraph-mode: FULL_AND_PIECEWISE
-        default-chat-template-kwargs: {"enable_thinking":false}
+        extra_args: '--default-chat-template-kwargs {"enable_thinking":false}'
     suites:
       nightly:
         - name: glm-52-mxfp4-1p1d-tp4
@@ -379,8 +383,14 @@ models:
         AITER_SITUV2_A4W4: "1"
         AITER_QUICK_REDUCE_QUANTIZATION: INT4
         AITER_FLYDSL_STAGE2_FP8: "1"
+        # AgentX enables comm-group reuse only on C56/C64.
+        AITER_REUSE_IDENTICAL_COMM_GROUPS: "0"
         ATOM_MLA_MAX_SPLIT_PER_BATCH: "256"
         ATOM_STATE_CHECKPOINT_DEMAND: "0"
+        # AgentX band default: ReplaySSM off on CONC 1/2/4, on for the mid band
+        # (CONC 8-16), off again from CONC 32. Cases that declare their own env
+        # block must restate the key, because a YAML merge key loses to an
+        # explicit `env:` on the same node.
         ATOM_ENABLE_REPLAYSSM: "0"
       prefill: {}
       decode: {}
@@ -418,7 +428,11 @@ models:
             decode:
               workers: 1
               tp: 8
-              cudagraph: none
+              # AgentX pins the compile path and captures the dense query-token
+              # range 2..2*CONC*(1+spec) that `auto` derives per concurrency.
+              cudagraph: auto
+              cudagraph_mode: FULL
+              compilation_level: 3
             benchmark:
               <<: *agentic_1m_aiperf
               aiperf_commit: 754356e9a39acc6cc6afb242d123bb57c3fb6f75
@@ -433,13 +447,8 @@ models:
         - <<: *kimi_k3_agentic_tp8
           name: kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c4
           concurrency: [4]
-          server:
-            common_args:
-              <<: *kimi_k3_agentic_dspark7_args
-              state_checkpoint_slots: 64
-          env:
-            common:
-              ATOM_ENABLE_REPLAYSSM: "1"
+          run_eval: true
+          eval_concurrency: [4]
 
         - &kimi_k3_agentic_dcp8_lmcache
           <<: *kimi_k3_agentic_tp8
@@ -455,7 +464,6 @@ models:
               draft_model: "${ATOMESH_MODEL_ROOT}/Kimi-K3-DSpark"
               num_speculative_tokens: 3
               spec_decode_acceptance_length: 3.00
-              state_checkpoint_slots: 96
           prefill:
             workers: 1
             tp: 8
@@ -464,18 +472,26 @@ models:
             workers: 1
             tp: 8
             dcp: 8
-            cudagraph: none
+            cudagraph: auto
+            cudagraph_mode: FULL
+            compilation_level: 3
           env:
             common:
               ATOM_ENABLE_REPLAYSSM: "1"
-            prefill: &kimi_k3_agentic_lmcache100_env
+            prefill: &kimi_k3_agentic_lmcache128_env
               LMCACHE_LOCAL_CPU: "True"
-              LMCACHE_MAX_LOCAL_CPU_SIZE: "100"
+              LMCACHE_MAX_LOCAL_CPU_SIZE: "128"
               LMCACHE_CHUNK_SIZE: "1024"
+              LMCACHE_NUMA_MODE: auto
               LMCACHE_ENABLE_OUTPUT_PATH_MODE: "1"
               LMCACHE_ENABLE_LAYOUT_FILE_MODE: "1"
+              ATOM_NUMA_BIND: "1"
+              ATOM_NUMA_NODE: "0,0,0,0,1,1,1,1"
+              # Auto-binding off so the explicit ATOM_NUMA_NODE map is what takes effect.
+              ATOM_AUTO_NUMA_BIND: "0"
               OFFLOAD_KV_FOR_HYBRID: "1"
               OFFLOAD_PROFILE: "1"
+              OFFLOAD_GPU_STAGING_CHUNKS: "32"
               PREFILL_KV_TRANSFER_CONFIG: >-
                 {"kv_connector":"multi","connectors":[{"kv_connector":"mooncake","kv_role":"kv_producer","proxy_ip":"${ROLE_IP}","handshake_port":6301},{"kv_connector":"lmcache_offload","kv_role":"offload"}]}
 
@@ -487,9 +503,37 @@ models:
               <<: *kimi_k3_agentic_dspark3_args
               max_num_seqs: 24
 
+        # C14 runs the C16 server verbatim and only moves the client, so it also
+        # keeps C16's CUDA-graph width: deriving it from 2*CONC gives 28 and the
+        # server dies during graph warmup. cudagraph_max_num_seqs pins the window
+        # back to 32, which lands the same graph_max 128 as C16.
+        - <<: *kimi_k3_agentic_dcp8_lmcache
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c14
+          concurrency: [14]
+          server:
+            common_args: &kimi_k3_agentic_dspark3_8192_args
+              <<: *kimi_k3_agentic_dspark3_args
+              max_num_seqs: 32
+              max_num_batched_tokens: 8192
+              gpu_memory_utilization: 0.86
+          decode:
+            workers: 1
+            tp: 8
+            dcp: 8
+            cudagraph: auto
+            cudagraph_max_num_seqs: 32
+            cudagraph_mode: FULL
+            compilation_level: 3
+
+        - <<: *kimi_k3_agentic_dcp8_lmcache
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c16
+          concurrency: [16]
+          server:
+            common_args: *kimi_k3_agentic_dspark3_8192_args
+
         - &kimi_k3_agentic_no_dspark
           <<: *kimi_k3_agentic_dcp8_lmcache
-          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c32
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-1m-c32
           display_topology: 1P1D-TP8-DCP8
           concurrency: [32]
           server:
@@ -500,17 +544,13 @@ models:
           env:
             common:
               ATOM_ENABLE_REPLAYSSM: "0"
-            prefill:
-              <<: *kimi_k3_agentic_lmcache100_env
-              LMCACHE_MAX_LOCAL_CPU_SIZE: "96"
-              OFFLOAD_STATE: "1"
-              OFFLOAD_STATE_CPU_SIZE: "32"
-              OFFLOAD_STATE_STAGING_GROUPS: "8"
-              OFFLOAD_STATE_MIN_LOAD_TOKENS: "0"
-              OFFLOAD_GPU_STAGING_CHUNKS: "32"
+            # No CPU state tier here: the throughput band carries no draft model
+            # and no ReplaySSM, so the whole per-rank CPU budget goes to the
+            # paged KV instead of a state pool nothing replays from.
+            prefill: *kimi_k3_agentic_lmcache128_env
 
         - <<: *kimi_k3_agentic_no_dspark
-          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c40
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-1m-c40
           concurrency: [40]
           server:
             common_args:
@@ -518,16 +558,34 @@ models:
               max_num_seqs: 80
 
         - <<: *kimi_k3_agentic_no_dspark
-          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c56
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-1m-c56
           concurrency: [56]
           server:
             common_args:
               <<: *kimi_k3_agentic_no_dspark_args
-              gpu_memory_utilization: 0.88
-              max_num_seqs: 72
-              max_num_batched_tokens: 4096
-          run_eval: true
-          eval_concurrency: [56]
+              max_num_seqs: 112
+          env:
+            common:
+              ATOM_ENABLE_REPLAYSSM: "0"
+              AITER_REUSE_IDENTICAL_COMM_GROUPS: "1"
+            prefill:
+              <<: *kimi_k3_agentic_lmcache128_env
+              LMCACHE_MAX_LOCAL_CPU_SIZE: "192"
+
+        - <<: *kimi_k3_agentic_no_dspark
+          name: kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-1m-c64
+          concurrency: [64]
+          server:
+            common_args:
+              <<: *kimi_k3_agentic_no_dspark_args
+              max_num_seqs: 128
+          env:
+            common:
+              ATOM_ENABLE_REPLAYSSM: "0"
+              AITER_REUSE_IDENTICAL_COMM_GROUPS: "1"
+            prefill:
+              <<: *kimi_k3_agentic_lmcache128_env
+              LMCACHE_MAX_LOCAL_CPU_SIZE: "192"
 
     accuracy:
       task: gsm8k
@@ -535,8 +593,9 @@ models:
       limit: null
       model_type: local-chat-completions
       endpoint: chat/completions
-      max_gen_toks: 16384
+      max_gen_toks: 512
       apply_chat_template: true
+      threshold: 0.94
 
   Kimi-K2.5-MXFP4:
     backend: atom

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -3208,6 +3208,7 @@ function atomeshLatencyRowsHTML(row) {
     [mean, p90, p99].map(v => Number.isFinite(v) ? fmtNum(v, 2) : '—').join(' / ')
   }</span></div>`).join('');
 }
+
 function atomeshDpAttentionLabel(row) {
   if (row.prefillDpa && row.decodeDpa) return 'True';
   if (row.prefillDpa) return 'Prefill only';

--- a/.github/dashboard/index.html
+++ b/.github/dashboard/index.html
@@ -558,62 +558,103 @@ function atomeshHardwareKey(value) {
   return text || 'unknown';
 }
 
+// process_result.py names the interactivity column after the definition that
+// produced it ("Interactivity (P90 E2E Normalized)"), so the key is not a fixed
+// string. Everything else in the table has a stable header.
+const ATOMESH_INTERACTIVITY_KEY = 'interactivity';
+
+function atomeshSummaryInteractivityKey(headers) {
+  return headers.find(header => header.startsWith(ATOMESH_INTERACTIVITY_KEY))
+    || ATOMESH_INTERACTIVITY_KEY;
+}
+
+// TP/DCP cells collapse to a single number when prefill and decode agree and
+// read "P8/D4" when they do not.
+function parseAtomeshPdLabel(text) {
+  const value = String(text || '').trim();
+  const split = value.match(/^P(\d+)\s*\/\s*D(\d+)$/i);
+  if (split) return { prefill: Number(split[1]), decode: Number(split[2]) };
+  const single = parseAtomeshNumber(value);
+  return { prefill: single, decode: single };
+}
+
 function parseAtomeshSummaryRows(markdown) {
-  const lines = String(markdown || '').split(/\r?\n/).filter(line => line.trim().startsWith('|'));
+  const lines = String(markdown || '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.startsWith('|'));
   if (lines.length < 3) return [];
   const headers = lines[0].split('|').slice(1, -1).map(h => atomeshSummaryHeaderKey(h.trim()));
-  return lines.slice(2).map((line, idx) => {
-    const cells = line.split('|').slice(1, -1).map(cell => cell.trim());
-    const raw = {};
-    headers.forEach((header, i) => { raw[header] = cells[i] || ''; });
-    const [isl, osl] = String(raw.islosl || '').split('/');
-    const totalTputPerGpu = parseAtomeshNumber(raw.totaltoksgpu);
-    const outputTputPerGpu = parseAtomeshNumber(raw.outputtoksgpu);
-    // One column per definition (see write_summary in process_result.py), so
-    // which one is populated is itself the method -- there is no discriminator
-    // column to read. A row carries at most one of these two.
-    const intvtyE2eNorm = parseAtomeshNumber(raw.intvtye2enorm);
-    const intvtyMedianTpot = parseAtomeshNumber(raw.intvtymediantpot);
-    const interactivity = Number.isFinite(intvtyE2eNorm) ? intvtyE2eNorm : intvtyMedianTpot;
-    const gsm8k = parseAtomeshNumber(raw.gsm8k);
-    const cacheHitPct = parseAtomeshNumber(String(raw.cachehit || '').replace('%', ''));
-    const accuracyScore = parseAtomeshNumber(raw.accuracy) ?? gsm8k;
-    const accuracyTask = raw.accuracytask || (Number.isFinite(gsm8k) ? 'gsm8k' : '');
-    return {
-      id: `atomesh-summary-${idx}`,
-      backend: ATOMESH_DATA.backend,
-      hardware: atomeshHardwareKey(raw.hardware),
-      model: raw.model || 'unknown',
-      topology: raw.topology || 'unknown',
-      islOsl: raw.islosl || '--',
-      isl: parseAtomeshNumber(isl),
-      osl: parseAtomeshNumber(osl),
-      concurrency: parseAtomeshNumber(raw.concurrency),
-      interactivity,
-      interactivityMethod: Number.isFinite(intvtyE2eNorm) ? 'p90_e2e_normalized' : 'median_tpot',
-      interactivityP90Itl: parseAtomeshNumber(raw.intvtyp90itl),
-      totalTput: parseAtomeshNumber(raw.totaltoks),
-      inputTput: parseAtomeshNumber(raw.inputtoks),
-      outputTput: parseAtomeshNumber(raw.outputtoks),
-      totalTputPerGpu,
-      inputTputPerGpu: parseAtomeshNumber(raw.inputtoksgpu),
-      outputTputPerGpu,
-      ttftMs: parseAtomeshNumber(raw.ttftms),
-      tpotMs: parseAtomeshNumber(raw.tpotms),
-      e2eMs: parseAtomeshNumber(raw.e2ems),
-      // The summary table prints this column as a percentage; the point payload
-      // carries a 0-1 fraction, so normalise to the fraction here too.
-      cacheHitRate: cacheHitPct != null ? cacheHitPct / 100 : null,
-      accuracyTask,
-      accuracyMetric: accuracyTask === 'gsm8k' ? 'flexible-extract' : '',
-      accuracyScore,
-      accuracyRaw: raw.accuracy || raw.gsm8k || '--',
-      gsm8k,
-      gsm8kRaw: raw.gsm8k || '--',
-      runUrl: ATOMESH_DATA.runUrl,
-      status: Number.isFinite(interactivity) && Number.isFinite(totalTputPerGpu ?? outputTputPerGpu) ? 'completed' : 'incomplete',
-    };
-  }).filter(row => row.model !== 'unknown' || row.topology !== 'unknown');
+  const interactivityKey = atomeshSummaryInteractivityKey(headers);
+  // A bare "Interactivity" header means the table mixes both definitions and so
+  // cannot name one. Leave the method unset rather than inventing one; older
+  // summaries carried it in an "Intvty def" column of their own, which still wins.
+  const headerMethod = interactivityKey === ATOMESH_INTERACTIVITY_KEY ? '' : interactivityKey;
+  return lines.slice(2)
+    // Guard against a second table appended below this one: its alignment row
+    // would otherwise be read as data.
+    .filter(line => !/^\|[\s:|-]+\|$/.test(line))
+    .map((line, idx) => {
+      const cells = line.split('|').slice(1, -1).map(cell => cell.trim());
+      const raw = {};
+      headers.forEach((header, i) => { raw[header] = cells[i] || ''; });
+      const [isl, osl] = String(raw.islosl || '').split('/');
+      const totalTputPerGpu = parseAtomeshNumber(raw.totaltoksgpu);
+      const outputTputPerGpu = parseAtomeshNumber(raw.outputtoksgpu);
+      const interactivity = parseAtomeshNumber(raw[interactivityKey]);
+      const gsm8k = parseAtomeshNumber(raw.gsm8k);
+      const cacheHitPct = parseAtomeshNumber(String(raw.cachehit || '').replace('%', ''));
+      const accuracyScore = parseAtomeshNumber(raw.accuracy) ?? gsm8k;
+      const accuracyTask = raw.accuracytask || (Number.isFinite(gsm8k) ? 'gsm8k' : '');
+      const tp = parseAtomeshPdLabel(raw.tp);
+      const dcp = parseAtomeshPdLabel(raw.dcp);
+      return {
+        id: `atomesh-summary-${idx}`,
+        backend: ATOMESH_DATA.backend,
+        hardware: atomeshHardwareKey(raw.hardware),
+        model: raw.model || 'unknown',
+        topology: raw.topology || 'unknown',
+        islOsl: raw.islosl || '--',
+        isl: parseAtomeshNumber(isl),
+        osl: parseAtomeshNumber(osl),
+        concurrency: parseAtomeshNumber(raw.concurrency),
+        interactivity,
+        interactivityMethod: atomeshInteractivityMethod(raw.intvtydef || headerMethod),
+        totalTput: parseAtomeshNumber(raw.totaltoks),
+        inputTput: parseAtomeshNumber(raw.inputtoks),
+        outputTput: parseAtomeshNumber(raw.outputtoks),
+        totalTputPerGpu,
+        inputTputPerGpu: parseAtomeshNumber(raw.inputtoksgpu),
+        outputTputPerGpu,
+        // `*ms` are the pre-p90 header spellings, kept so summaries archived
+        // before the percentile columns landed still populate the mean.
+        ttftMs: parseAtomeshNumber(raw.ttftmeanms ?? raw.ttftms),
+        ttftP90Ms: parseAtomeshNumber(raw.ttftp90ms),
+        ttftP99Ms: parseAtomeshNumber(raw.ttftp99ms),
+        tpotMs: parseAtomeshNumber(raw.tpotmeanms ?? raw.tpotms),
+        tpotP90Ms: parseAtomeshNumber(raw.tpotp90ms),
+        tpotP99Ms: parseAtomeshNumber(raw.tpotp99ms),
+        e2eMs: parseAtomeshNumber(raw.e2emeanms ?? raw.e2ems),
+        e2eP90Ms: parseAtomeshNumber(raw.e2ep90ms),
+        e2eP99Ms: parseAtomeshNumber(raw.e2ep99ms),
+        prefillTp: tp.prefill,
+        decodeTp: tp.decode,
+        prefillDcp: dcp.prefill,
+        decodeDcp: dcp.decode,
+        speculativeMethod: raw.spec && raw.spec !== '--' ? raw.spec : '',
+        // The summary table prints this column as a percentage; the point payload
+        // carries a 0-1 fraction, so normalise to the fraction here too.
+        cacheHitRate: cacheHitPct != null ? cacheHitPct / 100 : null,
+        accuracyTask,
+        accuracyMetric: accuracyTask === 'gsm8k' ? 'flexible-extract' : '',
+        accuracyScore,
+        accuracyRaw: raw.accuracy || raw.gsm8k || '--',
+        gsm8k,
+        gsm8kRaw: raw.gsm8k || '--',
+        runUrl: ATOMESH_DATA.runUrl,
+        status: Number.isFinite(interactivity) && Number.isFinite(totalTputPerGpu ?? outputTputPerGpu) ? 'completed' : 'incomplete',
+      };
+    }).filter(row => row.model !== 'unknown' || row.topology !== 'unknown');
 }
 
 function parseAtomeshPerfPointExtra(extra) {
@@ -674,8 +715,14 @@ function atomeshPointRow(point, meta, idx) {
     inputTputPerGpu: atomeshPointNumber(point, 'input_tput_per_gpu'),
     outputTputPerGpu,
     ttftMs: atomeshPointNumber(point, 'ttft_ms'),
+    ttftP90Ms: atomeshPointNumber(point, 'ttft_p90'),
+    ttftP99Ms: atomeshPointNumber(point, 'ttft_p99'),
     tpotMs: atomeshPointNumber(point, 'tpot_ms'),
+    tpotP90Ms: atomeshPointNumber(point, 'tpot_p90'),
+    tpotP99Ms: atomeshPointNumber(point, 'tpot_p99'),
     e2eMs: atomeshPointNumber(point, 'e2el_ms'),
+    e2eP90Ms: atomeshPointNumber(point, 'e2el_p90'),
+    e2eP99Ms: atomeshPointNumber(point, 'e2el_p99'),
     // Prefill prefix-cache token hit rate, 0-1. Only present for cases that run
     // with prefix caching on and long enough for the engine to report it.
     cacheHitRate: atomeshPointNumber(point, 'cache_hit_rate'),
@@ -700,6 +747,9 @@ function atomeshPointRow(point, meta, idx) {
     totalGpu: atomeshPointNumber(point, 'total_gpu'),
     prefillTp: atomeshPointNumber(point, 'prefill_tp'),
     decodeTp: atomeshPointNumber(point, 'decode_tp'),
+    prefillDcp: atomeshPointNumber(point, 'prefill_dcp'),
+    decodeDcp: atomeshPointNumber(point, 'decode_dcp'),
+    speculativeMethod: point.speculative_method || '',
     prefillWorkers: atomeshPointNumber(point, 'prefill_workers'),
     decodeWorkers: atomeshPointNumber(point, 'decode_workers'),
     numPrefillGpu: atomeshPointNumber(point, 'num_prefill_gpu'),
@@ -3134,6 +3184,30 @@ function atomeshTpLabel(row) {
   }
   return row.prefillTp ?? row.decodeTp ?? '—';
 }
+function atomeshDcpLabel(row) {
+  if (row.prefillDcp != null && row.decodeDcp != null && row.prefillDcp !== row.decodeDcp) {
+    return `P${row.prefillDcp}/D${row.decodeDcp}`;
+  }
+  return row.prefillDcp ?? row.decodeDcp ?? '—';
+}
+// process_result.py folds the token count into the method ("dspark-3") on both
+// the point and the summary paths, so this only has to reject the em-dash
+// placeholder a summary row carries when the case runs no speculative decoding.
+function atomeshSpeculativeLabel(row) {
+  const method = String(row.speculativeMethod || '').trim();
+  return !method || method === '--' ? '—' : method;
+}
+// Three statistics per metric: an agentic trace routinely has a p99 TTFT an order
+// of magnitude above its mean, which a lone averaged number hides completely.
+function atomeshLatencyRowsHTML(row) {
+  return [
+    ['TTFT', row.ttftMs, row.ttftP90Ms, row.ttftP99Ms],
+    ['TPOT', row.tpotMs, row.tpotP90Ms, row.tpotP99Ms],
+    ['E2E', row.e2eMs, row.e2eP90Ms, row.e2eP99Ms],
+  ].map(([label, mean, p90, p99]) => `<div class="pop-row"><span class="pop-key">${label} mean / p90 / p99 (ms)</span><span class="pop-val">${
+    [mean, p90, p99].map(v => Number.isFinite(v) ? fmtNum(v, 2) : '—').join(' / ')
+  }</span></div>`).join('');
+}
 function atomeshDpAttentionLabel(row) {
   if (row.prefillDpa && row.decodeDpa) return 'True';
   if (row.prefillDpa) return 'Prefill only';
@@ -3157,11 +3231,10 @@ function atomeshCacheHitRowHTML(row) {
 // 1/p90(ITL) -- and so gets its own row rather than sharing this one.
 function atomeshInteractivityRowHTML(row) {
   const isP90 = row.interactivityMethod === 'p90_e2e_normalized';
-  const key = isP90 ? 'E2E Norm. Interactivity p90 (tok/s/user)' : 'Interactivity (tok/s/user)';
-  const note = isP90 || !Number.isFinite(row.interactivity)
-    ? ''
-    : ` <span style="color:var(--text-tertiary)">(median TPOT)</span>`;
-  let html = `<div class="pop-row"><span class="pop-key">${key}</span><span class="pop-val">${atomeshDetailValue(row.interactivity, v => fmtNum(v, 3))}${note}</span></div>`;
+  // Same wording as the markdown summary's column header, so the two read as
+  // the same metric rather than two that happen to share a name.
+  const definition = isP90 ? 'P90 E2E Normalized' : '1 / median_tpot_s';
+  let html = `<div class="pop-row"><span class="pop-key">Interactivity (${definition}) (tok/s/user)</span><span class="pop-val">${atomeshDetailValue(row.interactivity, v => fmtNum(v, 3))}</span></div>`;
   // Second row only when the plain metric was actually measured: rendering an
   // em dash for every legacy point would suggest a value went missing rather
   // than that the run predates the metric.
@@ -3188,16 +3261,18 @@ function showAtomeshPopover(row) {
       <div class="pop-row"><span class="pop-key">Input Token Throughput per GPU</span><span class="pop-val">${atomeshDetailValue(row.inputTputPerGpu, v => fmtNum(v, 3))}</span></div>
       <div class="pop-row"><span class="pop-key">Output Token Throughput per GPU</span><span class="pop-val">${atomeshDetailValue(row.outputTputPerGpu, v => fmtNum(v, 3))}</span></div>
       <div class="pop-row"><span class="pop-key">Total tok/s</span><span class="pop-val">${atomeshDetailValue(row.totalTput, v => fmtNum(v, 3))}</span></div>
-      <div class="pop-row"><span class="pop-key">TTFT / TPOT / E2E</span><span class="pop-val">${[row.ttftMs, row.tpotMs, row.e2eMs].map(v => v != null ? fmtNum(v, 2) : '—').join(' / ')} ms</span></div>
+      ${atomeshLatencyRowsHTML(row)}
       ${atomeshCacheHitRowHTML(row)}
     </div>
     <div class="pop-section">
       <div class="pop-row"><span class="pop-key">Topology</span><span class="pop-val" style="font-family:inherit">${escHTML(row.sourceTopology || row.topology || '—')}</span></div>
       <div class="pop-row"><span class="pop-key">Total GPUs</span><span class="pop-val">${atomeshDetailValue(row.totalGpu)}</span></div>
       <div class="pop-row"><span class="pop-key">Tensor Parallelism</span><span class="pop-val">${escHTML(String(atomeshTpLabel(row)))}</span></div>
+      <div class="pop-row"><span class="pop-key">Decode Context Parallelism</span><span class="pop-val">${escHTML(String(atomeshDcpLabel(row)))}</span></div>
+      <div class="pop-row"><span class="pop-key">Speculative Method</span><span class="pop-val">${escHTML(atomeshSpeculativeLabel(row))}</span></div>
       <div class="pop-row"><span class="pop-key">Prefill/Decode Workers</span><span class="pop-val">${row.prefillWorkers ?? '—'} / ${row.decodeWorkers ?? '—'}</span></div>
       <div class="pop-row"><span class="pop-key">Prefill/Decode GPUs</span><span class="pop-val">${row.numPrefillGpu ?? '—'} / ${row.numDecodeGpu ?? '—'}</span></div>
-      <div class="pop-row"><span class="pop-key">Expert Parallelism</span><span class="pop-val">${atomeshDetailValue(row.expertParallelism ?? 1)}</span></div>
+      <div class="pop-row"><span class="pop-key">Expert Parallelism</span><span class="pop-val">${atomeshDetailValue(row.expertParallelism)}</span></div>
       <div class="pop-row"><span class="pop-key">DP Attention</span><span class="pop-val">${atomeshDpAttentionLabel(row)}</span></div>
       <div class="pop-row"><span class="pop-key">Concurrency</span><span class="pop-val">${atomeshDetailValue(row.concurrency)}</span></div>
       <div class="pop-row"><span class="pop-key">Precision</span><span class="pop-val">${escHTML(String(row.precision || '—').toUpperCase())}</span></div>

--- a/.github/scripts/atomesh/aiperf_console_report.py
+++ b/.github/scripts/atomesh/aiperf_console_report.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Render AIPerf's own console summary tables as a markdown section.
+
+process_result.py reduces every run to one row of a comparison table, which
+drops the metrics AIPerf reports but the dashboard does not track -- prefill vs
+decode throughput, tokens in flight, CO-aware latency, the full percentile
+spread. Those matter when triaging an agentic run, so the raw tables are
+reproduced verbatim next to the summary.
+
+Only agentic runs have anything to show: profile_export_console.txt is written
+by AIPerf alone, so its absence is what makes this a no-op for standard
+ISL/OSL cases rather than an explicit benchmark-kind check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+CONSOLE_FILENAME = "profile_export_console.txt"
+
+
+def artifact_label(path: Path) -> str:
+    """Identify the run a console dump belongs to.
+
+    The artifact directory is named aiperf-<model>-<topology>-c<conc>, which is
+    the case identity; the slurm_job-<id> above it disambiguates re-runs of the
+    same case merged into one result tree.
+    """
+    parts = [path.parent.name]
+    for parent in path.parents:
+        if parent.name.startswith("slurm_job-"):
+            parts.insert(0, parent.name)
+            break
+    return " / ".join(parts)
+
+
+def render(root: Path) -> str:
+    sections = []
+    for path in sorted(root.rglob(CONSOLE_FILENAME)):
+        try:
+            body = path.read_text(encoding="utf-8", errors="replace").strip("\n")
+        except OSError as exc:
+            print(f"WARNING: cannot read {path}: {exc}", file=sys.stderr)
+            continue
+        if not body:
+            continue
+        # Collapsed by default: each dump is ~80 lines of fixed-width tables and
+        # a run can hold several, which would bury the comparison table above it.
+        sections.append(
+            f"<details><summary>AIPerf raw metrics — {artifact_label(path)}"
+            f"</summary>\n\n```text\n{body}\n```\n\n</details>"
+        )
+    if not sections:
+        return ""
+    return "\n\n".join(["### AIPerf Raw Metrics (agentic runs)", *sections]) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result_dir", help="Directory containing benchmark artifacts")
+    parser.add_argument(
+        "--output", default=None, help="Write markdown here instead of stdout"
+    )
+    args = parser.parse_args()
+
+    markdown = render(Path(args.result_dir))
+    if args.output:
+        Path(args.output).write_text(markdown, encoding="utf-8")
+        print(
+            f"AIPerf raw metrics: {'written to ' + args.output if markdown else 'none found'}"
+        )
+        return
+    sys.stdout.write(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/atomesh/pd_server_atom.sh
+++ b/.github/scripts/atomesh/pd_server_atom.sh
@@ -712,6 +712,7 @@ run_benchmark() {
         --ignore-eos \
         --save-result \
         --percentile-metrics='ttft,tpot,itl,e2el' \
+        --metric-percentiles='90,99' \
         --result-dir="${RUN_DIR}/benchmark_results" \
         --result-filename="${result_file}"
     done
@@ -811,12 +812,15 @@ payload = {
     "request_throughput": avg("request_throughput"),
     "mean_ttft_ms": avg("time_to_first_token"),
     "median_ttft_ms": pct("time_to_first_token", "p50"),
+    "p90_ttft_ms": pct("time_to_first_token", "p90"),
     "p99_ttft_ms": pct("time_to_first_token", "p99"),
     "mean_itl_ms": avg("inter_token_latency"),
     "median_itl_ms": pct("inter_token_latency", "p50"),
+    "p90_itl_ms": pct("inter_token_latency", "p90"),
     "p99_itl_ms": pct("inter_token_latency", "p99"),
     "mean_e2el_ms": avg("request_latency"),
     "median_e2el_ms": pct("request_latency", "p50"),
+    "p90_e2el_ms": pct("request_latency", "p90"),
     "p99_e2el_ms": pct("request_latency", "p99"),
     "input_throughput": avg("input_token_throughput"),
     "output_throughput": avg("output_token_throughput"),

--- a/.github/scripts/atomesh/pd_server_atom.sh
+++ b/.github/scripts/atomesh/pd_server_atom.sh
@@ -32,6 +32,8 @@ xP="${xP:-1}"
 yD="${yD:-1}"
 PREFILL_TP_SIZE="${PREFILL_TP_SIZE:-8}"
 DECODE_TP_SIZE="${DECODE_TP_SIZE:-8}"
+PREFILL_DCP_SIZE="${PREFILL_DCP_SIZE:-1}"
+DECODE_DCP_SIZE="${DECODE_DCP_SIZE:-1}"
 PREFILL_ENABLE_DP="${PREFILL_ENABLE_DP:-false}"
 DECODE_ENABLE_DP="${DECODE_ENABLE_DP:-false}"
 
@@ -109,6 +111,9 @@ HF_OVERRIDES="${HF_OVERRIDES:-}"
 SPEC_METHOD="${SPEC_METHOD:-}"
 DRAFT_MODEL_PATH="${DRAFT_MODEL_PATH:-}"
 NUM_SPEC_TOKENS="${NUM_SPEC_TOKENS:-}"
+SPEC_DECODE_ACCEPTANCE_LENGTH="${SPEC_DECODE_ACCEPTANCE_LENGTH:-}"
+STATE_CHECKPOINT_INTERVAL_TOKENS="${STATE_CHECKPOINT_INTERVAL_TOKENS:-}"
+STATE_CHECKPOINT_SLOTS="${STATE_CHECKPOINT_SLOTS:-}"
 EXTRA_SERVER_ARGS="${EXTRA_SERVER_ARGS:-}"
 PREFILL_EXTRA_SERVER_ARGS="${PREFILL_EXTRA_SERVER_ARGS:-}"
 DECODE_EXTRA_SERVER_ARGS="${DECODE_EXTRA_SERVER_ARGS:-}"
@@ -180,6 +185,7 @@ AIPERF_VENV="${AIPERF_VENV:-/tmp/atomesh-aiperf-venv}"
 AIPERF_COMMIT="${AIPERF_COMMIT:-b7b16cf851885567988a643282266bce74e34437}"
 AIPERF_SCENARIO="${AIPERF_SCENARIO:-inferencex-agentx-mvp}"
 AIPERF_PUBLIC_DATASET="${AIPERF_PUBLIC_DATASET:-semianalysis_cc_traces_weka_062126_256k}"
+AIPERF_APPLY_CHAT_TEMPLATE="${AIPERF_APPLY_CHAT_TEMPLATE:-false}"
 AIPERF_MAX_CONTEXT_LENGTH="${AIPERF_MAX_CONTEXT_LENGTH:-262144}"
 AIPERF_NUM_DATASET_ENTRIES="${AIPERF_NUM_DATASET_ENTRIES:-393}"
 AIPERF_BENCHMARK_DURATION="${AIPERF_BENCHMARK_DURATION:-1800}"
@@ -320,12 +326,18 @@ else
   done
 fi
 
-prefill_parallel=(-tp "${PREFILL_TP_SIZE}")
+prefill_parallel=(
+  -tp "${PREFILL_TP_SIZE}"
+  --decode-context-parallel-size "${PREFILL_DCP_SIZE}"
+)
 if [[ "${PREFILL_ENABLE_DP}" == "true" ]]; then
   prefill_parallel+=("--enable-dp-attention")
 fi
 
-decode_parallel=(-tp "${DECODE_TP_SIZE}")
+decode_parallel=(
+  -tp "${DECODE_TP_SIZE}"
+  --decode-context-parallel-size "${DECODE_DCP_SIZE}"
+)
 if [[ "${DECODE_ENABLE_DP}" == "true" ]]; then
   decode_parallel+=("--enable-dp-attention")
 fi
@@ -403,6 +415,19 @@ if [[ -n "${DRAFT_MODEL_PATH}" ]]; then
 fi
 if [[ -n "${NUM_SPEC_TOKENS}" ]]; then
   server_common+=(--num-speculative-tokens "${NUM_SPEC_TOKENS}")
+fi
+if [[ -n "${SPEC_DECODE_ACCEPTANCE_LENGTH}" ]]; then
+  server_common+=(
+    --spec-decode-acceptance-length "${SPEC_DECODE_ACCEPTANCE_LENGTH}"
+  )
+fi
+if [[ -n "${STATE_CHECKPOINT_INTERVAL_TOKENS}" ]]; then
+  server_common+=(
+    --state-checkpoint-interval-tokens "${STATE_CHECKPOINT_INTERVAL_TOKENS}"
+  )
+fi
+if [[ -n "${STATE_CHECKPOINT_SLOTS}" ]]; then
+  server_common+=(--state-checkpoint-slots "${STATE_CHECKPOINT_SLOTS}")
 fi
 
 wait_http() {
@@ -902,9 +927,14 @@ run_aiperf_agentic_benchmark() {
     local aiperf_json="${out_dir}/profile_export_aiperf.json"
     local dashboard_json="${RUN_DIR}/benchmark_results/${result_file}"
     local -a unsafe_args=()
+    local -a chat_template_args=()
     if (( AIPERF_BENCHMARK_DURATION < 900 )) \
       || [[ "${AIPERF_UNSAFE_OVERRIDE}" == "1" || "${AIPERF_UNSAFE_OVERRIDE}" == "true" ]]; then
       unsafe_args+=(--unsafe-override)
+    fi
+    if [[ "${AIPERF_APPLY_CHAT_TEMPLATE}" == "1" \
+      || "${AIPERF_APPLY_CHAT_TEMPLATE}" == "true" ]]; then
+      chat_template_args+=(--apply-chat-template)
     fi
 
     echo "[aiperf] ${result_file}"
@@ -937,6 +967,7 @@ run_aiperf_agentic_benchmark() {
       --no-gpu-telemetry \
       --tokenizer "${MODEL_PATH}" \
       --tokenizer-trust-remote-code \
+      "${chat_template_args[@]}" \
       --max-context-length "${AIPERF_MAX_CONTEXT_LENGTH}" \
       --num-dataset-entries "${AIPERF_NUM_DATASET_ENTRIES}" \
       --slice-duration "${AIPERF_SLICE_DURATION}" \
@@ -1150,10 +1181,10 @@ run_benchmark_and_eval() {
     return
   fi
   if [[ "${BENCHMARK_KIND}" == "aiperf_agentic" \
-    && "${EVAL_TASK}" == "swebench_lite" \
+    && ( "${EVAL_TASK}" == "swebench_lite" || "${EVAL_TASK}" == "gsm8k" ) \
     && ( "${RUN_EVAL}" == "true" || "${RUN_EVAL}" == "1" ) ]]; then
-    # Agentic performance cases require a fresh prefix-cache state. Run their
-    # trace benchmark before the independent SWE-bench workload.
+    # Agentic performance cases require a fresh prefix/state-cache state. Run
+    # their trace benchmark before any independent accuracy workload.
     run_benchmark
     run_eval
   else

--- a/.github/scripts/atomesh/pd_server_atom.sh
+++ b/.github/scripts/atomesh/pd_server_atom.sh
@@ -113,7 +113,6 @@ DRAFT_MODEL_PATH="${DRAFT_MODEL_PATH:-}"
 NUM_SPEC_TOKENS="${NUM_SPEC_TOKENS:-}"
 SPEC_DECODE_ACCEPTANCE_LENGTH="${SPEC_DECODE_ACCEPTANCE_LENGTH:-}"
 STATE_CHECKPOINT_INTERVAL_TOKENS="${STATE_CHECKPOINT_INTERVAL_TOKENS:-}"
-STATE_CHECKPOINT_SLOTS="${STATE_CHECKPOINT_SLOTS:-}"
 EXTRA_SERVER_ARGS="${EXTRA_SERVER_ARGS:-}"
 PREFILL_EXTRA_SERVER_ARGS="${PREFILL_EXTRA_SERVER_ARGS:-}"
 DECODE_EXTRA_SERVER_ARGS="${DECODE_EXTRA_SERVER_ARGS:-}"
@@ -342,23 +341,65 @@ if [[ "${DECODE_ENABLE_DP}" == "true" ]]; then
   decode_parallel+=("--enable-dp-attention")
 fi
 
+# AgentX captures every query-token count the engine can produce, i.e. the dense
+# range [2, graph_max] with graph_max = seqs * (1 + spec_tokens), where seqs
+# defaults to 2 * CONC. Concurrencies whose in-flight window is wider than
+# 2 * CONC pin seqs explicitly via cudagraph_max_num_seqs.
+auto_cudagraph_capture_sizes() {
+  local role="$1"
+  local seqs="$2"
+  local conc spec graph_max
+  spec="${NUM_SPEC_TOKENS:-0}"
+  [[ "${spec}" =~ ^[0-9]+$ ]] || spec=0
+  if [[ ! "${seqs}" =~ ^[0-9]+$ ]]; then
+    conc="$(echo "${BENCH_MAX_CONCURRENCY}" | tr 'x,' '\n' | sort -n | tail -1)"
+    [[ "${conc}" =~ ^[0-9]+$ ]] || conc=1
+    seqs=$(( 2 * conc ))
+  fi
+  graph_max=$(( seqs * (1 + spec) ))
+  if (( graph_max < 2 )); then
+    graph_max=2
+  fi
+  echo "[${role}] cudagraph auto range 2..${graph_max} (seqs=${seqs} spec=${spec})" >&2
+  echo "[$(seq -s, 2 "${graph_max}")]"
+}
+
 build_cudagraph_args() {
-  local value="$1"
+  local role="$1"
   local -n out="$2"
-  case "${value:-}" in
+  local prefix="${role^^}"
+  local sizes_var="${prefix}_CUDAGRAPH"
+  local mode_var="${prefix}_CUDAGRAPH_MODE"
+  local level_var="${prefix}_COMPILATION_LEVEL"
+  local seqs_var="${prefix}_CUDAGRAPH_MAX_NUM_SEQS"
+  local mode="${!mode_var:-}"
+  local level="${!level_var:-}"
+  case "${!sizes_var:-}" in
     ""|none|None|NONE|false|False|FALSE|off|Off|OFF|disabled|Disabled|DISABLED)
       out=()
       ;;
+    auto|Auto|AUTO)
+      out=(
+        --cudagraph-capture-sizes
+        "$(auto_cudagraph_capture_sizes "${role}" "${!seqs_var:-}")"
+      )
+      ;;
     *)
-      out=(--cudagraph-capture-sizes "${value}")
+      out=(--cudagraph-capture-sizes "${!sizes_var}")
       ;;
   esac
+  if [[ -n "${mode}" ]]; then
+    out+=(--cudagraph-mode "${mode}")
+  fi
+  if [[ -n "${level}" ]]; then
+    out+=(--level "${level}")
+  fi
 }
 
 prefill_cudagraph_args=()
 decode_cudagraph_args=()
-build_cudagraph_args "${PREFILL_CUDAGRAPH:-}" prefill_cudagraph_args
-build_cudagraph_args "${DECODE_CUDAGRAPH:-}" decode_cudagraph_args
+build_cudagraph_args prefill prefill_cudagraph_args
+build_cudagraph_args decode decode_cudagraph_args
 
 build_server_cache_env() {
   local role="$1"
@@ -416,9 +457,14 @@ fi
 if [[ -n "${NUM_SPEC_TOKENS}" ]]; then
   server_common+=(--num-speculative-tokens "${NUM_SPEC_TOKENS}")
 fi
-if [[ -n "${SPEC_DECODE_ACCEPTANCE_LENGTH}" ]]; then
+spec_decode_acceptance_for_server="${SPEC_DECODE_ACCEPTANCE_LENGTH}"
+if [[ "${ATOMESH_EXECUTION_PHASE}" == "eval" && "${EVAL_TASK}" == "gsm8k" ]]; then
+  spec_decode_acceptance_for_server=""
+  echo "[runtime] omitting spec-decode-acceptance-length for gsm8k eval phase"
+fi
+if [[ -n "${spec_decode_acceptance_for_server}" ]]; then
   server_common+=(
-    --spec-decode-acceptance-length "${SPEC_DECODE_ACCEPTANCE_LENGTH}"
+    --spec-decode-acceptance-length "${spec_decode_acceptance_for_server}"
   )
 fi
 if [[ -n "${STATE_CHECKPOINT_INTERVAL_TOKENS}" ]]; then
@@ -426,10 +472,6 @@ if [[ -n "${STATE_CHECKPOINT_INTERVAL_TOKENS}" ]]; then
     --state-checkpoint-interval-tokens "${STATE_CHECKPOINT_INTERVAL_TOKENS}"
   )
 fi
-if [[ -n "${STATE_CHECKPOINT_SLOTS}" ]]; then
-  server_common+=(--state-checkpoint-slots "${STATE_CHECKPOINT_SLOTS}")
-fi
-
 wait_http() {
   local url="$1"
   local name="$2"
@@ -584,7 +626,7 @@ start_prefill() {
   else
     prefill_kv_transfer_config="{\"kv_role\":\"kv_producer\",\"kv_connector\":\"mooncake\",\"proxy_ip\":\"${host_ip}\",\"handshake_port\":${handshake_port}}"
   fi
-  echo "[prefill] rank=${NODE_RANK} host=${host_name} ip=${host_ip} gpu=${HIP_VISIBLE_DEVICES} port=${server_port} handshake=${handshake_port} dp_master=${dp_master_port} dp_base=${dp_base_port} cudagraph=${PREFILL_CUDAGRAPH:-none}"
+  echo "[prefill] rank=${NODE_RANK} host=${host_name} ip=${host_ip} gpu=${HIP_VISIBLE_DEVICES} port=${server_port} handshake=${handshake_port} dp_master=${dp_master_port} dp_base=${dp_base_port} cudagraph=${prefill_cudagraph_args[*]:-none}"
   local -a prefill_cmd=(
     python3 -m atom.entrypoints.openai_server
     "${server_common[@]}"
@@ -636,7 +678,7 @@ start_decode() {
   else
     decode_kv_transfer_config="{\"kv_role\":\"kv_consumer\",\"kv_connector\":\"mooncake\",\"proxy_ip\":\"${host_ip}\",\"handshake_port\":${handshake_port}}"
   fi
-  echo "[decode] rank=${NODE_RANK} host=${host_name} ip=${host_ip} gpu=${HIP_VISIBLE_DEVICES} port=${server_port} handshake=${handshake_port} dp_master=${dp_master_port} dp_base=${dp_base_port} cudagraph=${DECODE_CUDAGRAPH:-none}"
+  echo "[decode] rank=${NODE_RANK} host=${host_name} ip=${host_ip} gpu=${HIP_VISIBLE_DEVICES} port=${server_port} handshake=${handshake_port} dp_master=${dp_master_port} dp_base=${dp_base_port} cudagraph=${decode_cudagraph_args[*]:-none}"
   local -a decode_cmd=(
     python3 -m atom.entrypoints.openai_server
     "${server_common[@]}"

--- a/.github/scripts/atomesh/pd_slurm_job.sh
+++ b/.github/scripts/atomesh/pd_slurm_job.sh
@@ -15,7 +15,8 @@ mkdir -p "${RUN_DIR}"
 
 EXECUTION_PHASES=(combined)
 if [[ "${BENCHMARK_KIND:-random}" == "aiperf_agentic" \
-  && "${EVAL_TASK:-gsm8k}" == "swebench_lite" \
+  && ( "${EVAL_TASK:-gsm8k}" == "swebench_lite" \
+    || "${EVAL_TASK:-gsm8k}" == "gsm8k" ) \
   && ( "${RUN_EVAL:-false}" == "true" || "${RUN_EVAL:-false}" == "1" ) ]]; then
   EXECUTION_PHASES=(benchmark eval)
 fi
@@ -73,6 +74,7 @@ allow = (
     # Preserve FlyDSL cache overrides for non-root Spur containers.
     "FLYDSL_",
     "SPEC_",
+    "STATE_CHECKPOINT_",
     "DRAFT_MODEL_PATH",
     "NUM_SPEC_TOKENS",
     "EXTRA_SERVER_ARGS",

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -134,6 +134,9 @@ exports = {
     "AIPERF_COMMIT": benchmark.get("aiperf_commit", ""),
     "AIPERF_SCENARIO": benchmark.get("scenario", ""),
     "AIPERF_PUBLIC_DATASET": benchmark.get("public_dataset", ""),
+    "AIPERF_APPLY_CHAT_TEMPLATE": str(
+        benchmark.get("apply_chat_template", False)
+    ).lower(),
     "AIPERF_MAX_CONTEXT_LENGTH": benchmark.get("max_context_length", ""),
     "AIPERF_NUM_DATASET_ENTRIES": benchmark.get("num_dataset_entries", ""),
     "AIPERF_BENCHMARK_DURATION": benchmark.get("benchmark_duration", ""),
@@ -172,6 +175,8 @@ exports = {
     "DECODE_WORKERS": decode.get("workers", 1),
     "PREFILL_TP": prefill.get("tp", 8),
     "DECODE_TP": decode.get("tp", 8),
+    "PREFILL_DCP_SIZE": prefill.get("dcp", 1),
+    "DECODE_DCP_SIZE": decode.get("dcp", 1),
     "PREFILL_ENABLE_DP": str(prefill.get("enable_dp_attention", False)).lower(),
     "DECODE_ENABLE_DP": str(decode.get("enable_dp_attention", False)).lower(),
     "PREFILL_CUDAGRAPH": prefill.get("cudagraph", ""),
@@ -199,6 +204,13 @@ exports = {
     "SPEC_METHOD": server_args.get("method", ""),
     "DRAFT_MODEL_PATH": server_args.get("draft_model", ""),
     "NUM_SPEC_TOKENS": server_args.get("num_speculative_tokens", ""),
+    "SPEC_DECODE_ACCEPTANCE_LENGTH": server_args.get(
+        "spec_decode_acceptance_length", ""
+    ),
+    "STATE_CHECKPOINT_INTERVAL_TOKENS": server_args.get(
+        "state_checkpoint_interval_tokens", ""
+    ),
+    "STATE_CHECKPOINT_SLOTS": server_args.get("state_checkpoint_slots", ""),
     "EXTRA_SERVER_ARGS": server_args.get("extra_args", ""),
     "PREFILL_EXTRA_SERVER_ARGS": prefill.get("extra_args", ""),
     "DECODE_EXTRA_SERVER_ARGS": decode.get("extra_args", ""),

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -70,9 +70,23 @@ service = cell.get("service", {})
 prefill = service.get("prefill", {})
 decode = service.get("decode", {})
 router = service.get("router", {})
-server_args = cell.get("server_args", {})
 benchmark = cell.get("benchmark", {})
 accuracy = cell.get("accuracy", {})
+
+
+class TrackedArgs(dict):
+    """Remembers which keys the export mapping below actually reads."""
+
+    def __init__(self, data):
+        super().__init__(data)
+        self.seen = set()
+
+    def get(self, key, default=None):
+        self.seen.add(key)
+        return super().get(key, default)
+
+
+server_args = TrackedArgs(cell.get("server_args", {}))
 
 def shell_value(value):
     if isinstance(value, (list, dict)):
@@ -181,6 +195,12 @@ exports = {
     "DECODE_ENABLE_DP": str(decode.get("enable_dp_attention", False)).lower(),
     "PREFILL_CUDAGRAPH": prefill.get("cudagraph", ""),
     "DECODE_CUDAGRAPH": decode.get("cudagraph", ""),
+    "PREFILL_CUDAGRAPH_MODE": prefill.get("cudagraph_mode", ""),
+    "DECODE_CUDAGRAPH_MODE": decode.get("cudagraph_mode", ""),
+    "PREFILL_COMPILATION_LEVEL": prefill.get("compilation_level", ""),
+    "DECODE_COMPILATION_LEVEL": decode.get("compilation_level", ""),
+    "PREFILL_CUDAGRAPH_MAX_NUM_SEQS": prefill.get("cudagraph_max_num_seqs", ""),
+    "DECODE_CUDAGRAPH_MAX_NUM_SEQS": decode.get("cudagraph_max_num_seqs", ""),
     "PREFILL_PORT": prefill.get("port", 8010),
     "DECODE_PORT": decode.get("port", 8020),
     "ROUTER_PORT": router.get("port", 8000),
@@ -210,7 +230,6 @@ exports = {
     "STATE_CHECKPOINT_INTERVAL_TOKENS": server_args.get(
         "state_checkpoint_interval_tokens", ""
     ),
-    "STATE_CHECKPOINT_SLOTS": server_args.get("state_checkpoint_slots", ""),
     "EXTRA_SERVER_ARGS": server_args.get("extra_args", ""),
     "PREFILL_EXTRA_SERVER_ARGS": prefill.get("extra_args", ""),
     "DECODE_EXTRA_SERVER_ARGS": decode.get("extra_args", ""),
@@ -248,6 +267,20 @@ exports = {
         os.environ.get("SPUR_ACCOUNTING_ADDR", default_spur_accounting_addr),
     ),
 }
+
+# server_args is mapped key by key above, so a key the mapping never read would
+# be dropped without a trace. The launcher always passes --trust-remote-code.
+server_args.get("trust_remote_code")
+dropped = sorted(set(server_args) - server_args.seen)
+if dropped:
+    reason = (
+        f"ERROR: {cell['id']} sets unsupported server_args {dropped}; "
+        "raw server flags belong in extra_args"
+    )
+    # A non-zero exit here is swallowed by `eval "$(...)"`, so fail via the shell.
+    print(f"echo {shlex.quote(reason)} >&2")
+    print("exit 1")
+    raise SystemExit(0)
 
 for key, value in exports.items():
     print(f"export {key}={q(value)}")
@@ -315,6 +348,9 @@ PY
 fi
 
 mkdir -p "${LOG_ROOT}"
+# Recorded before sbatch so the job summary can point at the logs even when the
+# Slurm job never starts or dies before copying anything back.
+printf '%s\n' "${LOG_ROOT}" > "${RESULT_DIR}/${ATOMESH_CELL_ID}.log-root"
 
 if ! command -v sbatch >/dev/null 2>&1; then
   echo "ERROR: sbatch not found; use --dry-run on non-Slurm runners" >&2

--- a/.github/scripts/atomesh/process_result.py
+++ b/.github/scripts/atomesh/process_result.py
@@ -382,6 +382,10 @@ def enrich_payload(
     enriched.setdefault("decode_workers", env.get("DECODE_WORKERS"))
     enriched.setdefault("prefill_tp", env.get("PREFILL_TP"))
     enriched.setdefault("decode_tp", env.get("DECODE_TP"))
+    enriched.setdefault("prefill_dcp", env.get("PREFILL_DCP_SIZE"))
+    enriched.setdefault("decode_dcp", env.get("DECODE_DCP_SIZE"))
+    enriched.setdefault("speculative_method", env.get("SPEC_METHOD"))
+    enriched.setdefault("num_speculative_tokens", env.get("NUM_SPEC_TOKENS"))
     runner = env.get("SLURM_SUBMIT_RUNNER", "")
     if hardware:
         enriched["hardware"] = hardware

--- a/.github/scripts/atomesh/process_result.py
+++ b/.github/scripts/atomesh/process_result.py
@@ -21,12 +21,20 @@ from interactivity import (
 
 AGENTIC_BENCHMARK_KIND = "aiperf_agentic"
 
+# How each interactivity definition is spelled out in the markdown summary, so a
+# reader never has to guess which formula produced the number in the column.
+INTERACTIVITY_LABELS = {
+    METHOD_P90_E2E: "P90 E2E Normalized",
+    METHOD_MEDIAN_TPOT: "1 / median_tpot_s",
+}
+
 RESULT_RE = re.compile(
     r"^pd-(?P<backend>[^-]+)-(?P<model>.+)-(?P<topology>[^-]+(?:-[^-]+)*)-"
     r"isl(?P<isl>\d+)-osl(?P<osl>\d+)-conc(?P<conc>\d+)-(?P<ratio>[0-9.]+)\.json$"
 )
 TOPOLOGY_RE = re.compile(r"(?P<p>\d+)p(?P<d>\d+)d", re.IGNORECASE)
 TP_RE = re.compile(r"tp(?P<tp>\d+)", re.IGNORECASE)
+DCP_RE = re.compile(r"dcp(?P<dcp>\d+)", re.IGNORECASE)
 EVAL_CONC_RE = re.compile(r"(?:^|[_-])c(?P<conc>\d+)(?:$|[_-])", re.IGNORECASE)
 EVAL_TOPOLOGY_RE = re.compile(
     r"(?:^|[_-])(?P<topology>\d+p\d+d(?:[_-]dpa)?)(?:$|[_-])",
@@ -104,6 +112,28 @@ def int_value(*values: Any) -> int | None:
 def round_or_none(*values: Any, digits: int = 4) -> float | None:
     parsed = number(*values)
     return round(parsed, digits) if parsed is not None else None
+
+
+def speculative_label(payload: dict[str, Any]) -> str | None:
+    method = string_value(
+        payload.get("speculative_method"), payload.get("spec_method")
+    ).lower()
+    tokens = int_value(
+        payload.get("num_speculative_tokens"), payload.get("num_spec_tokens")
+    )
+    # Separated, because concatenating a method that already ends in a digit onto
+    # its token count is unreadable: eagle3 with 2 tokens rendered as "eagle32".
+    if method and tokens is not None:
+        return f"{method}-{tokens}"
+    return method or None
+
+
+def pd_label(prefill: Any, decode: Any) -> str:
+    """Render a prefill/decode pair as P8/D4, or as a bare value when they agree."""
+    if prefill is not None and decode is not None:
+        return str(prefill) if prefill == decode else f"P{prefill}/D{decode}"
+    value = prefill if prefill is not None else decode
+    return "--" if value is None else str(value)
 
 
 def interactivity_value(payload: dict[str, Any]) -> float | None:
@@ -223,6 +253,17 @@ def topology_resources(
         prefill_tp = prefill_tp or int(tp.group("tp"))
         decode_tp = decode_tp or int(tp.group("tp"))
 
+    prefill_dcp = int_value(
+        payload.get("prefill_dcp"), payload.get("prefill_decode_context_parallel_size")
+    )
+    decode_dcp = int_value(
+        payload.get("decode_dcp"), payload.get("decode_context_parallel_size")
+    )
+    dcp = DCP_RE.search(text)
+    if dcp:
+        prefill_dcp = prefill_dcp or int(dcp.group("dcp"))
+        decode_dcp = decode_dcp or int(dcp.group("dcp"))
+
     num_prefill_gpu = int_value(payload.get("num_prefill_gpu"))
     num_decode_gpu = int_value(payload.get("num_decode_gpu"))
     if num_prefill_gpu is None and prefill_workers and prefill_tp:
@@ -239,6 +280,8 @@ def topology_resources(
         "decode_workers": decode_workers,
         "prefill_tp": prefill_tp,
         "decode_tp": decode_tp,
+        "prefill_dcp": prefill_dcp,
+        "decode_dcp": decode_dcp,
         "num_prefill_gpu": num_prefill_gpu,
         "num_decode_gpu": num_decode_gpu,
         "total_gpu": total_gpu,
@@ -431,6 +474,9 @@ def perf_point(
     input_tput = number(payload.get("input_throughput"))
     tpot_ms = number(payload.get("mean_tpot_ms"), payload.get("mean_itl_ms"))
     interactivity = interactivity_value(payload)
+    num_speculative_tokens = int_value(
+        payload.get("num_speculative_tokens"), payload.get("num_spec_tokens")
+    )
 
     config_label = "_".join(
         part
@@ -465,15 +511,21 @@ def perf_point(
         "concurrency": int(payload["max_concurrency"]),
         "ratio": ratio,
         "ttft_ms": round_or_none(payload.get("mean_ttft_ms")),
+        "ttft_p90": round_or_none(payload.get("p90_ttft_ms")),
         "ttft_p99": round_or_none(payload.get("p99_ttft_ms")),
         "tpot_ms": round_or_none(tpot_ms),
+        "tpot_p90": round_or_none(
+            payload.get("p90_tpot_ms"), payload.get("p90_itl_ms")
+        ),
         "tpot_p99": round_or_none(
             payload.get("p99_tpot_ms"), payload.get("p99_itl_ms")
         ),
         "itl_ms": round_or_none(
             payload.get("mean_itl_ms"), payload.get("mean_tpot_ms")
         ),
+        "itl_p90": round_or_none(payload.get("p90_itl_ms"), payload.get("p90_tpot_ms")),
         "e2el_ms": round_or_none(payload.get("mean_e2el_ms")),
+        "e2el_p90": round_or_none(payload.get("p90_e2el_ms")),
         "e2el_p99": round_or_none(payload.get("p99_e2el_ms")),
         "median_ttft_ms": round_or_none(payload.get("median_ttft_ms")),
         "median_tpot_ms": round_or_none(
@@ -494,6 +546,10 @@ def perf_point(
         "num_prompts": int_value(payload.get("num_prompts")),
         "prefill_tp": resources["prefill_tp"],
         "decode_tp": resources["decode_tp"],
+        "prefill_dcp": resources["prefill_dcp"],
+        "decode_dcp": resources["decode_dcp"],
+        "speculative_method": speculative_label(payload),
+        "num_speculative_tokens": num_speculative_tokens,
         "prefill_workers": resources["prefill_workers"],
         "decode_workers": resources["decode_workers"],
         "prefill_dpa": resources["prefill_dpa"],
@@ -710,60 +766,126 @@ def find_eval_scores(root: Path) -> dict[tuple[str, str, int], dict[str, Any]]:
     return scores
 
 
-def is_p90_e2e(row: dict[str, Any]) -> bool:
-    """Was this row's ``interactivity`` computed per-request, not from median TPOT?
+INTERACTIVITY_HEADER = "Interactivity"
 
-    A missing ``interactivity_method`` means the row predates the field, which is
-    the legacy median-TPOT definition -- so anything that does not name the p90
-    method is median TPOT.
+# (header, right-aligned). The interactivity header is rewritten per table by
+# summary_headers() so it can name the definition behind its numbers.
+SUMMARY_LAYOUT: list[tuple[str, bool]] = [
+    ("Hardware", False),
+    ("Model", False),
+    ("Topology", False),
+    ("ISL/OSL", False),
+    ("Concurrency", True),
+    (INTERACTIVITY_HEADER, True),
+    ("TP", False),
+    ("DCP", False),
+    ("Spec", False),
+    ("Total tok/s", True),
+    ("Input tok/s", True),
+    ("Output tok/s", True),
+    ("Total tok/s/GPU", True),
+    ("Input tok/s/GPU", True),
+    ("Output tok/s/GPU", True),
+    ("TTFT mean ms", True),
+    ("TTFT p90 ms", True),
+    ("TTFT p99 ms", True),
+    ("TPOT mean ms", True),
+    ("TPOT p90 ms", True),
+    ("TPOT p99 ms", True),
+    ("E2E mean ms", True),
+    ("E2E p90 ms", True),
+    ("E2E p99 ms", True),
+    ("Cache Hit", True),
+    ("Accuracy Task", False),
+    ("Accuracy", True),
+]
+INTERACTIVITY_COLUMN = SUMMARY_LAYOUT.index((INTERACTIVITY_HEADER, True))
+
+
+def interactivity_method(row: dict[str, Any]) -> str:
+    return string_value(row.get("interactivity_method")) or METHOD_MEDIAN_TPOT
+
+
+def summary_headers(rows: list[dict[str, Any]]) -> list[str]:
+    """Column headers, with the interactivity definition named in its own header.
+
+    Only possible when every row shares one definition. The aggregate summary
+    merges agentic and fixed ISL/OSL cases, so a mixed table is normal there and
+    keeps the plain header; summary_note() carries the definitions instead.
     """
-    return row.get("interactivity_method") == METHOD_P90_E2E
+    methods = {interactivity_method(row) for row in rows}
+    label = INTERACTIVITY_LABELS.get(methods.pop()) if len(methods) == 1 else None
+    headers = [header for header, _ in SUMMARY_LAYOUT]
+    if label:
+        headers[INTERACTIVITY_COLUMN] = f"{INTERACTIVITY_HEADER} ({label})"
+    return headers
+
+
+def summary_note(rows: list[dict[str, Any]]) -> str:
+    """Spell out the interactivity definitions when the header cannot.
+
+    Which one applies to a row is decided entirely by whether that row is an
+    agentic trace, so naming both is a complete specification -- no per-row
+    column needed.
+    """
+    if len({interactivity_method(row) for row in rows}) < 2:
+        return ""
+    return (
+        f"Interactivity definition varies by row: "
+        f"{INTERACTIVITY_LABELS[METHOD_P90_E2E]} for agentic traces, "
+        f"{INTERACTIVITY_LABELS[METHOD_MEDIAN_TPOT]} for fixed ISL/OSL cases."
+    )
+
+
+def summary_cells(row: dict[str, Any]) -> list[str]:
+    resources = topology_resources(row, {})
+    return [
+        string_value(row.get("hardware"), default="--"),
+        string_value(row.get("benchmark_model_name"), default="--"),
+        string_value(row.get("display_topology"), row.get("topology"), default="--"),
+        "{}/{}".format(
+            row.get("random_input_len", "--"), row.get("random_output_len", "--")
+        ),
+        string_value(row.get("max_concurrency"), default="--"),
+        fmt(row.get("interactivity")),
+        pd_label(resources["prefill_tp"], resources["decode_tp"]),
+        pd_label(resources["prefill_dcp"], resources["decode_dcp"]),
+        speculative_label(row) or "--",
+        fmt(row.get("total_token_throughput")),
+        fmt(row.get("input_throughput")),
+        fmt(row.get("output_throughput")),
+        fmt(row.get("tput_per_gpu")),
+        fmt(row.get("input_tput_per_gpu")),
+        fmt(row.get("output_tput_per_gpu")),
+        fmt(row.get("mean_ttft_ms")),
+        fmt(row.get("p90_ttft_ms")),
+        fmt(row.get("p99_ttft_ms")),
+        fmt(number(row.get("mean_tpot_ms"), row.get("mean_itl_ms"))),
+        fmt(number(row.get("p90_tpot_ms"), row.get("p90_itl_ms"))),
+        fmt(number(row.get("p99_tpot_ms"), row.get("p99_itl_ms"))),
+        fmt(row.get("mean_e2el_ms")),
+        fmt(row.get("p90_e2el_ms")),
+        fmt(row.get("p99_e2el_ms")),
+        fmt_pct(row.get("cache_hit_rate")),
+        string_value(row.get("accuracy_task"), default="--"),
+        fmt(row.get("accuracy_score"), digits=4),
+    ]
 
 
 def write_summary(rows: list[dict[str, Any]], summary_path: Path) -> None:
-    """Render the CI step summary, one column per interactivity definition.
-
-    The header names the definition, so no discriminator column is needed and no
-    column carries two different quantities. A row fills at most two of the
-    three: agentic runs get E2E norm + p90 ITL, everything else -- including an
-    agentic run whose per-request records were missing and fell back -- gets
-    median TPOT. ``fmt()`` renders None as "--", so "not applicable" and "value
-    missing" look alike, which is what a reader of this table wants.
-    """
+    headers = summary_headers(rows)
     lines = [
         "### ATOMesh Model Performance Benchmark Summary",
         "",
-        "| Hardware | Model | Topology | ISL/OSL | Concurrency | Intvty E2E norm | Intvty p90 ITL | Intvty median TPOT | Total tok/s | Input tok/s | Output tok/s | Total tok/s/GPU | Input tok/s/GPU | Output tok/s/GPU | TTFT ms | TPOT ms | E2E ms | Cache Hit | Accuracy Task | Accuracy |",
-        "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |",
+        "| " + " | ".join(headers) + " |",
+        "| "
+        + " | ".join("---:" if right else "---" for _, right in SUMMARY_LAYOUT)
+        + " |",
     ]
-    for row in rows:
-        lines.append(
-            "| {hardware} | {model} | {topology} | {isl}/{osl} | {conc} | {intvty_e2e} | {intvty_p90_itl} | {intvty_median_tpot} | {total} | {input_} | {output} | {total_per_gpu} | {input_per_gpu} | {output_per_gpu} | {ttft} | {tpot} | {e2e} | {cache_hit} | {accuracy_task} | {accuracy} |".format(
-                hardware=row.get("hardware", "--"),
-                model=row.get("benchmark_model_name", "--"),
-                topology=row.get("display_topology") or row.get("topology", "--"),
-                isl=row.get("random_input_len", "--"),
-                osl=row.get("random_output_len", "--"),
-                conc=row.get("max_concurrency", "--"),
-                intvty_e2e=(fmt(row.get("interactivity")) if is_p90_e2e(row) else "--"),
-                intvty_p90_itl=fmt(row.get("interactivity_p90_itl")),
-                intvty_median_tpot=(
-                    "--" if is_p90_e2e(row) else fmt(row.get("interactivity"))
-                ),
-                total=fmt(row.get("total_token_throughput")),
-                input_=fmt(row.get("input_throughput")),
-                output=fmt(row.get("output_throughput")),
-                total_per_gpu=fmt(row.get("tput_per_gpu")),
-                input_per_gpu=fmt(row.get("input_tput_per_gpu")),
-                output_per_gpu=fmt(row.get("output_tput_per_gpu")),
-                ttft=fmt(row.get("mean_ttft_ms")),
-                tpot=fmt(row.get("mean_tpot_ms")),
-                e2e=fmt(row.get("mean_e2el_ms")),
-                cache_hit=fmt_pct(row.get("cache_hit_rate")),
-                accuracy_task=row.get("accuracy_task") or "--",
-                accuracy=fmt(row.get("accuracy_score"), digits=4),
-            )
-        )
+    lines.extend("| " + " | ".join(summary_cells(row)) + " |" for row in rows)
+    note = summary_note(rows)
+    if note:
+        lines.extend(["", note])
     summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/.github/scripts/atomesh/process_result.py
+++ b/.github/scripts/atomesh/process_result.py
@@ -876,6 +876,21 @@ def summary_cells(row: dict[str, Any]) -> list[str]:
     ]
 
 
+def summary_sort_key(row: dict[str, Any]) -> tuple[str, int, int, int]:
+    """Group the table by model, then walk each concurrency ladder upward.
+
+    Without this the rows arrive in result-path order, which interleaves the
+    serving bands of a single model (c32, c40, c12, c16, c8, c1 ...) because the
+    band name sits ahead of the concurrency in every cell id.
+    """
+    return (
+        model_key(row.get("benchmark_model_name")),
+        int(number(row.get("max_concurrency")) or 0),
+        int(number(row.get("random_input_len")) or 0),
+        int(number(row.get("random_output_len")) or 0),
+    )
+
+
 def write_summary(rows: list[dict[str, Any]], summary_path: Path) -> None:
     headers = summary_headers(rows)
     lines = [
@@ -886,7 +901,10 @@ def write_summary(rows: list[dict[str, Any]], summary_path: Path) -> None:
         + " | ".join("---:" if right else "---" for _, right in SUMMARY_LAYOUT)
         + " |",
     ]
-    lines.extend("| " + " | ".join(summary_cells(row)) + " |" for row in rows)
+    lines.extend(
+        "| " + " | ".join(summary_cells(row)) + " |"
+        for row in sorted(rows, key=summary_sort_key)
+    )
     note = summary_note(rows)
     if note:
         lines.extend(["", note])

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -1268,6 +1268,7 @@ jobs:
           set -euo pipefail
           mkdir -p atomesh-results
           SUMMARY_PATH="atomesh-results/${MATRIX_ID}-summary.md"
+          AIPERF_RAW_PATH="atomesh-results/${MATRIX_ID}-aiperf-raw.md"
           BENCHMARK_ACTION_INPUT="atomesh-results/${MATRIX_ID}-benchmark-action.json"
 
           python3 .github/scripts/atomesh/process_result.py \
@@ -1277,6 +1278,11 @@ jobs:
             --hardware "${ATOMESH_DASHBOARD_HARDWARE}" \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+          # Empty for standard ISL/OSL cases: only AIPerf writes the console dump.
+          python3 .github/scripts/atomesh/aiperf_console_report.py \
+            "atomesh-results/${MATRIX_ID}" \
+            --output "${AIPERF_RAW_PATH}"
+
           {
             echo "## ${MATRIX_ID}"
             echo
@@ -1285,9 +1291,16 @@ jobs:
               echo
             fi
             cat "${SUMMARY_PATH}"
+            if [ -s "${AIPERF_RAW_PATH}" ]; then
+              echo
+              cat "${AIPERF_RAW_PATH}"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
           cat "${SUMMARY_PATH}"
+          if [ -s "${AIPERF_RAW_PATH}" ]; then
+            cat "${AIPERF_RAW_PATH}"
+          fi
 
       - name: Upload AIPerf Perfetto traces
         if: ${{ always() && matrix.benchmark.kind == 'aiperf_agentic' }}
@@ -1336,7 +1349,17 @@ jobs:
             --summary atomesh-benchmark-summary.md \
             --hardware "${ATOMESH_DASHBOARD_HARDWARE}" \
             --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # Empty for standard ISL/OSL cases: only AIPerf writes the console dump.
+          python3 .github/scripts/atomesh/aiperf_console_report.py \
+            atomesh-results \
+            --output atomesh-aiperf-raw.md
           cat atomesh-benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
+          if [[ -s atomesh-aiperf-raw.md ]]; then
+            {
+              echo
+              cat atomesh-aiperf-raw.md
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
           ENTRY_COUNT="$(python3 - <<'PY'
           import json
           from pathlib import Path
@@ -1370,6 +1393,8 @@ jobs:
           path: |
             atomesh-benchmark-action.json
             atomesh-benchmark-summary.md
+            atomesh-aiperf-raw.md
+          if-no-files-found: ignore
 
   dashboard:
     concurrency:

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -69,9 +69,12 @@ on:
             kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c4,
             kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c8,
             kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c12,
-            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c32,
-            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c40,
-            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c56
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c14,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c16,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-1m-c32,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-1m-c40,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-1m-c56,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-1m-c64
 
           Kimi-K2.5:
             kimi-k25-1p1d-tp4,kimi-k25-1p1d-tp4-tp8,
@@ -1300,6 +1303,10 @@ jobs:
               echo "Slurm job: $(cat "atomesh-results/${MATRIX_ID}.slurm-job-id")"
               echo
             fi
+            if [ -f "atomesh-results/${MATRIX_ID}.log-root" ]; then
+              echo "Log path: \`$(cat "atomesh-results/${MATRIX_ID}.log-root")\`"
+              echo
+            fi
             cat "${SUMMARY_PATH}"
             if [ -s "${AIPERF_RAW_PATH}" ]; then
               echo
@@ -1363,6 +1370,62 @@ jobs:
           python3 .github/scripts/atomesh/aiperf_console_report.py \
             atomesh-results \
             --output atomesh-aiperf-raw.md
+          python3 - <<'PY' > atomesh-case-log-paths.md
+          import json
+          import re
+          from pathlib import Path
+
+          results = Path("atomesh-results")
+
+
+          def sort_key(case_id):
+              """Order this table like the perf summary: (benchmark_model_name,
+              max_concurrency), read from the case's own result JSON so both tables
+              key off the same fields. A cell that sweeps several concurrencies
+              leads at its lowest one; a case that died before writing any result
+              falls back to its id, whose prefix ahead of the NpMd topology token is
+              the model name.
+              """
+              keys = []
+              for path in sorted((results / case_id).rglob("pd-*.json")):
+                  try:
+                      payload = json.loads(path.read_text(encoding="utf-8"))
+                      model = str(payload.get("benchmark_model_name") or "")
+                      conc = int(payload.get("max_concurrency") or 0)
+                  except (OSError, ValueError, TypeError):
+                      continue
+                  keys.append((model.rstrip("/").split("/")[-1].lower(), conc))
+              if keys:
+                  return min(keys)
+              topology = re.search(r"-\d+p\d+d-", case_id)
+              found = re.findall(r"-c(\d+)-", case_id)
+              return (
+                  case_id[: topology.start()] if topology else case_id,
+                  int(found[-1]) if found else 0,
+              )
+
+
+          rows = []
+          for path in results.glob("*.log-root"):
+              case_id = path.name[: -len(".log-root")]
+              job_file = path.with_name(f"{case_id}.slurm-job-id")
+              job_id = job_file.read_text().strip() if job_file.is_file() else ""
+              rows.append((case_id, job_id or "--", path.read_text().strip()))
+
+          if rows:
+              print("### ATOMesh Case Log Paths")
+              print()
+              print("| Case | Slurm job | Log path |")
+              print("| --- | --- | --- |")
+              for case_id, job_id, log_root in sorted(
+                  rows, key=lambda row: sort_key(row[0]) + (row[0],)
+              ):
+                  print(f"| {case_id} | {job_id} | `{log_root}` |")
+              print()
+          PY
+          if [[ -s atomesh-case-log-paths.md ]]; then
+            cat atomesh-case-log-paths.md >> "$GITHUB_STEP_SUMMARY"
+          fi
           cat atomesh-benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
           if [[ -s atomesh-aiperf-raw.md ]]; then
             {
@@ -1404,6 +1467,7 @@ jobs:
             atomesh-benchmark-action.json
             atomesh-benchmark-summary.md
             atomesh-aiperf-raw.md
+            atomesh-case-log-paths.md
           if-no-files-found: ignore
 
   dashboard:

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -44,7 +44,7 @@ on:
         default: false
         type: boolean
       model_names:
-        description: 'When run_all_models=false, run all cases in the selected suite for these model families. Comma-separated: DeepSeek-V4-Pro,GLM-5.2-MXFP4,Kimi-K2.5-MXFP4,MiniMax-M3-MXFP4,MiniMax-M3-MXFP8'
+        description: 'When run_all_models=false, run all cases in the selected suite for these model families. Comma-separated: DeepSeek-V4-Pro,GLM-5.2-MXFP4,Kimi-K3-MXFP4,Kimi-K2.5-MXFP4,MiniMax-M3-MXFP4,MiniMax-M3-MXFP8'
         required: false
         default: ''
         type: string
@@ -63,7 +63,17 @@ on:
             glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c32,
             glm-52-mxfp4-1p1d-tp4-dpa-agentic-lmcache-1m-c48
 
-          Kimi:
+          Kimi-K3:
+            kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c1,
+            kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c2,
+            kimi-k3-mxfp4-1p1d-tp8-dspark7-agentic-1m-c4,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c8,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-dspark3-agentic-lmcache-1m-c12,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c32,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c40,
+            kimi-k3-mxfp4-1p1d-tp8-dcp8-agentic-lmcache-state-1m-c56
+
+          Kimi-K2.5:
             kimi-k25-1p1d-tp4,kimi-k25-1p1d-tp4-tp8,
             kimi-k25-2p1d-tp4,kimi-k25-1p2d-tp4
 


### PR DESCRIPTION
### CI

**Benchmark matrix** — `.github/benchmark/models_atomesh.yaml`

- All 11 concurrency points from `recipes/Agentic-Kimi-K3.md` at ROCm/ATOM#2131 (`30c2f1b`): 1/2/4/8/12/14/16/32/40/56/64 across the three serving bands.
- Verified field by field against the recipe's per-concurrency table: DCP, spec tokens, acceptance length, LMCache size, ReplaySSM, `max-num-seqs`, batched tokens, GPU utilization, `graph_max`.
- CUDA graphs: `--cudagraph-mode FULL --level 3` over the dense range `[2 … 2*CONC*(1+spec)]`.
- ReplaySSM off on C1/C2/C4, on for C8–C16, off from C32 up. `AITER_REUSE_IDENTICAL_COMM_GROUPS` only on C56/C64.
- LMCache 128 GiB per rank on C8–C40, 192 GiB on C56/C64, with explicit `ATOM_NUMA_NODE=0,0,0,0,1,1,1,1` and auto-binding off.
- Throughput band drops the CPU state-offload tier: it keeps no draft model and no ReplaySSM, so `OFFLOAD_STATE_CPU_SIZE` was taking 32 GiB per rank from the paged KV for a state pool nothing replays from.
- `--state-checkpoint-interval-tokens -1` and `ATOM_STATE_CHECKPOINT_DEMAND=0` both differ from the ATOM defaults; omitting either reproduces a different configuration than the recipe's published numbers.

**Launcher plumbing** — `.github/scripts/atomesh/pd_server_atom.sh`, `pd_submit.sh`, `pd_slurm_job.sh`

- CUDA-graph capture sizes derived from concurrency and spec width instead of enumerated per case.
- `cudagraph_max_num_seqs` available as a per-case override — C14 pins the window to 32, since `2*CONC` gives 28 and the server dies during graph warmup.
- DCP, speculative-decoding and state-checkpoint parameters propagated per role; `STATE_CHECKPOINT_` allowed through the env forwarding list that gates what reaches the container.
- `server_args` self-validating: the export mapping records which keys it reads and the submit step fails on any key it never consumed, so a config key can no longer be dropped without a trace.
- GSM8K joins SWE-bench in getting its own service phase, so the accuracy server restarts with its own arguments rather than reusing the benchmark server.

**Result reporting** — `.github/scripts/atomesh/process_result.py`, `aiperf_console_report.py`, `.github/workflows/atomesh-benchmark.yaml`, `.github/dashboard/index.html`

- Mean / p90 / p99 for TTFT, TPOT and E2E plus TP / DCP / Spec, replacing single averaged numbers that hid the tail dominating agentic traces; p90 exported at the source and carried on every dashboard point.
- New `aiperf_console_report.py` reproduces AIPerf's console tables — prefill/decode throughput, tokens in flight, CO-aware latency — otherwise untracked; no-op for fixed ISL/OSL runs.
- Each case's log path surfaced in the job summary; performance table and log-path table both ordered by `(benchmark_model_name, max_concurrency)`.
- Dashboard details popover builds parallelism and percentile fields on the markdown-summary row path, and no longer reports a hardcoded expert-parallelism value it never measured.
