### PR TITLE
[CI] Fix shared model cache mount path for vLLM and SGLang

### DIFF
--- a/.github/scripts/plugin_ci/run_sglang_ci.sh
+++ b/.github/scripts/plugin_ci/run_sglang_ci.sh
@@ -162,8 +162,8 @@ elif [[ -d "/it-share/models" ]]; then
   MODEL_CACHE_MOUNT="-v /it-share/models:/models"
 elif [[ -d "/mnt/dcgpuval/models" ]]; then
   MODEL_CACHE_MOUNT="-v /mnt/dcgpuval/models:/models"
-elif [[ -d "/shared_nfs/huggingface_models/amd" ]]; then
-  MODEL_CACHE_MOUNT="-v /shared_nfs/huggingface_models/amd:/models"
+elif [[ -d "/shared_nfs/huggingface_models" ]]; then
+  MODEL_CACHE_MOUNT="-v /shared_nfs/huggingface_models:/models"
 elif [[ -d "/shareddata/models" ]]; then
   MODEL_CACHE_MOUNT="-v /shareddata/models:/models"
 elif [[ -d "/data/models" ]]; then

--- a/.github/scripts/plugin_ci/run_vllm_ci.sh
+++ b/.github/scripts/plugin_ci/run_vllm_ci.sh
@@ -177,8 +177,8 @@ elif [[ -d "/it-share/models" ]]; then
   MODEL_CACHE_MOUNT="-v /it-share/models:/models"
 elif [[ -d "/mnt/dcgpuval/models" ]]; then
   MODEL_CACHE_MOUNT="-v /mnt/dcgpuval/models:/models"
-elif [[ -d "/shared_nfs/huggingface_models/amd" ]]; then
-  MODEL_CACHE_MOUNT="-v /shared_nfs/huggingface_models/amd:/models"
+elif [[ -d "/shared_nfs/huggingface_models" ]]; then
+  MODEL_CACHE_MOUNT="-v /shared_nfs/huggingface_models:/models"
 elif [[ -d "/shareddata/models" ]]; then
   MODEL_CACHE_MOUNT="-v /shareddata/models:/models"
 elif [[ -d "/data/models" ]]; then


### PR DESCRIPTION
The vLLM and SGLang plugin CI scripts mount `/shared_nfs/huggingface_models/amd` at `/models`, but model paths already include the repository namespace. For `amd/GLM-5.2-MXFP4`, this resolves `/models/amd/GLM-5.2-MXFP4` to `/shared_nfs/huggingface_models/amd/amd/GLM-5.2-MXFP4` on the host.

Mount `/shared_nfs/huggingface_models` at `/models` in both scripts so the same model path resolves to `/shared_nfs/huggingface_models/amd/GLM-5.2-MXFP4`.

Validation:
- `bash -n .github/scripts/plugin_ci/run_vllm_ci.sh .github/scripts/plugin_ci/run_sglang_ci.sh`
- `git diff --check`
- Checked the intended GLM-5.2-MXFP4 cache on `crsuse2-m2m-v2-027`: all 282 indexed shards exist, indexed tensor names are present, and Safetensors headers and payload lengths are consistent.

The full plugin CI jobs have not been rerun for this change.
