### PR TITLE
[Perf][MiniMax-M3] Split the dense paged decode by workgroups

### DIFF
--- a/atom/model_ops/attention_mha.py
+++ b/atom/model_ops/attention_mha.py
@@ -8,7 +8,6 @@ import torch
 from aiter import fused_qk_norm_rope_cache_quant_shuffle
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.triton.fused_kv_cache import fused_qk_rope_reshape_and_cache
-from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
 from aiter.ops.triton.unified_attention import unified_attention
 from torch import nn
 
@@ -16,6 +15,7 @@ from atom.config import get_current_atom_config
 from atom.model_ops.base_attention import (
     PA_ASM_MAX_QUERY_GROUP_SIZE,
     cp_mha_gather_cache,
+    dense_decode_splits,
     gluon_decode_over_limit,
     run_pa_decode_gluon,
     run_pa_fwd_asm,
@@ -558,9 +558,10 @@ class PagedAttentionImpl(nn.Module):
         )
         assert num_q_heads_total % num_kv_heads == 0
 
-        max_context_partition_num = get_recommended_splits(num_seqs, num_kv_heads)
+        max_context_partition_num = dense_decode_splits(num_seqs, num_kv_heads)
 
         context_partition_size = 256
+        # Left after the split so a sliding-window layer still overrides both.
         if self.sliding_window > 0:
             max_context_partition_num = 1
             context_partition_size = 128

--- a/atom/model_ops/base_attention.py
+++ b/atom/model_ops/base_attention.py
@@ -49,6 +49,49 @@ PA_GLUON_MAX_QUERY_LEN = 4
 PA_GLUON_MAX_QUERY_GROUP_SIZE = 64
 PA_ASM_MAX_QUERY_GROUP_SIZE = 16
 
