### PR TITLE
feat(wideep): integrate EP16 transport with modular fused MoE

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1746,19 +1746,23 @@ class Config:
             self.enable_tbo_decode = False
 
         self.moe_backend = self.moe_backend.strip().lower()
-        if self.moe_backend not in ("standard", "mega"):
+        if self.moe_backend not in ("standard", "mega", "wideep"):
             raise ValueError(
-                "moe_backend must be one of {'standard', 'mega'}, "
+                "moe_backend must be one of {'standard', 'mega', 'wideep'}, "
                 f"got {self.moe_backend!r}"
             )
-        if self.moe_backend == "mega" and not self.enable_expert_parallel:
+        if self.moe_backend in ("mega", "wideep") and not self.enable_expert_parallel:
             raise ValueError(
-                "moe_backend='mega' requires expert parallelism; "
+                f"moe_backend={self.moe_backend!r} requires expert parallelism; "
                 "pass --enable-expert-parallel."
             )
-        if self.moe_backend == "mega" and self.moe_all2all_backend == "rccl":
+        if (
+            self.moe_backend in ("mega", "wideep")
+            and self.moe_all2all_backend == "rccl"
+        ):
             raise ValueError(
-                "moe_backend='mega' owns its MoRI transport and cannot use the "
+                f"moe_backend={self.moe_backend!r} owns its MoRI transport and "
+                "cannot use the "
                 "experimental RCCL prepare/finalize backend"
             )
 

--- a/atom/model_engine/arg_utils.py
+++ b/atom/model_engine/arg_utils.py
@@ -333,9 +333,10 @@ class EngineArgs:
             "--moe-backend",
             type=str,
             default="standard",
-            choices=["standard", "mega"],
+            choices=["standard", "mega", "wideep"],
             help="MoE implementation. 'standard' uses the existing "
-            "prepare/GEMM/finalize path; 'mega' uses fused FlyDSL MegaMoE.",
+            "prepare/GEMM/finalize path; 'mega' uses fused FlyDSL MegaMoE; "
+            "'wideep' uses AITER's EP16 inter-node operator.",
         )
         parser.add_argument(
             "--method",

--- a/atom/model_ops/fused_moe/mori_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_prepare_finalize.py
@@ -183,6 +183,9 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         is_async: bool = False,
         tbo_mori_ops: list | None = None,
         low_latency: bool = False,
+        dispatch_quantizer: Callable[[torch.Tensor], tuple[torch.Tensor, torch.Tensor]]
+        | None = None,
+        fixed_dispatch_config: tuple[int, int] | None = None,
     ):
         if not MORI_AVAILABLE:
             raise ImportError(
@@ -198,6 +201,8 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         self.quant_dtype = quant_dtype
         self._is_async = is_async
         self._low_latency = low_latency
+        self._dispatch_quantizer = dispatch_quantizer
+        self._fixed_dispatch_config = fixed_dispatch_config
 
     # Derived from the resolved format so there is no second copy to keep in
     # sync with the staging config.
@@ -254,6 +259,9 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         completes -> warmup deadlocks. Capping at multi_processor_count keeps
         big-CU GPUs (MI300X/MI355X, >=128 CU) at 128 with no perf loss.
         """
+        if self._fixed_dispatch_config is not None:
+            return self._fixed_dispatch_config
+
         mp = get_cu_num()
         context = get_forward_context().context
         if context.is_prefill:
@@ -283,11 +291,19 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         - Optional dispatched expert topk IDs
         - Optional dispatched expert topk weight
         """
-        assert (
-            not apply_router_weight_on_input
-        ), "mori does not support apply_router_weight_on_input=True now."
+        assert not apply_router_weight_on_input, (
+            "mori does not support apply_router_weight_on_input=True now."
+        )
+        # EpDispatchCombineOp requires FP32 routing weights and contiguous INT32
+        # global expert IDs. Normalize at the shared MORI boundary so every
+        # transport, including WideEP, uses the same prepare implementation.
+        topk_weights = topk_weights.to(torch.float32).contiguous()
+        topk_ids = topk_ids.to(torch.int32).contiguous()
+
         scale = None
-        if self.use_fp4_dispatch:
+        if self._dispatch_quantizer is not None:
+            a1, scale = self._dispatch_quantizer(a1)
+        elif self.use_fp4_dispatch:
             from aiter import get_hip_quant
 
             quant_func = get_hip_quant(self.quant_type or quant_type)
@@ -331,6 +347,7 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         apply_router_weight_on_input: bool,
     ) -> torch.Tensor:
         num_token = topk_ids.shape[0]
+        topk_ids = topk_ids.to(torch.int32).contiguous()
 
         block_num, warp_per_block = self._get_dispatch_config(num_token)
 
@@ -354,9 +371,9 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         expert_map: torch.Tensor | None,
         apply_router_weight_on_input: bool,
     ) -> mk.ReceiverType:
-        assert (
-            not apply_router_weight_on_input
-        ), "mori does not support apply_router_weight_on_input=True now."
+        assert not apply_router_weight_on_input, (
+            "mori does not support apply_router_weight_on_input=True now."
+        )
 
         scale = None
         if self.use_fp4_dispatch:

--- a/atom/model_ops/fused_moe/mori_prepare_finalize.py
+++ b/atom/model_ops/fused_moe/mori_prepare_finalize.py
@@ -183,8 +183,9 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         is_async: bool = False,
         tbo_mori_ops: list | None = None,
         low_latency: bool = False,
-        dispatch_quantizer: Callable[[torch.Tensor], tuple[torch.Tensor, torch.Tensor]]
-        | None = None,
+        dispatch_quantizer: (
+            Callable[[torch.Tensor], tuple[torch.Tensor, torch.Tensor]] | None
+        ) = None,
         fixed_dispatch_config: tuple[int, int] | None = None,
     ):
         if not MORI_AVAILABLE:
@@ -291,9 +292,9 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         - Optional dispatched expert topk IDs
         - Optional dispatched expert topk weight
         """
-        assert not apply_router_weight_on_input, (
-            "mori does not support apply_router_weight_on_input=True now."
-        )
+        assert (
+            not apply_router_weight_on_input
+        ), "mori does not support apply_router_weight_on_input=True now."
         # EpDispatchCombineOp requires FP32 routing weights and contiguous INT32
         # global expert IDs. Normalize at the shared MORI boundary so every
         # transport, including WideEP, uses the same prepare implementation.
@@ -371,9 +372,9 @@ class MoriPrepareAndFinalize(mk.FusedMoEPrepareAndFinalize):
         expert_map: torch.Tensor | None,
         apply_router_weight_on_input: bool,
     ) -> mk.ReceiverType:
-        assert not apply_router_weight_on_input, (
-            "mori does not support apply_router_weight_on_input=True now."
-        )
+        assert (
+            not apply_router_weight_on_input
+        ), "mori does not support apply_router_weight_on_input=True now."
 
         scale = None
         if self.use_fp4_dispatch:

--- a/atom/model_ops/fused_moe/wideep_experts.py
+++ b/atom/model_ops/fused_moe/wideep_experts.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal adapter for AITER's EP16 inter-node MoE operator."""
+
+from __future__ import annotations
+
+import torch
+
+_WIDEEP_CACHE: dict[tuple, object] = {}
+
+
+def build_wideep_weights(layer) -> None:
+    """Convert ATOM's raw MXFP4 weights to TestWideEpMoe's layout."""
+    from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+    local_experts = int(layer.w13_weight.shape[0])
+    if local_experts != layer.local_num_experts:
+        raise RuntimeError(
+            "WideEP weight count does not match the local expert layout: "
+            f"weights={local_experts}, local_experts={layer.local_num_experts}"
+        )
+
+    layer._wideep_w1 = shuffle_weight_a16w4(
+        layer.w13_weight.data, 16, True
+    ).contiguous()
+    layer._wideep_w1_scale = shuffle_scale_a16w4(
+        layer.w13_weight_scale.data.flatten(0, 1), local_experts, True
+    ).contiguous()
+    layer._wideep_w2 = shuffle_weight_a16w4(
+        layer.w2_weight.data, 16, False
+    ).contiguous()
+    layer._wideep_w2_scale = shuffle_scale_a16w4(
+        layer.w2_weight_scale.data.flatten(0, 1), local_experts, False
+    ).contiguous()
+    layer._wideep_w1.is_shuffled = True
+    layer._wideep_w2.is_shuffled = True
+
+
+def _get_wideep_op(
+    *,
+    rank: int,
+    world_size: int,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    mtpr: int,
+    swiglu_limit: float,
+    layer,
+):
+    """Share the MORI transport and bind the current layer's weights."""
+    key = (
+        rank,
+        world_size,
+        model_dim,
+        inter_dim,
+        experts,
+        topk,
+        mtpr,
+        swiglu_limit,
+    )
+    op = _WIDEEP_CACHE.get(key)
+    if op is None:
+        from aiter.ops.flydsl.test_wide_ep_moe import TestWideEpMoe
+
+        op = TestWideEpMoe(
+            rank=rank,
+            world_size=world_size,
+            model_dim=model_dim,
+            inter_dim=inter_dim,
+            experts=experts,
+            topk=topk,
+            quant="a8w4",
+            w1=layer._wideep_w1,
+            w1_scale=layer._wideep_w1_scale,
+            w2=layer._wideep_w2,
+            w2_scale=layer._wideep_w2_scale,
+            max_tok_per_rank=mtpr,
+            gpu_per_node=8,
+            swiglu_limit=swiglu_limit,
+            activation="silu",
+            gate_mode="interleave",
+        )
+        _WIDEEP_CACHE[key] = op
+
+    op.w1 = layer._wideep_w1
+    op.w1_scale = layer._wideep_w1_scale
+    op.w2 = layer._wideep_w2
+    op.w2_scale = layer._wideep_w2_scale
+    return op
+
+
+def run_wideep_moe(
+    layer,
+    hidden_states: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    mtpr: int,
+) -> torch.Tensor:
+    """Run AITER dispatch, expert GEMMs, and combine as one eager call."""
+    if torch.compiler.is_compiling():
+        raise RuntimeError(
+            "moe_backend='wideep' currently supports eager execution only; "
+            "start ATOM with --enforce-eager --level 0"
+        )
+
+    from aiter.dist.parallel_state import get_ep_group
+
+    # Accessing all2all_manager initializes MORI's symmetric heap.
+    manager = get_ep_group().device_communicator.all2all_manager
+    rank = int(manager.rank)
+    world_size = int(manager.world_size)
+    if world_size != 16:
+        raise RuntimeError(f"WideEP requires EP16, got EP{world_size}")
+    if int(hidden_states.shape[0]) > mtpr:
+        raise ValueError(
+            f"WideEP tokens={hidden_states.shape[0]} exceed max_num_tokens={mtpr}"
+        )
+
+    op = _get_wideep_op(
+        rank=rank,
+        world_size=world_size,
+        model_dim=model_dim,
+        inter_dim=inter_dim,
+        experts=experts,
+        topk=int(topk_ids.shape[1]),
+        mtpr=mtpr,
+        swiglu_limit=float(getattr(layer, "swiglu_limit", 0.0)),
+        layer=layer,
+    )
+    with torch.inference_mode(False), torch.no_grad():
+        output = op.forward(
+            hidden_states.contiguous(),
+            topk_weights.to(torch.float32).contiguous(),
+            topk_ids.to(torch.int32).contiguous(),
+        )
+    # MORI's result aliases its reusable combine arena.
+    return output.clone()
+
+
+class WideEpFusedExperts:
+    """Adapter for Mxfp4MoEMethod's whole-pipeline experts hook."""
+
+    def __init__(
+        self, layer, *, model_dim: int, inter_dim: int, experts: int, mtpr: int
+    ):
+        self.layer = layer
+        self.model_dim = model_dim
+        self.inter_dim = inter_dim
+        self.experts = experts
+        self.mtpr = mtpr
+
+    def __call__(
+        self,
+        *,
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        activation=None,
+        apply_router_weight_on_input=False,
+        **_ignored,
+    ):
+        from aiter import ActivationType
+
+        if apply_router_weight_on_input:
+            raise NotImplementedError(
+                "WideEP does not support apply_router_weight_on_input=True"
+            )
+        if activation is not None and activation != ActivationType.Silu:
+            raise NotImplementedError("WideEP A8W4 supports SiLU only")
+        return run_wideep_moe(
+            self.layer,
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            model_dim=self.model_dim,
+            inter_dim=self.inter_dim,
+            experts=self.experts,
+            mtpr=self.mtpr,
+        )

