### PR TITLE
ci: gate heavy tests on current review decision

### DIFF
--- a/.github/scripts/check_heavy_ci_gate.sh
+++ b/.github/scripts/check_heavy_ci_gate.sh
@@ -2,8 +2,9 @@
 
 # Decide whether an expensive PR CI workflow should run.
 # Non-PR events keep their existing behavior. For PR events, run when the PR
-# currently has one of CI_GATE_LABELS, or the PR has any historical APPROVED
-# review.
+# currently has one of CI_GATE_LABELS, or GitHub reports that the PR's current
+# aggregate review decision is APPROVED. Dismissed or superseded reviews must
+# not authorize unrelated heavy CI workflows.
 
 set -euo pipefail
 
@@ -167,7 +168,6 @@ fi
 ACTION="$(jq -r '.action // ""' "${EVENT_PATH}")"
 PR_NUMBER="$(jq -r '.pull_request.number // empty' "${EVENT_PATH}")"
 IS_DRAFT="$(jq -r '.pull_request.draft // false' "${EVENT_PATH}")"
-EVENT_LABEL="$(jq -r '.label.name // empty' "${EVENT_PATH}")"
 BASE_REF="$(jq -r '.pull_request.base.ref // ""' "${EVENT_PATH}")"
 
 if [ "${BASE_REF}" != "main" ]; then
@@ -209,17 +209,33 @@ fi
 
 check_relevant_paths
 
-if ! REVIEW_STATES="$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '.[].state')"; then
-  echo "Failed to query PR review state; skipping heavy CI."
+if ! REVIEW_DECISION="$(
+  gh api graphql \
+    -f owner="${OWNER}" \
+    -f name="${NAME}" \
+    -F number="${PR_NUMBER}" \
+    -f query='query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewDecision
+        }
+      }
+    }' \
+    --jq '.data.repository.pullRequest.reviewDecision // ""'
+)"; then
+  echo "Failed to query the current PR review decision; skipping heavy CI."
   emit_decision "false" "review-query-failed"
   exit 0
 fi
 
-APPROVAL_COUNT="$(printf '%s\n' "${REVIEW_STATES}" | awk '$0 == "APPROVED" || $0 == "DISMISSED" { count++ } END { print count + 0 }')"
-CHANGES_REQUESTED_COUNT="$(printf '%s\n' "${REVIEW_STATES}" | awk '$0 == "CHANGES_REQUESTED" { count++ } END { print count + 0 }')"
-
-if [ "${APPROVAL_COUNT}" -gt 0 ]; then
-  emit_decision "true" "approved-history" "" "APPROVED_HISTORY" "${APPROVAL_COUNT}" "${CHANGES_REQUESTED_COUNT}"
-else
-  emit_decision "false" "not-approved" "" "" "${APPROVAL_COUNT}" "${CHANGES_REQUESTED_COUNT}"
-fi
+case "${REVIEW_DECISION}" in
+  APPROVED)
+    emit_decision "true" "current-approval" "" "${REVIEW_DECISION}" "1" "0"
+    ;;
+  CHANGES_REQUESTED)
+    emit_decision "false" "changes-requested" "" "${REVIEW_DECISION}" "0" "1"
+    ;;
+  *)
+    emit_decision "false" "not-approved" "" "${REVIEW_DECISION}" "0" "0"
+    ;;
+esac