+# Both are fits on a 256-CU gfx950 and do not scale with the machine, unlike the
+# heuristic they bound. TARGET_WG: past it the extra splits only add reduce work.
+# MAX is two separate bounds that happen to agree on a number no larger than 32:
+# temporary_output is bf16, so each split adds a round trip through the PS
+# combine, and the worst shape measured drifts 20pp further from an fp32
+# reference at 64 than at 8; and 64 is where the C++ PS reduce stops being built
+# at all, with no working fallback under it (see the test that pins this).
+PA_DENSE_SPLIT_TARGET_WG = 128
+PA_DENSE_SPLIT_MAX = 32
+
+
+def dense_decode_splits(num_seqs: int, num_kv_heads: int) -> int:
+    """KV splits for the dense paged decode.
+
+    aiter's heuristic ends in a flat min(..., 8): at batch 1 it computes 512 and
+    returns 8, leaving a call that reads the whole context on 3% of the machine.
+
+    A function of the grid alone, deliberately not of the context length: decode
+    runs under a cuda graph, where max_seqlen_k is the model limit rather than the
+    real length, so a context term is inert in production and would only over-split
+    short requests (+114% measured on a 2K one).
+
+    Only the dense path is routed here. The two MiniMax-M3 sparse call sites are
+    excluded on purpose -- their context is a fixed topk window and their num_seqs
+    already folds the query tokens in -- as is the vLLM bridge's own copy of this
+    dispatch, which is untested against this.
+    """
+    from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
+
+    n = max(1, int(num_seqs) * int(num_kv_heads))
+    # Power of two, and only the term added here: the PS reduce compiles one
+    # variant per distinct count, and a continuous cdiv adds 11 of them that no
+    # sweep ever measured. Rounding the RESULT would drop below the heuristic
+    # wherever it returns 3, 5, 6 or 7.
+    boost = min(PA_DENSE_SPLIT_MAX, triton.cdiv(PA_DENSE_SPLIT_TARGET_WG, n))
+    boost = 1 << (boost.bit_length() - 1)
+    # The ceiling clamps the result as well. Staying at or above the heuristic is
+    # a preference; staying inside what the reduce was built for is not.
+    return min(
+        PA_DENSE_SPLIT_MAX,
+        max(get_recommended_splits(num_seqs, num_kv_heads), boost),
+    )
+
 
 def gluon_decode_over_limit(max_qlen: int, num_heads: int, num_kv_heads: int) -> bool:
     """Whether decode is past what the gluon kernel takes.

--- a/tests/test_paged_attention_dispatch.py
+++ b/tests/test_paged_attention_dispatch.py
@@ -24,16 +24,28 @@ import pytest
 pytest.importorskip("triton", reason="base_attention defines @triton.jit kernels")
 pytest.importorskip("aiter", reason="base_attention imports the AITER runtime")
 
+from aiter.ops.triton.gluon import pa_decode_gluon
+
 from atom.model_ops.base_attention import (
     PA_ASM_MAX_QUERY_GROUP_SIZE,
+    PA_DENSE_SPLIT_MAX,
+    PA_DENSE_SPLIT_TARGET_WG,
     PA_GLUON_MAX_QUERY_GROUP_SIZE,
     PA_GLUON_MAX_QUERY_LEN,
+    dense_decode_splits,
     gluon_decode_over_limit,
 )
 
 # aiter pa_decode_gluon.py:134-168 -- the arms `register_bases` is defined for,
 # plus a separate path below 16. There is no 128 arm and no else.
 AITER_GLUON_GROUP_ARMS = (16, 32, 64)
+
+# aiter pa_ps.py:69 -- the C++ PS reduce is built for 1..64 partitions. Past it
+# the launcher falls to flydsl, whose module-level wrapper takes no `stream`
+# argument, and the TypeError that raises is not caught by the `except
+# ImportError` that would otherwise reach the Triton kernel. So there is no
+# fallback: decode aborts.
+AITER_PS_REDUCE_MAX_PARTITIONS = 64
 
 
 class TestGluonEnvelope:
@@ -105,6 +117,20 @@ class TestEnvelopeConstants:
     def test_gluon_group_limit_is_the_last_layout_arm(self):
         assert PA_GLUON_MAX_QUERY_GROUP_SIZE == max(AITER_GLUON_GROUP_ARMS)
 
+    def test_the_split_ceiling_stays_inside_what_the_ps_reduce_was_built_for(self):
+        """The bound the rule is written against, not the one it declares.
+
+        Every other test here reads its limit off PA_DENSE_SPLIT_MAX, so raising
+        that constant past what aiter serves leaves them all green while decode
+        aborts. This is the one that goes red.
+        """
+        assert PA_DENSE_SPLIT_MAX <= AITER_PS_REDUCE_MAX_PARTITIONS
+
+    def test_the_split_constants_are_positive(self):
+        """`1 << (x.bit_length() - 1)` raises on 0, and both are tuning knobs."""
+        assert PA_DENSE_SPLIT_TARGET_WG >= 1
+        assert PA_DENSE_SPLIT_MAX >= 1
+
     def test_every_reachable_group_has_an_arm(self):
         """Anything reported as safe must land on an arm, not between two."""
         for qlen in range(1, PA_GLUON_MAX_QUERY_LEN + 1):
@@ -124,6 +150,80 @@ class TestEnvelopeConstants:
         asm_pa.cu:113-116 carries `# mtp * gqa <= 16` as a source comment.
         """
         assert PA_ASM_MAX_QUERY_GROUP_SIZE < PA_GLUON_MAX_QUERY_GROUP_SIZE
