### PR TITLE
fix(openai): validate token limits and preserve thinking history

### DIFF
--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -70,6 +70,7 @@ from .protocol import (
     CompletionRequest,
     ModelCard,
     ModelList,
+    validated_max_tokens,
 )
 from .reasoning import (
     ReasoningChannel,
@@ -2056,6 +2057,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
     # streaming it arrives after the client was told the request succeeded.
     try:
         validate_tool_list(anthropic_to_openai_tools(request.tools))
+        validated_max_tokens(request.max_tokens, "max_tokens")
     except ValueError as exc:
         return JSONResponse(
             status_code=400,

--- a/atom/entrypoints/openai/api_server.py
+++ b/atom/entrypoints/openai/api_server.py
@@ -70,7 +70,7 @@ from .protocol import (
     CompletionRequest,
     ModelCard,
     ModelList,
-    validated_max_tokens,
+    validate_max_tokens,
 )
 from .reasoning import (
     ReasoningChannel,
@@ -2057,7 +2057,7 @@ async def anthropic_messages(request: AnthropicMessagesRequest, raw_request: Req
     # streaming it arrives after the client was told the request succeeded.
     try:
         validate_tool_list(anthropic_to_openai_tools(request.tools))
-        validated_max_tokens(request.max_tokens, "max_tokens")
+        validate_max_tokens(request.max_tokens)
     except ValueError as exc:
         return JSONResponse(
             status_code=400,

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -28,18 +28,11 @@ STREAM_DONE_MESSAGE = "data: [DONE]\n\n"
 TOOL_CHOICE_VALUES = frozenset({"auto", "none", "required"})
 
 
-def validated_max_tokens(value: int, field: str) -> int:
-    """The generation cap, rejecting values the engine cannot honour.
-
-    A cap below 1 leaves nothing to generate, and the engine returns an empty
-    completion with `finish_reason: length` rather than refusing it -- a 200
-    that reads as a successful empty answer instead of the client error it is.
-
-    Raises `ValueError`, which both completion endpoints surface as HTTP 400.
-    """
-    if value < 1:
-        raise ValueError(f"{field} must be at least 1, got {value}")
-    return value
+def validate_max_tokens(max_tokens: int) -> int:
+    """Return a valid generation limit or raise a client-facing error."""
+    if max_tokens < 1:
+        raise ValueError(f"max_tokens must be at least 1, got {max_tokens}")
+    return max_tokens
 
 
 def openai_stop_reason(finish_reason: str | None) -> str | None:
@@ -229,11 +222,9 @@ class ChatCompletionRequest(BaseModel):
     def get_max_tokens(self) -> int:
         """Return the effective generation cap for OpenAI chat requests."""
         if self.max_completion_tokens is not None:
-            return validated_max_tokens(
-                self.max_completion_tokens, "max_completion_tokens"
-            )
+            return validate_max_tokens(self.max_completion_tokens)
         if self.max_tokens is not None:
-            return validated_max_tokens(self.max_tokens, "max_tokens")
+            return validate_max_tokens(self.max_tokens)
         return DEFAULT_MAX_TOKENS
 
     def get_messages(self) -> list[ChatMessage]:
@@ -270,11 +261,9 @@ class CompletionRequest(BaseModel):
     def get_max_tokens(self) -> int:
         """Return the effective generation cap for completion requests."""
         if self.max_completion_tokens is not None:
-            return validated_max_tokens(
-                self.max_completion_tokens, "max_completion_tokens"
-            )
+            return validate_max_tokens(self.max_completion_tokens)
         if self.max_tokens is not None:
-            return validated_max_tokens(self.max_tokens, "max_tokens")
+            return validate_max_tokens(self.max_tokens)
         return DEFAULT_MAX_TOKENS
 
 

--- a/atom/entrypoints/openai/protocol.py
+++ b/atom/entrypoints/openai/protocol.py
@@ -28,6 +28,20 @@ STREAM_DONE_MESSAGE = "data: [DONE]\n\n"
 TOOL_CHOICE_VALUES = frozenset({"auto", "none", "required"})
 
 
+def validated_max_tokens(value: int, field: str) -> int:
+    """The generation cap, rejecting values the engine cannot honour.
+
+    A cap below 1 leaves nothing to generate, and the engine returns an empty
+    completion with `finish_reason: length` rather than refusing it -- a 200
+    that reads as a successful empty answer instead of the client error it is.
+
+    Raises `ValueError`, which both completion endpoints surface as HTTP 400.
+    """
+    if value < 1:
+        raise ValueError(f"{field} must be at least 1, got {value}")
+    return value
+
+
 def openai_stop_reason(finish_reason: str | None) -> str | None:
     """The engine's leave reason as OpenAI spells it.
 
@@ -215,9 +229,11 @@ class ChatCompletionRequest(BaseModel):
     def get_max_tokens(self) -> int:
         """Return the effective generation cap for OpenAI chat requests."""
         if self.max_completion_tokens is not None:
-            return self.max_completion_tokens
+            return validated_max_tokens(
+                self.max_completion_tokens, "max_completion_tokens"
+            )
         if self.max_tokens is not None:
-            return self.max_tokens
+            return validated_max_tokens(self.max_tokens, "max_tokens")
         return DEFAULT_MAX_TOKENS
 
     def get_messages(self) -> list[ChatMessage]:
@@ -254,9 +270,11 @@ class CompletionRequest(BaseModel):
     def get_max_tokens(self) -> int:
         """Return the effective generation cap for completion requests."""
         if self.max_completion_tokens is not None:
-            return self.max_completion_tokens
+            return validated_max_tokens(
+                self.max_completion_tokens, "max_completion_tokens"
+            )
         if self.max_tokens is not None:
-            return self.max_tokens
+            return validated_max_tokens(self.max_tokens, "max_tokens")
         return DEFAULT_MAX_TOKENS
 
 

--- a/atom/entrypoints/openai/serving_anthropic.py
+++ b/atom/entrypoints/openai/serving_anthropic.py
@@ -94,11 +94,16 @@ def anthropic_to_openai_messages(
                 result.append({"role": "assistant", "content": content})
             elif isinstance(content, list):
                 text_parts = []
+                reasoning_parts = []
                 tool_calls = []
                 for block in content:
                     if isinstance(block, dict):
                         if block.get("type") == "text":
                             text_parts.append(block["text"])
+                        elif block.get("type") == "thinking":
+                            thinking = block.get("thinking")
+                            if isinstance(thinking, str) and thinking:
+                                reasoning_parts.append(thinking)
                         elif block.get("type") == "tool_use":
                             tool_calls.append(
                                 {
@@ -111,6 +116,8 @@ def anthropic_to_openai_messages(
                                 }
                             )
                 entry = {"role": "assistant", "content": "\n".join(text_parts) or None}
+                if reasoning_parts:
+                    entry["reasoning_content"] = "\n".join(reasoning_parts)
                 if tool_calls:
                     entry["tool_calls"] = tool_calls
                 result.append(entry)

--- a/tests/entrypoints/test_anthropic_endpoint.py
+++ b/tests/entrypoints/test_anthropic_endpoint.py
@@ -9,12 +9,14 @@ functions and response builders.
 """
 
 import ast
+import asyncio
 import json
 import pathlib
 
 import pytest
 
 from atom.entrypoints.openai import api_server
+from atom.entrypoints.openai.protocol import ChatMessage
 from atom.entrypoints.openai.reasoning import separate_reasoning
 from atom.entrypoints.openai.serving_anthropic import (
     AnthropicMessage,
@@ -84,6 +86,54 @@ class TestAnthropicToOpenAIMessages:
         ]
         result = anthropic_to_openai_messages(msgs)
         assert result[1] == {"role": "assistant", "content": "Hello!"}
+
+    def test_assistant_thinking_is_preserved_for_multi_turn_history(self):
+        msgs = [
+            AnthropicMessage(role="user", content="Solve this carefully."),
+            AnthropicMessage(
+                role="assistant",
+                content=[
+                    {
+                        "type": "thinking",
+                        "thinking": "First inspect the constraints.",
+                        "signature": "opaque-signature",
+                    },
+                    {"type": "text", "text": "The answer is 42."},
+                ],
+            ),
+            AnthropicMessage(role="user", content="Why?"),
+        ]
+
+        result = anthropic_to_openai_messages(msgs)
+
+        assert result[1] == {
+            "role": "assistant",
+            "content": "The answer is 42.",
+            "reasoning_content": "First inspect the constraints.",
+        }
+        assert ChatMessage(**result[1]).to_template_dict() == result[1]
+
+    def test_assistant_thinking_only_is_not_converted_to_empty_history(self):
+        msgs = [
+            AnthropicMessage(
+                role="assistant",
+                content=[
+                    {
+                        "type": "thinking",
+                        "thinking": "Work still in progress.",
+                        "signature": "opaque-signature",
+                    }
+                ],
+            )
+        ]
+
+        result = anthropic_to_openai_messages(msgs)
+
+        assert result[0] == {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "Work still in progress.",
+        }
 
     def test_assistant_with_tool_use(self):
         msgs = [
@@ -490,6 +540,23 @@ class TestAnthropicMessagesRequest:
         assert req.stream is True
         assert req.stop_sequences == ["STOP"]
         assert len(req.tools) == 1
+
+    @pytest.mark.parametrize("value", [-5, -1, 0])
+    def test_non_positive_max_tokens_returns_invalid_request(self, value):
+        request = AnthropicMessagesRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=value,
+        )
+
+        response = asyncio.run(api_server.anthropic_messages(request, None))
+        body = json.loads(response.body)
+
+        assert response.status_code == 400
+        assert body["error"]["type"] == "invalid_request_error"
+        assert body["error"]["message"] == (
+            f"max_tokens must be at least 1, got {value}"
+        )
 
     def test_attribution_header_stripped(self):
         system = [

--- a/tests/entrypoints/test_protocol.py
+++ b/tests/entrypoints/test_protocol.py
@@ -217,9 +217,7 @@ class TestChatCompletionRequest:
                 "max_completion_tokens": value,
             }
         )
-        with pytest.raises(
-            ValueError, match="max_completion_tokens must be at least 1"
-        ):
+        with pytest.raises(ValueError, match="max_tokens must be at least 1"):
             req.get_max_tokens()
 
     def test_max_tokens_of_one_allowed(self):
@@ -302,7 +300,7 @@ class TestCompletionRequest:
     @pytest.mark.parametrize("value", [-5, -1, 0])
     def test_non_positive_max_tokens_rejected(self, field, value):
         req = CompletionRequest.model_validate({"prompt": "Hello world", field: value})
-        with pytest.raises(ValueError, match=f"{field} must be at least 1"):
+        with pytest.raises(ValueError, match="max_tokens must be at least 1"):
             req.get_max_tokens()
 
     def test_extra_fields_ignored(self):

--- a/tests/entrypoints/test_protocol.py
+++ b/tests/entrypoints/test_protocol.py
@@ -198,6 +198,39 @@ class TestChatCompletionRequest:
         assert req.max_tokens == 32
         assert req.get_max_tokens() == 32
 
+    @pytest.mark.parametrize("value", [-5, -1, 0])
+    def test_non_positive_max_tokens_rejected(self, value):
+        req = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": value,
+            }
+        )
+        with pytest.raises(ValueError, match="max_tokens must be at least 1"):
+            req.get_max_tokens()
+
+    @pytest.mark.parametrize("value", [-5, -1, 0])
+    def test_non_positive_max_completion_tokens_rejected(self, value):
+        req = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_completion_tokens": value,
+            }
+        )
+        with pytest.raises(
+            ValueError, match="max_completion_tokens must be at least 1"
+        ):
+            req.get_max_tokens()
+
+    def test_max_tokens_of_one_allowed(self):
+        req = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "max_tokens": 1,
+            }
+        )
+        assert req.get_max_tokens() == 1
+
     def test_n_greater_than_one(self):
         req = ChatCompletionRequest.model_validate(
             {
@@ -264,6 +297,13 @@ class TestCompletionRequest:
         assert req.max_tokens == 8192
         assert req.max_completion_tokens == 16
         assert req.get_max_tokens() == 16
+
+    @pytest.mark.parametrize("field", ["max_tokens", "max_completion_tokens"])
+    @pytest.mark.parametrize("value", [-5, -1, 0])
+    def test_non_positive_max_tokens_rejected(self, field, value):
+        req = CompletionRequest.model_validate({"prompt": "Hello world", field: value})
+        with pytest.raises(ValueError, match=f"{field} must be at least 1"):
+            req.get_max_tokens()
 
     def test_extra_fields_ignored(self):
         req = CompletionRequest.model_validate(


### PR DESCRIPTION
## Motivation

This change addresses two serving correctness issues:

1. ATOM currently accepts non-positive max_tokens and max_completion_tokens. Such requests return HTTP 200 with an empty completion instead of being rejected as invalid input. All OpenAI and Anthropic completion endpoints should consistently return HTTP 400 for generation limits below 1.
2. The Anthropic-to-OpenAI message adapter drops assistant thinking blocks from multi-turn history. Reasoning-model templates such as GLM-5.3 rely on reasoning_content to reconstruct previous assistant reasoning. Dropping it produces incomplete conversation context and may affect subsequent turns.

This change adds consistent token-limit validation and preserves Anthropic thinking history through the internal message conversion path.