--- a/tests/test_heavy_ci_gate.py
+++ b/tests/test_heavy_ci_gate.py
@@ -1,0 +1,125 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GATE_SCRIPT = REPO_ROOT / ".github" / "scripts" / "check_heavy_ci_gate.sh"
+
+
+def _run_gate(
+    tmp_path,
+    *,
+    labels=(),
+    review_decision="",
+    review_query_fails=False,
+    allowed="ci:full,ci:vllm",
+):
+    event_path = tmp_path / "event.json"
+    output_path = tmp_path / "output.txt"
+    summary_path = tmp_path / "summary.md"
+    event_path.write_text(
+        json.dumps(
+            {
+                "action": "synchronize",
+                "pull_request": {
+                    "number": 2166,
+                    "draft": False,
+                    "base": {"ref": "main"},
+                    "labels": [{"name": label} for label in labels],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " == *"/pulls/"*"/files"* ]]; then
+  printf '%s\\n' 'atom/model_engine/scheduler.py'
+elif [[ "${2:-}" == "graphql" ]]; then
+  if [[ "${FAKE_REVIEW_QUERY_FAIL:-0}" == "1" ]]; then
+    exit 1
+  fi
+  printf '%s\\n' "${FAKE_REVIEW_DECISION:-}"
+elif [[ " $* " == *" /labels "* ]]; then
+  exit 0
+else
+  echo "unexpected gh invocation: $*" >&2
+  exit 2
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "GITHUB_OUTPUT": str(output_path),
+            "GITHUB_STEP_SUMMARY": str(summary_path),
+            "GITHUB_EVENT_NAME": "pull_request",
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_REPOSITORY": "ROCm/ATOM",
+            "CI_GATE_LABELS": allowed,
+            "CI_GATE_PATHS_IGNORE": "docs/**",
+            "FAKE_REVIEW_DECISION": review_decision,
+            "FAKE_REVIEW_QUERY_FAIL": "1" if review_query_fails else "0",
+        }
+    )
+    subprocess.run(["bash", str(GATE_SCRIPT)], check=True, env=env)
+    return dict(
+        line.split("=", 1)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_matching_label_runs_without_review(tmp_path):
+    result = _run_gate(tmp_path, labels=("ci:vllm",))
+
+    assert result["should_run"] == "true"
+    assert result["reason"] == "label-present"
+    assert result["matched_label"] == "ci:vllm"
+
+
+def test_unrelated_label_does_not_authorize_workflow(tmp_path):
+    result = _run_gate(tmp_path, labels=("ci:atom",))
+
+    assert result["should_run"] == "false"
+    assert result["reason"] == "not-approved"
+
+
+def test_current_approval_runs_without_label(tmp_path):
+    result = _run_gate(tmp_path, review_decision="APPROVED")
+
+    assert result["should_run"] == "true"
+    assert result["reason"] == "current-approval"
+    assert result["review_decision"] == "APPROVED"
+
+
+def test_dismissed_or_superseded_review_does_not_run(tmp_path):
+    result = _run_gate(tmp_path, review_decision="REVIEW_REQUIRED")
+
+    assert result["should_run"] == "false"
+    assert result["reason"] == "not-approved"
+    assert result["approval_count"] == "0"
+
+
+def test_changes_requested_does_not_run(tmp_path):
+    result = _run_gate(tmp_path, review_decision="CHANGES_REQUESTED")
+
+    assert result["should_run"] == "false"
+    assert result["reason"] == "changes-requested"
+    assert result["changes_requested_count"] == "1"
+
+
+def test_review_query_failure_fails_closed(tmp_path):
+    result = _run_gate(tmp_path, review_query_fails=True)
+
+    assert result["should_run"] == "false"
+    assert result["reason"] == "review-query-failed"


### PR DESCRIPTION
## Summary

- stop treating historical `DISMISSED` reviews as approval for every heavy CI workflow
- query GitHub's current aggregate `reviewDecision` and only auto-run when it is `APPROVED`
- preserve workflow-specific `ci:*` label overrides
- fail closed when the current review decision cannot be queried

This fixes cases such as #2166, where the PR only has `ci:atom` and its current review decision is `REVIEW_REQUIRED`, but a historical dismissed review caused the vLLM and SGLang heavy test matrices to run.

## Validation

- `python3 -m pytest -q tests/test_heavy_ci_gate.py` (6 passed)
- `python3 -m black --target-version py310 --check tests/test_heavy_ci_gate.py`
- `python3 -m ruff check tests/test_heavy_ci_gate.py`
- `bash -n .github/scripts/check_heavy_ci_gate.sh`
- `git diff --check`

No `ci:*` label is intentionally applied to this PR so the gate behavior can also be observed in CI.