+
+
+class TestDenseDecodeSplits:
+    """How finely the dense decode splits the KV, and what bounds it.
+
+    Integer arithmetic, no device. `dense_decode_splits` imports the aiter
+    heuristic inside its body, so monkeypatching the module attribute reaches it
+    -- which is what lets the cases aiter cannot produce today be tested at all.
+    """
+
+    def test_batch_one_asks_for_the_ceiling(self):
+        """Reverting to the bare heuristic returns 8 and turns this red."""
+        assert dense_decode_splits(1, 1) == PA_DENSE_SPLIT_MAX
+
+    def test_a_full_grid_is_left_to_the_heuristic(self, monkeypatch):
+        """Past TARGET_WG the added term is 1, so the heuristic must win outright.
+
+        Red if max() becomes min(), or if TARGET_WG grows past the grid.
+        """
+        monkeypatch.setattr(
+            pa_decode_gluon, "get_recommended_splits", lambda seqs, heads: 3
+        )
+        assert dense_decode_splits(128, 4) == 3
+
+    def test_never_below_the_heuristic(self, monkeypatch):
+        """Guards the direction: this is what makes the change unable to regress."""
+        monkeypatch.setattr(
+            pa_decode_gluon, "get_recommended_splits", lambda seqs, heads: 8
+        )
+        for num_seqs in (1, 2, 4, 8, 16, 64, 256):
+            assert dense_decode_splits(num_seqs, 1) >= 8
+
+    @pytest.mark.parametrize("num_seqs", range(1, 40))
+    def test_only_ever_asks_for_a_power_of_two_above_the_heuristic(
+        self, num_seqs, monkeypatch
+    ):
+        """Every split count past the heuristic's own range is a power of two.
+
+        The C++ PS reduce compiles one variant per distinct count, so a
+        continuous cdiv would add ~11 of them, each a first-use hipcc on the
+        request path under eager decode. Red if the rounding is dropped: n=5
+        would ask for 26.
+        """
+        monkeypatch.setattr(
+            pa_decode_gluon, "get_recommended_splits", lambda seqs, heads: 1
+        )
+        s = dense_decode_splits(num_seqs, 1)
+        assert s & (s - 1) == 0, f"n={num_seqs} asked for {s}"
+
+    def test_stays_inside_the_ps_reduce_contract(self, monkeypatch):
+        """The C++ PS reduce is built for 1..64 and there is no usable fallback.
+
+        Past it `launch_pa_decode_ps_reduce_flydsl` is called with a `stream`
+        kwarg its module-level signature does not take, and the resulting
+        TypeError is not caught by the `except ImportError` that would otherwise
+        reach the Triton kernel. So the ceiling has to clamp the result, not just
+        the term this function adds -- red if it moves back inside the max().
+        """
+        monkeypatch.setattr(
+            pa_decode_gluon, "get_recommended_splits", lambda seqs, heads: 128
+        )
+        assert 1 <= dense_decode_splits(1, 1) <= PA_DENSE_SPLIT_MAX
+
+    def test_kv_heads_count_toward_the_grid(self, monkeypatch):
+        """The grid is (num_seqs, num_kv_heads, splits), so both dims fill it.
+
+        Red if num_kv_heads is dropped from the product: 4 x 4 would then be read
+        as 4 and ask for TARGET_WG // 4 instead of // 16.
+        """
+        monkeypatch.setattr(
+            pa_decode_gluon, "get_recommended_splits", lambda seqs, heads: 1
+        )
+        assert dense_decode_splits(4, 4) == dense_decode_splits(16, 1)
+        assert dense_decode_splits(4, 4) == PA_DENSE_SPLIT_TARGET_WG // 16
 
 
 class _Layer:


### PR DESCRIPTION
## Motivation

In a conc=1 MiniMax-M3 decode step, `paged_attention_decode_sliding_window_head_1` is bimodal: 57 sparse layers at ~7.7 μs, and **6 full-context calls (3 dense layers + 3 EAGLE3 draft passes) at 300–500 μs** — **19.8% of the step**, 5.6× everything the sparse layers cost together.

They run on 8 workgroups, because `get_recommended_splits` ends in a flat `min(..., 8)`: at batch 1 it computes **512** and returns **8**. Grid `(1, 1, 8)` — **3% of 256 CUs** for a call reading ~80 MB (~200 GB/s, 2.5% of peak). Across 370 measured shapes that ceiling sits **94.8%** off the per-shape optimum.

**Result at conc=1: +19.5% interactivity, +6.1% throughput.**

## Technical Details

```python
PA_DENSE_SPLIT_TARGET_WG = 128
PA_DENSE_SPLIT_MAX = 32

n = max(1, num_seqs * num_kv_heads)
boost = min(PA_DENSE_SPLIT_MAX, triton.cdiv(PA_DENSE_SPLIT_TARGET_WG, n))
boost = 1 << (boost.bit_length() - 1)
return min(PA_DENSE_SPLIT_MAX,
           max(get_recommended_splits(num_seqs, num_kv_heads), boost))
```