--- a/atom/model_ops/fused_moe/wideep_experts.py
+++ b/atom/model_ops/fused_moe/wideep_experts.py
@@ -1,183 +1,120 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Minimal adapter for AITER's EP16 inter-node MoE operator."""
+"""WideEP transport construction for ATOM's modular fused-MoE path."""
 
 from __future__ import annotations
 
+import os
+from functools import lru_cache
+
 import torch
+from aiter import QuantType, dtypes
 
-_WIDEEP_CACHE: dict[tuple, object] = {}
-
-
-def build_wideep_weights(layer) -> None:
-    """Convert ATOM's raw MXFP4 weights to TestWideEpMoe's layout."""
-    from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
-
-    local_experts = int(layer.w13_weight.shape[0])
-    if local_experts != layer.local_num_experts:
-        raise RuntimeError(
-            "WideEP weight count does not match the local expert layout: "
-            f"weights={local_experts}, local_experts={layer.local_num_experts}"
-        )
-
-    layer._wideep_w1 = shuffle_weight_a16w4(
-        layer.w13_weight.data, 16, True
-    ).contiguous()
-    layer._wideep_w1_scale = shuffle_scale_a16w4(
-        layer.w13_weight_scale.data.flatten(0, 1), local_experts, True
-    ).contiguous()
-    layer._wideep_w2 = shuffle_weight_a16w4(
-        layer.w2_weight.data, 16, False
-    ).contiguous()
-    layer._wideep_w2_scale = shuffle_scale_a16w4(
-        layer.w2_weight_scale.data.flatten(0, 1), local_experts, False
-    ).contiguous()
-    layer._wideep_w1.is_shuffled = True
-    layer._wideep_w2.is_shuffled = True
+from atom.model_ops.fused_moe.mori_prepare_finalize import (
+    MoriDispatchFormat,
+    MoriPrepareAndFinalize,
+)
 
 
-def _get_wideep_op(
+def _quantize_wideep_dispatch(
+    hidden_states: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Use the quantizer validated with AITER's inter-node WideEP path."""
+    from aiter.ops.flydsl.kernels.mega_moe.quant import per_1x32_mx_quant
+
+    return per_1x32_mx_quant(hidden_states, quant_mode="fp8")
+
+
+@lru_cache(maxsize=16)
+def _init_wideep_op(
     *,
     rank: int,
     world_size: int,
     model_dim: int,
-    inter_dim: int,
-    experts: int,
+    experts_per_rank: int,
     topk: int,
     mtpr: int,
-    swiglu_limit: float,
-    layer,
 ):
-    """Share the MORI transport and bind the current layer's weights."""
-    key = (
-        rank,
-        world_size,
-        model_dim,
-        inter_dim,
-        experts,
-        topk,
-        mtpr,
-        swiglu_limit,
+    """Create the dedicated two-node InterNodeV1LL MORI transport."""
+    import mori
+
+    capacity_mtpr = 1 << (mtpr - 1).bit_length()
+    config = mori.ops.EpDispatchCombineConfig(
+        data_type=dtypes.fp8,
+        rank=rank,
+        world_size=world_size,
+        hidden_dim=model_dim,
+        scale_dim=model_dim // 32,
+        scale_type_size=1,
+        max_num_inp_token_per_rank=capacity_mtpr,
+        num_experts_per_rank=experts_per_rank,
+        num_experts_per_token=topk,
+        max_token_type_size=torch.bfloat16.itemsize,
+        kernel_type=mori.ops.EpDispatchCombineKernelType.InterNodeV1LL,
+        gpu_per_node=8,
+        num_qp_per_pe=2,
+        rdma_block_num=int(os.environ.get("MORI_EP_RDMA_BLOCK_NUM", "64")),
+        block_num=int(os.environ.get("MORI_EP_BLOCK_NUM", "96")),
+        warp_num_per_block=int(os.environ.get("MORI_EP_WARP_PER_BLOCK", "8")),
     )
-    op = _WIDEEP_CACHE.get(key)
-    if op is None:
-        from aiter.ops.flydsl.test_wide_ep_moe import TestWideEpMoe
-
-        op = TestWideEpMoe(
-            rank=rank,
-            world_size=world_size,
-            model_dim=model_dim,
-            inter_dim=inter_dim,
-            experts=experts,
-            topk=topk,
-            quant="a8w4",
-            w1=layer._wideep_w1,
-            w1_scale=layer._wideep_w1_scale,
-            w2=layer._wideep_w2,
-            w2_scale=layer._wideep_w2_scale,
-            max_tok_per_rank=mtpr,
-            gpu_per_node=8,
-            swiglu_limit=swiglu_limit,
-            activation="silu",
-            gate_mode="interleave",
-        )
-        _WIDEEP_CACHE[key] = op
-
-    op.w1 = layer._wideep_w1
-    op.w1_scale = layer._wideep_w1_scale
-    op.w2 = layer._wideep_w2
-    op.w2_scale = layer._wideep_w2_scale
-    return op
+    return mori.ops.EpDispatchCombineOp(config)
 
 
-def run_wideep_moe(
-    layer,
-    hidden_states: torch.Tensor,
-    topk_weights: torch.Tensor,
-    topk_ids: torch.Tensor,
+def make_wideep_prepare_finalize(
     *,
     model_dim: int,
-    inter_dim: int,
     experts: int,
+    experts_per_rank: int,
+    topk: int,
     mtpr: int,
-) -> torch.Tensor:
-    """Run AITER dispatch, expert GEMMs, and combine as one eager call."""
-    if torch.compiler.is_compiling():
-        raise RuntimeError(
-            "moe_backend='wideep' currently supports eager execution only; "
-            "start ATOM with --enforce-eager --level 0"
-        )
-
+) -> MoriPrepareAndFinalize:
+    """Bind WideEP transport to the shared ATOM prepare/finalize implementation."""
     from aiter.dist.parallel_state import get_ep_group
 
-    # Accessing all2all_manager initializes MORI's symmetric heap.
+    # Accessing all2all_manager initializes MORI's symmetric heap before this
+    # dedicated operator allocates its communication arena.
     manager = get_ep_group().device_communicator.all2all_manager
     rank = int(manager.rank)
     world_size = int(manager.world_size)
     if world_size != 16:
         raise RuntimeError(f"WideEP requires EP16, got EP{world_size}")
-    if int(hidden_states.shape[0]) > mtpr:
-        raise ValueError(
-            f"WideEP tokens={hidden_states.shape[0]} exceed max_num_tokens={mtpr}"
+    if experts != experts_per_rank * world_size:
+        raise RuntimeError(
+            "WideEP requires an evenly sharded expert space: "
+            f"experts={experts}, experts_per_rank={experts_per_rank}, "
+            f"world_size={world_size}"
         )
 
-    op = _get_wideep_op(
+    # The dispatched activation is already FP8. AITER's mixed MoE selector
+    # must therefore stay on its A8W4 path even for decode-sized M.
+    bf16_fp8_bound = os.environ.get("AITER_BF16_FP8_MOE_BOUND")
+    if bf16_fp8_bound not in (None, "0"):
+        raise RuntimeError(
+            "WideEP requires AITER_BF16_FP8_MOE_BOUND=0 because dispatch "
+            "produces prequantized FP8 activations"
+        )
+    os.environ["AITER_BF16_FP8_MOE_BOUND"] = "0"
+
+    op = _init_wideep_op(
         rank=rank,
         world_size=world_size,
         model_dim=model_dim,
-        inter_dim=inter_dim,
-        experts=experts,
-        topk=int(topk_ids.shape[1]),
+        experts_per_rank=experts_per_rank,
+        topk=topk,
         mtpr=mtpr,
-        swiglu_limit=float(getattr(layer, "swiglu_limit", 0.0)),
-        layer=layer,
     )
-    with torch.inference_mode(False), torch.no_grad():
-        output = op.forward(
-            hidden_states.contiguous(),
-            topk_weights.to(torch.float32).contiguous(),
-            topk_ids.to(torch.int32).contiguous(),
-        )
-    # MORI's result aliases its reusable combine arena.
-    return output.clone()
-
-
-class WideEpFusedExperts:
-    """Adapter for Mxfp4MoEMethod's whole-pipeline experts hook."""
-
-    def __init__(
-        self, layer, *, model_dim: int, inter_dim: int, experts: int, mtpr: int
-    ):
-        self.layer = layer
-        self.model_dim = model_dim
-        self.inter_dim = inter_dim
-        self.experts = experts
-        self.mtpr = mtpr
-
-    def __call__(
-        self,
-        *,
-        hidden_states,
-        topk_weights,
-        topk_ids,
-        activation=None,
-        apply_router_weight_on_input=False,
-        **_ignored,
-    ):
-        from aiter import ActivationType
-
-        if apply_router_weight_on_input:
-            raise NotImplementedError(
-                "WideEP does not support apply_router_weight_on_input=True"
-            )
-        if activation is not None and activation != ActivationType.Silu:
-            raise NotImplementedError("WideEP A8W4 supports SiLU only")
-        return run_wideep_moe(
-            self.layer,
-            hidden_states,
-            topk_weights,
-            topk_ids,
-            model_dim=self.model_dim,
-            inter_dim=self.inter_dim,
-            experts=self.experts,
-            mtpr=self.mtpr,
-        )
+    return MoriPrepareAndFinalize(
+        op,
+        max_tokens_per_rank=mtpr,
+        num_dispatchers=world_size,
+        dispatch_format=MoriDispatchFormat(
+            dtype=dtypes.fp8,
+            quant_type=QuantType.per_1x32,
+            scale_dim=model_dim // 32,
+            scale_type_size=1,
+        ),
+        dispatch_quantizer=_quantize_wideep_dispatch,
+        fixed_dispatch_config=(
+            int(os.environ.get("MORI_EP_BLOCK_NUM", "96")),
+            int(os.environ.get("MORI_EP_WARP_PER_BLOCK", "8")),
+        ),
+    )

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1811,11 +1811,65 @@ class MegaMxfp4MoEMethod(Mxfp4MoEMethod):
         return views
 
 
+class WideEpMxfp4MoEMethod(Mxfp4MoEMethod):
+    """MXFP4 MoE method backed by AITER's EP16 inter-node operator."""
+
+    def __init__(self, quant_config: LayerQuantConfig, moe: FusedMoEConfig):
+        super().__init__(quant_config, moe)
+        parallel = moe.moe_parallel_config
+        if not parallel.use_ep or parallel.ep_size != 16 or parallel.local_ep_size != 8:
+            raise ValueError("moe_backend='wideep' requires EP16 on two 8-GPU nodes")
+        if not parallel.use_mori_kernels:
+            raise ValueError(
+                "moe_backend='wideep' requires the MORI all-to-all runtime"
+            )
+        if get_gfx() != "gfx950":
+            raise ValueError("moe_backend='wideep' requires gfx950")
+        if not quant_config.is_dynamic:
+            raise ValueError(
+                "moe_backend='wideep' requires dynamic activation quantization"
+            )
+        if get_current_atom_config().eplb_enable:
+            raise ValueError("moe_backend='wideep' does not support EPLB")
+        if moe.expert_layout.mode is not SharedExpertMode.NONE or moe.has_bias:
+            raise ValueError(
+                "moe_backend='wideep' supports routed experts without bias"
+            )
+        self.use_triton = False
+        self.use_triton_decode = False
+
+    def _process_weight_layout_after_loading(self, layer) -> None:
+        from atom.model_ops.fused_moe.wideep_experts import build_wideep_weights
+
+        build_wideep_weights(layer)
+        layer.w13_weight.data = torch.empty(
+            0, dtype=layer.w13_weight.dtype, device=layer.w13_weight.device
+        )
+        layer.w2_weight.data = torch.empty(
+            0, dtype=layer.w2_weight.dtype, device=layer.w2_weight.device
+        )
+
+    def init_prepare_finalize(self, layer: torch.nn.Module):
+        from atom.model_ops.fused_moe.wideep_experts import WideEpFusedExperts
+
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        self.fused_experts = WideEpFusedExperts(
+            layer,
+            model_dim=self.hidden_size,
+            inter_dim=self.intermediate_size,
+            experts=self.moe.num_experts,
+            mtpr=self.moe.max_num_tokens,
+        )
+
+
 def _make_mxfp4_moe_method(
     quant_config: LayerQuantConfig, moe: FusedMoEConfig
 ) -> Mxfp4MoEMethod:
-    if get_current_atom_config().moe_backend == "mega":
+    backend = get_current_atom_config().moe_backend
+    if backend == "mega":
         return MegaMxfp4MoEMethod(quant_config, moe)
+    if backend == "wideep":
+        return WideEpMxfp4MoEMethod(quant_config, moe)
     return Mxfp4MoEMethod(quant_config, moe)
 
 
@@ -3108,14 +3162,19 @@ class FusedMoE(torch.nn.Module):
             self._comm_fused_moe.initialize(self)
 
     def _validate_moe_backend(self) -> None:
-        if get_current_atom_config().moe_backend != "mega":
+        backend = get_current_atom_config().moe_backend
+        if backend == "standard":
             return
-        if not isinstance(self.quant_method, MegaMxfp4MoEMethod):
+        expected = MegaMxfp4MoEMethod if backend == "mega" else WideEpMxfp4MoEMethod
+        if not isinstance(self.quant_method, expected):
             raise TypeError(
-                "moe_backend='mega' currently supports only MXFP4/A8W4 MoE, "
+                f"moe_backend={backend!r} currently supports only MXFP4/A8W4 MoE, "
                 f"got {type(self.quant_method).__name__}"
             )
-        if self.expert_layout.mode is SharedExpertMode.LEGACY_AITER:
+        if (
+            backend == "mega"
+            and self.expert_layout.mode is SharedExpertMode.LEGACY_AITER
+        ):
             raise NotImplementedError(
                 "moe_backend='mega' requires the shared expert to be fused into "
                 "the dispatch space; the legacy AITER fusion is unsupported."

--- a/atom/model_ops/moe.py
+++ b/atom/model_ops/moe.py
@@ -1812,7 +1812,7 @@ class MegaMxfp4MoEMethod(Mxfp4MoEMethod):
 
 
 class WideEpMxfp4MoEMethod(Mxfp4MoEMethod):
-    """MXFP4 MoE method backed by AITER's EP16 inter-node operator."""
+    """MXFP4 MoE using WideEP dispatch/combine around AITER fused_moe."""
 
     def __init__(self, quant_config: LayerQuantConfig, moe: FusedMoEConfig):
         super().__init__(quant_config, moe)
@@ -1837,28 +1837,47 @@ class WideEpMxfp4MoEMethod(Mxfp4MoEMethod):
             )
         self.use_triton = False
         self.use_triton_decode = False
+        # The validated gfx950 A8W4 kernel consumes GUGU-interleaved w1 and
+        # scales. Keep the normal ATOM/AITER weight preparation, but pin its
+        # layout instead of relying on a launch-time environment variable.
+        self.is_guinterleave = True
 
     def _process_weight_layout_after_loading(self, layer) -> None:
-        from atom.model_ops.fused_moe.wideep_experts import build_wideep_weights
-
-        build_wideep_weights(layer)
-        layer.w13_weight.data = torch.empty(
-            0, dtype=layer.w13_weight.dtype, device=layer.w13_weight.device
-        )
-        layer.w2_weight.data = torch.empty(
-            0, dtype=layer.w2_weight.dtype, device=layer.w2_weight.device
-        )
+        # Use the same shuffled weights that ATOM's normal aiter.fused_moe path
+        # consumes. WideEP changes only prepare/finalize communication.
+        super()._process_weight_layout_after_loading(layer)
 
     def init_prepare_finalize(self, layer: torch.nn.Module):
-        from atom.model_ops.fused_moe.wideep_experts import WideEpFusedExperts
+        from atom.model_ops.fused_moe.wideep_experts import (
+            make_wideep_prepare_finalize,
+        )
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        self.fused_experts = WideEpFusedExperts(
-            layer,
+        prepare_finalize = make_wideep_prepare_finalize(
             model_dim=self.hidden_size,
-            inter_dim=self.intermediate_size,
             experts=self.moe.num_experts,
+            experts_per_rank=self.moe.num_local_experts,
+            topk=self.moe.experts_per_token,
             mtpr=self.moe.max_num_tokens,
+        )
+        self.topk_indices_dtype = prepare_finalize.topk_indices_dtype()
+
+        # MORI pads inactive arena rows with the global-expert sentinel. Keep
+        # one masked slot for that value, matching TestWideEpMoe's native path.
+        if (
+            layer.expert_mask is not None
+            and layer.expert_mask.numel() == self.moe.num_experts
+        ):
+            layer.expert_mask = torch.cat(
+                (layer.expert_mask, layer.expert_mask.new_zeros(1))
+            )
+
+        # TODO(wideep): split fused_moe when the BF16 stage-1 intermediate for
+        # the static receive bound exceeds one AMDGPU buffer descriptor's 4-GiB
+        # byte range. The communication contract is independent of that guard.
+        self.fused_experts = FusedMoEModularKernel(
+            prepare_finalize,
+            quant_config=self.moe_quant_config,
         )
 
 

--- a/tests/test_arg_utils_spec.py
+++ b/tests/test_arg_utils_spec.py
@@ -131,6 +131,11 @@ class TestMoEBackendCli:
         assert args.moe_backend == "mega"
         assert args._get_engine_kwargs()["moe_backend"] == "mega"
 
+    def test_wideep_backend(self):
+        args = self._parse(["--moe-backend", "wideep"])
+        assert args.moe_backend == "wideep"
+        assert args._get_engine_kwargs()["moe_backend"] == "wideep"
+
 
 class TestMoEAll2AllBackendCli:
     def _parse(self, argv):

--- a/tests/test_wideep_mxfp4_method.py
+++ b/tests/test_wideep_mxfp4_method.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from import_guard import skip_if_dependency_missing
+
+try:
+    import atom.model_ops.moe as moe_mod
+except ImportError as exc:
+    skip_if_dependency_missing(exc, "requires full atom import env")
+
+
+def _moe_parallel(**overrides):
+    values = {
+        "use_ep": True,
+        "ep_size": 16,
+        "local_ep_size": 8,
+        "use_mori_kernels": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _moe(**overrides):
+    values = {
+        "moe_parallel_config": _moe_parallel(),
+        "expert_layout": SimpleNamespace(mode=moe_mod.SharedExpertMode.NONE),
+        "has_bias": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_explicit_wideep_backend_selects_wideep_method(monkeypatch):
+    standard = object()
+    wideep = object()
+    monkeypatch.setattr(
+        moe_mod,
+        "get_current_atom_config",
+        lambda: SimpleNamespace(moe_backend="wideep"),
+    )
+    monkeypatch.setattr(moe_mod, "Mxfp4MoEMethod", lambda *_args: standard)
+    monkeypatch.setattr(moe_mod, "WideEpMxfp4MoEMethod", lambda *_args: wideep)
+
+    assert moe_mod._make_mxfp4_moe_method(object(), object()) is wideep
+
+
+def test_wideep_method_requires_ep16_mori(monkeypatch):
+    monkeypatch.setattr(moe_mod.Mxfp4MoEMethod, "__init__", lambda *_args: None)
+    monkeypatch.setattr(moe_mod, "get_gfx", lambda: "gfx950")
+    monkeypatch.setattr(
+        moe_mod,
+        "get_current_atom_config",
+        lambda: SimpleNamespace(eplb_enable=False),
+    )
+
+    method = moe_mod.WideEpMxfp4MoEMethod(SimpleNamespace(is_dynamic=True), _moe())
+    assert method.use_triton is False
+    assert method.use_triton_decode is False
+
+    with pytest.raises(ValueError, match="requires EP16"):
+        moe_mod.WideEpMxfp4MoEMethod(
+            SimpleNamespace(is_dynamic=True),
+            _moe(moe_parallel_config=_moe_parallel(ep_size=8)),
+        )
+
+    with pytest.raises(ValueError, match="requires the MORI"):
+        moe_mod.WideEpMxfp4MoEMethod(
+            SimpleNamespace(is_dynamic=True),
+            _moe(moe_parallel_config=_moe_parallel(use_mori_kernels=False)),
+        )
+
+
+def test_wideep_run_calls_aiter_and_copies_combine_output(monkeypatch):
+    from aiter.dist import parallel_state
+
+    from atom.model_ops.fused_moe import wideep_experts
+
+    manager = SimpleNamespace(rank=3, world_size=16)
+    group = SimpleNamespace(
+        device_communicator=SimpleNamespace(all2all_manager=manager)
+    )
+    monkeypatch.setattr(parallel_state, "get_ep_group", lambda: group)
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: False)
+
+    arena_output = torch.ones((2, 4), dtype=torch.bfloat16)
+    calls = []
+
+    class FakeOp:
+        def forward(self, hidden, weights, ids):
+            calls.append((hidden, weights, ids))
+            return arena_output
+
+    captured = {}
+
+    def fake_get(**kwargs):
+        captured.update(kwargs)
+        return FakeOp()
+
+    monkeypatch.setattr(wideep_experts, "_get_wideep_op", fake_get)
+    layer = SimpleNamespace(swiglu_limit=10.0)
+    hidden = torch.randn(2, 4, dtype=torch.bfloat16)
+    weights = torch.randn(2, 2, dtype=torch.bfloat16)
+    ids = torch.tensor([[0, 1], [2, 3]], dtype=torch.int64)
+
+    output = wideep_experts.run_wideep_moe(
+        layer,
+        hidden,
+        weights,
+        ids,
+        model_dim=4,
+        inter_dim=8,
+        experts=16,
+        mtpr=32,
+    )
+
+    assert captured["rank"] == 3
+    assert captured["world_size"] == 16
+    assert captured["topk"] == 2
+    assert calls[0][1].dtype == torch.float32
+    assert calls[0][2].dtype == torch.int32
+    assert torch.equal(output, arena_output)
+    assert output.data_ptr() != arena_output.data_ptr()
+
+
+def test_wideep_rejects_torch_compile(monkeypatch):
+    from atom.model_ops.fused_moe import wideep_experts
+
+    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
+    with pytest.raises(RuntimeError, match="--level 0"):
+        wideep_experts.run_wideep_moe(
+            SimpleNamespace(),
+            torch.empty(1, 4),
+            torch.empty(1, 1),
+            torch.empty(1, 1, dtype=torch.int64),
+            model_dim=4,
+            inter_dim=8,
+            experts=16,
+            mtpr=32,
+        )

--- a/tests/test_wideep_mxfp4_method.py
+++ b/tests/test_wideep_mxfp4_method.py
@@ -99,7 +99,7 @@ def test_wideep_reuses_mori_prepare_finalize_around_fused_moe(monkeypatch):
     recv_weights = torch.randn(8, 2, dtype=torch.float32)
     recv_ids = torch.zeros(8, 2, dtype=torch.int32)
     recv_count = torch.tensor([5], dtype=torch.int32)
-    fused_output = torch.full((8, 4), 7, dtype=torch.bfloat16)
+    fused_output = torch.full((3, 4), 7, dtype=torch.bfloat16)
     combined = torch.full((3, 4), 9, dtype=torch.bfloat16)
     calls = {}
 
@@ -128,7 +128,9 @@ def test_wideep_reuses_mori_prepare_finalize_around_fused_moe(monkeypatch):
     monkeypatch.setattr(
         modular_kernel,
         "get_forward_context",
-        lambda: SimpleNamespace(context=None),
+        lambda: SimpleNamespace(
+            context=SimpleNamespace(running_tokens_across_dp=(1, 2))
+        ),
     )
 
     def fake_fused_moe(*args, **kwargs):
@@ -175,9 +177,10 @@ def test_wideep_reuses_mori_prepare_finalize_around_fused_moe(monkeypatch):
     assert dispatch[4:] == (96, 8)
 
     args, kwargs = calls["fused_moe"]
-    assert args[0] is recv_x
-    assert args[3] is recv_weights
-    assert args[4] is recv_ids
+    assert args[0].shape[0] == 3
+    assert torch.equal(args[0], recv_x[:3])
+    assert torch.equal(args[3], recv_weights[:3])
+    assert torch.equal(args[4], recv_ids[:3])
     assert args[5] is expert_mask
     assert kwargs["a1_scale"] is recv_scale
     assert kwargs["num_local_tokens"] is recv_count

--- a/tests/test_wideep_mxfp4_method.py
+++ b/tests/test_wideep_mxfp4_method.py
@@ -98,7 +98,7 @@ def test_wideep_reuses_mori_prepare_finalize_around_fused_moe(monkeypatch):
     recv_scale = torch.ones(8, 1, dtype=torch.uint8)
     recv_weights = torch.randn(8, 2, dtype=torch.float32)
     recv_ids = torch.zeros(8, 2, dtype=torch.int32)
-    recv_count = torch.tensor([5], dtype=torch.int32)
+    recv_count = torch.tensor([2], dtype=torch.int32)
     fused_output = torch.full((3, 4), 7, dtype=torch.bfloat16)
     combined = torch.full((3, 4), 9, dtype=torch.bfloat16)
     calls = {}
@@ -182,7 +182,7 @@ def test_wideep_reuses_mori_prepare_finalize_around_fused_moe(monkeypatch):
     assert torch.equal(args[3], recv_weights[:3])
     assert torch.equal(args[4], recv_ids[:3])
     assert args[5] is expert_mask
-    assert kwargs["a1_scale"] is recv_scale
+    assert torch.equal(kwargs["a1_scale"], recv_scale[:3])
     assert kwargs["num_local_tokens"] is recv_count
     assert kwargs["gate_mode"] == "interleave"
 

--- a/tests/test_wideep_mxfp4_method.py
+++ b/tests/test_wideep_mxfp4_method.py
@@ -59,6 +59,7 @@ def test_wideep_method_requires_ep16_mori(monkeypatch):
     method = moe_mod.WideEpMxfp4MoEMethod(SimpleNamespace(is_dynamic=True), _moe())
     assert method.use_triton is False
     assert method.use_triton_decode is False
+    assert method.is_guinterleave is True
 
     with pytest.raises(ValueError, match="requires EP16"):
         moe_mod.WideEpMxfp4MoEMethod(
@@ -73,70 +74,157 @@ def test_wideep_method_requires_ep16_mori(monkeypatch):
         )
 
 
-def test_wideep_run_calls_aiter_and_copies_combine_output(monkeypatch):
+def test_wideep_reuses_mori_prepare_finalize_around_fused_moe(monkeypatch):
+    from aiter import ActivationType, QuantType
     from aiter.dist import parallel_state
 
-    from atom.model_ops.fused_moe import wideep_experts
+    from atom.model_ops.fused_moe import (
+        modular_kernel,
+        mori_prepare_finalize,
+        wideep_experts,
+    )
 
     manager = SimpleNamespace(rank=3, world_size=16)
     group = SimpleNamespace(
         device_communicator=SimpleNamespace(all2all_manager=manager)
     )
     monkeypatch.setattr(parallel_state, "get_ep_group", lambda: group)
-    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: False)
+    monkeypatch.setattr(mori_prepare_finalize, "MORI_AVAILABLE", True)
+    monkeypatch.delenv("AITER_BF16_FP8_MOE_BOUND", raising=False)
 
-    arena_output = torch.ones((2, 4), dtype=torch.bfloat16)
-    calls = []
+    quantized = torch.zeros(3, 4, dtype=torch.uint8)
+    quant_scale = torch.ones(3, 1, dtype=torch.uint8)
+    recv_x = torch.zeros(8, 4, dtype=torch.uint8)
+    recv_scale = torch.ones(8, 1, dtype=torch.uint8)
+    recv_weights = torch.randn(8, 2, dtype=torch.float32)
+    recv_ids = torch.zeros(8, 2, dtype=torch.int32)
+    recv_count = torch.tensor([5], dtype=torch.int32)
+    fused_output = torch.full((8, 4), 7, dtype=torch.bfloat16)
+    combined = torch.full((3, 4), 9, dtype=torch.bfloat16)
+    calls = {}
+
+    def fake_quantize(hidden_states):
+        calls["quantize"] = hidden_states
+        return quantized, quant_scale
 
     class FakeOp:
-        def forward(self, hidden, weights, ids):
-            calls.append((hidden, weights, ids))
-            return arena_output
+        def dispatch(self, hidden, weights, scale, ids, block_num, warp_num):
+            calls["dispatch"] = (
+                hidden,
+                weights,
+                scale,
+                ids,
+                block_num,
+                warp_num,
+            )
+            return recv_x, recv_weights, recv_scale, recv_ids, recv_count
 
-    captured = {}
+        def combine(self, output, bias, ids, block_num, warp_num):
+            calls["combine"] = (output, bias, ids, block_num, warp_num)
+            return combined, None
 
-    def fake_get(**kwargs):
-        captured.update(kwargs)
-        return FakeOp()
-
-    monkeypatch.setattr(wideep_experts, "_get_wideep_op", fake_get)
-    layer = SimpleNamespace(swiglu_limit=10.0)
-    hidden = torch.randn(2, 4, dtype=torch.bfloat16)
-    weights = torch.randn(2, 2, dtype=torch.bfloat16)
-    ids = torch.tensor([[0, 1], [2, 3]], dtype=torch.int64)
-
-    output = wideep_experts.run_wideep_moe(
-        layer,
-        hidden,
-        weights,
-        ids,
-        model_dim=4,
-        inter_dim=8,
-        experts=16,
-        mtpr=32,
+    monkeypatch.setattr(wideep_experts, "_init_wideep_op", lambda **_kwargs: FakeOp())
+    monkeypatch.setattr(wideep_experts, "_quantize_wideep_dispatch", fake_quantize)
+    monkeypatch.setattr(
+        modular_kernel,
+        "get_forward_context",
+        lambda: SimpleNamespace(context=None),
     )
 
-    assert captured["rank"] == 3
-    assert captured["world_size"] == 16
-    assert captured["topk"] == 2
-    assert calls[0][1].dtype == torch.float32
-    assert calls[0][2].dtype == torch.int32
-    assert torch.equal(output, arena_output)
-    assert output.data_ptr() != arena_output.data_ptr()
+    def fake_fused_moe(*args, **kwargs):
+        calls["fused_moe"] = (args, kwargs)
+        return fused_output
+
+    monkeypatch.setattr(modular_kernel, "fused_moe", fake_fused_moe)
+
+    prepare_finalize = wideep_experts.make_wideep_prepare_finalize(
+        model_dim=4,
+        experts=16,
+        experts_per_rank=1,
+        topk=2,
+        mtpr=32,
+    )
+    assert isinstance(prepare_finalize, mori_prepare_finalize.MoriPrepareAndFinalize)
+    kernel = modular_kernel.FusedMoEModularKernel(prepare_finalize, quant_config=None)
+    hidden = torch.randn(3, 4, dtype=torch.bfloat16)
+    topk_weights = torch.randn(3, 2, dtype=torch.bfloat16)
+    topk_ids = torch.zeros(3, 2, dtype=torch.int64)
+    expert_mask = torch.tensor([1] + [0] * 16, dtype=torch.int32)
+
+    result = kernel(
+        hidden,
+        torch.empty(1, 8, 2),
+        torch.empty(1, 4, 4),
+        topk_weights,
+        topk_ids,
+        activation=ActivationType.Silu,
+        quant_type=QuantType.per_1x32,
+        global_num_experts=16,
+        expert_mask=expert_mask,
+        w1_scale=torch.ones(1),
+        w2_scale=torch.ones(1),
+        moe_extra_args={"gate_mode": "interleave", "swiglu_limit": 10.0},
+    )
+
+    assert calls["quantize"] is hidden
+    dispatch = calls["dispatch"]
+    assert dispatch[0] is quantized
+    assert dispatch[1].dtype == torch.float32
+    assert dispatch[2] is quant_scale
+    assert dispatch[3].dtype == torch.int32
+    assert dispatch[4:] == (96, 8)
+
+    args, kwargs = calls["fused_moe"]
+    assert args[0] is recv_x
+    assert args[3] is recv_weights
+    assert args[4] is recv_ids
+    assert args[5] is expert_mask
+    assert kwargs["a1_scale"] is recv_scale
+    assert kwargs["num_local_tokens"] is recv_count
+    assert kwargs["gate_mode"] == "interleave"
+
+    combine = calls["combine"]
+    assert combine[0] is fused_output
+    assert combine[1] is None
+    assert combine[2].dtype == torch.int32
+    assert combine[3:] == (96, 8)
+    assert torch.equal(result, combined)
 
 
-def test_wideep_rejects_torch_compile(monkeypatch):
+def test_wideep_method_installs_modular_kernel_and_sentinel_mask(monkeypatch):
     from atom.model_ops.fused_moe import wideep_experts
+    from atom.model_ops.fused_moe.modular_kernel import FusedMoEModularKernel
 
-    monkeypatch.setattr(torch.compiler, "is_compiling", lambda: True)
-    with pytest.raises(RuntimeError, match="--level 0"):
-        wideep_experts.run_wideep_moe(
-            SimpleNamespace(),
-            torch.empty(1, 4),
-            torch.empty(1, 1),
-            torch.empty(1, 1, dtype=torch.int64),
-            model_dim=4,
-            inter_dim=8,
-            experts=16,
-            mtpr=32,
-        )
+    method = object.__new__(moe_mod.WideEpMxfp4MoEMethod)
+    method.moe = SimpleNamespace(
+        num_experts=16,
+        num_local_experts=1,
+        experts_per_token=2,
+        max_num_tokens=32,
+    )
+    method.hidden_size = 4
+    method.intermediate_size = 8
+    method.topk_indices_dtype = None
+    method.fused_experts = None
+    quant_config = object()
+    method.get_fused_moe_quant_config = lambda _layer: quant_config
+
+    class FakePrepareFinalize:
+        def topk_indices_dtype(self):
+            return torch.int32
+
+    prepare_finalize = FakePrepareFinalize()
+    monkeypatch.setattr(
+        wideep_experts,
+        "make_wideep_prepare_finalize",
+        lambda **_kwargs: prepare_finalize,
+    )
+    layer = SimpleNamespace(expert_mask=torch.ones(16, dtype=torch.int32))
+
+    method.init_prepare_finalize(layer)
+
+    assert method.topk_indices_dtype == torch.int32
+    assert layer.expert_mask.tolist() == [1] * 16 + [0]
+    assert isinstance(method.fused_experts, FusedMoEModularKernel)
+    assert method.fused_experts.prepare_finalize is prepare_finalize
+    assert method.fused_experts.quant_config is quant_config


### PR DESCRIPTION
Adds an explicit `--moe-backend wideep` path for EP16 inter-node MXFP4 MoE.

WideEP now changes only the communication stages in ATOM's modular fused-MoE pipeline:

1. quantize activations with the FP8 per-1x32 format used by the WideEP transport;
2. dispatch with MORI `EpDispatchCombineOp` using `InterNodeV1LL`;
3. run ATOM's normal `FusedMoEModularKernel` and AITER `fused_moe` with the standard shuffled MXFP4 weights;
4. combine through the same MORI operator using the original routing IDs.

The implementation directly reuses `MoriPrepareAndFinalize`. The shared class now accepts an optional dispatch quantizer and fixed dispatch launch configuration, and normalizes MORI routing weights and IDs at the common transport boundary. The earlier whole-layer `TestWideEpMoe.forward()` adapter and duplicate weight conversion have been removed.

The backend remains limited to the currently validated topology and model path: gfx950, EP16 across two 8-GPU nodes, MORI transport, dynamic MXFP4, routed experts without bias, and EPLB disabled. The static receive arena can still require splitting before `fused_moe` when its BF16 intermediate exceeds the 4-GiB buffer range; that guard is tracked separately from this communication wiring change.

Validation:

- `python -m pytest -q tests/test_wideep_mxfp4_method.py tests/test_arg_utils_spec.py` (`28 passed`)
- `ruff check` and `ruff format --check` on the focused implementation and tests
- `git diff --check`
- `python -m py_compile` on all changed Python files
- EP16 GSM8K accuracy validation is pending