- **Never below the heuristic.** Past `n = 16` the added term contributes nothing, so 354 of 370 shapes are byte-identical to today and the worst of the other 16 is **+1.2 μs**.
- **A function of the grid, not the context.** Under a CUDA graph `max_seqlen_k` is `max_model_len`, not the live length (`aiter_attention.py:1334` vs `:1104`), so a context term is inert in production and only over-splits short requests — **+114%** measured on a 2K one.
- **Powers of two, on the added term only.** The C++ PS reduce compiles one variant per split count; a continuous `cdiv` adds 11 that no sweep measured, rounding adds 2. Rounding the *result* would drop below the heuristic where it returns 3, 5, 6, 7.
- **`MAX = 32` is two bounds that agree.** `temporary_output` is bf16, and the worst shape drifts 20pp further from fp32 at 64 than at 8; and 64 is where the C++ PS reduce stops being built, with no working fallback under it (the flydsl wrapper takes no `stream` kwarg, and the `TypeError` is not caught by the `except ImportError`). A test pins this against aiter's bound, not against the constant itself.

The sliding-window override that follows still forces `splits=1`.

## Test

MI355X (gfx950), TP4, MXFP4 + fp8 KV.

**Microbench**, 370 shapes — 7 real model configs (MiniMax-M3, Llama-3.3-70B, MiniMax-M2.5, gpt-oss-120b, Kimi-K3-DSpark, M3-EAGLE3 dense, M3 TP8), head_dim 64/128, 1–16 kv heads, ctx 512–315008, batch 1–128, qlen 1/4:

| rule | mean | worst cell | regressions | vs per-cell optimum |
| --- | ---: | ---: | ---: | ---: |
| today | +0.0% | +0.0 μs | 0 | 94.8% |
| **this** | **−17.2%** | **+1.2 μs** | 16 / 370 | 17.1% |

**Numerics** — every arm scored against fp32 over the same dequantized pages; all sit in today's band (4–6% at qlen=1 on fp8; 0.3% on bf16 KV), and this setting is *closer* than the baseline at batch 1 (4.0% vs 5.0%).

**gsm8k** full, TP4 + EAGLE3, `num_concurrent=4` so the rule actually fires (at CI's 32 it returns today's value and both arms compute the same thing): 5-shot **0.9340**, 20-shot **0.9409** (CI baseline 0.9363, threshold 0.93). Speculation live at 3.18 toks/fwd, 72.8% acceptance.

**End to end** — same-commit paired A/B, 1800 s/arm, agentic replay, conc=1:

| | base | this | Δ |
| --- | ---: | ---: | ---: |
| throughput | 18,427 | 19,544 | **+6.07%** |
| interactivity (1/ITL p90) | 274.1 | 327.6 | **+19.52%** |

Acceptance 2.78/2.78 and prefix hit 95.7/95.9 identical. Noise from three independent base runs: 0.04% throughput, 0.66% interactivity.

**Profile** on the patched tree, to confirm the mechanism and not just the outcome: the expensive bucket moves `[256,512)` → `[64,256)` μs, p99 507 → 139, while the 57 sparse layers stay at p50 7.8 μs — they read a fixed `topk × 128` window and are the control. Those six calls go **2436 → 678 μs/step (−72.2%)** against −71.5% predicted. The capture is at a 22% *longer* context than the reference, so this is conservative.

## Known Limitations

- The vLLM bridge's copy of this dispatch (`plugin/vllm/attention/layer_mha.py:444`) is **deliberately unchanged** — a separate serving path that neither the A/B nor gsm8k covers.
- The two MiniMax-M3 sparse call sites are excluded: fixed topk window, and `num_seqs` there already folds in the query tokens.
- Both constants are fits on a 256-CU gfx950 and do not scale with the machine.
- End to end was measured on M3 TP4 at conc=1 only; the other six shapes have microbench and numerics coverage, not a served workload.

## Submission Checklist

- [x] 186 tests pass; each new one verified red on revert — including the constant bound (`PA_DENSE_SPLIT_MAX = 128` turns exactly one red, the other 73 stay green)
- [x] gsm8k 5-shot / 20-shot above the CI threshold
- [x] End-to-end A/B on the production agentic workload
- [ ] vLLM bridge left for a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
