### PR TITLE
[CI] Adapt ATOMesh to Crusoe v2 runners and candidate node scheduling

### DIFF
--- a/.github/scripts/atomesh/pd_matrix.py
+++ b/.github/scripts/atomesh/pd_matrix.py
@@ -258,7 +258,6 @@ def build_cell(
     slurm_submit_runner = str(runner_cfg.get("slurm_submit_runner", ""))
     allow_auto_nodes = slurm_submit_runner in {
         "atomesh-cicd-mi350",
-        "atomesh-cicd-crusoe-mi355",
         "atomesh-cicd-mi355-crusoe",
     }
     requires_explicit_candidate_nodes = slurm_submit_runner == "atomesh-cicd-mi350"

--- a/.github/scripts/atomesh/pd_matrix.py
+++ b/.github/scripts/atomesh/pd_matrix.py
@@ -260,12 +260,9 @@ def build_cell(
         "atomesh-cicd-mi350",
         "atomesh-cicd-mi355-crusoe",
     }
-    requires_explicit_candidate_nodes = slurm_submit_runner == "atomesh-cicd-mi350"
-
     nodes = resolve_nodes(suite_cfg.get("nodes"))
-    if allow_auto_nodes and not requires_explicit_candidate_nodes:
-        nodes = []
-    if allow_auto_nodes and requires_explicit_candidate_nodes:
+    # Spur selects the required node count from the complete candidate pool.
+    if allow_auto_nodes:
         if not nodes:
             raise ValueError(
                 f"{suite_cfg.get('name', model_name)} needs a non-empty "

--- a/.github/scripts/atomesh/pd_slurm_job.sh
+++ b/.github/scripts/atomesh/pd_slurm_job.sh
@@ -12,6 +12,8 @@ CURRENT_USER="$(id -un 2>/dev/null || id -u)"
 RUN_DIR="${LOG_ROOT}/slurm_job-${JOB_ID}"
 
 mkdir -p "${RUN_DIR}"
+# Shared NFS: every Spur rank writes rank-rc-* here for GHA accounting fallback.
+chmod 0777 "${RUN_DIR}" 2>/dev/null || true
 
 EXECUTION_PHASES=(combined)
 if [[ "${BENCHMARK_KIND:-random}" == "aiperf_agentic" \
@@ -32,6 +34,28 @@ execution_phase_port_offset() {
   else
     printf '0\n'
   fi
+}
+
+# Do not wait on D-state RDMA leftovers: kill/rm with a bound so the Slurm
+# task can exit instead of sitting in COMPLETING (same as RDMA smoke).
+bounded_docker_rm() {
+  local container="$1"
+  [[ -n "${container}" ]] || return 0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 20 docker kill "${container}" >/dev/null 2>&1 || true
+    timeout 20 docker rm -f "${container}" >/dev/null 2>&1 || true
+  else
+    docker kill "${container}" >/dev/null 2>&1 || true
+    docker rm -f "${container}" >/dev/null 2>&1 || true
+  fi
+}
+
+publish_rank_rc() {
+  local rank="$1"
+  local rc="$2"
+  local rc_file="${RUN_DIR}/rank-rc-${rank}"
+  printf '%s\n' "${rc}" > "${rc_file}.tmp" 2>/dev/null || return 0
+  mv "${rc_file}.tmp" "${rc_file}" 2>/dev/null || true
 }
 
 write_env_file() {
@@ -146,7 +170,7 @@ EOF
     nccl_socket_ifname="eth1"
   fi
 
-  docker rm -f "${container}" >/dev/null 2>&1 || true
+  bounded_docker_rm "${container}"
   if [[ "${execution_phase}" != "eval" ]]; then
     docker pull "${DOCKER_IMAGE}"
   fi
@@ -158,7 +182,7 @@ EOF
   fi
 
   docker_args=(
-    run --rm --name "${container}"
+    run --name "${container}"
     --user "$(id -u):$(id -g)"
     --network host --ipc host
     --device=/dev/kfd --device=/dev/dri --device=/dev/infiniband
@@ -255,7 +279,12 @@ EOF
     bash -lc "export PATH=/run_logs/slurm_job-${JOB_ID}/bin:\${PATH}; cd /workspace/ATOM && bash .github/scripts/atomesh/pd_server_atom.sh"
   )
 
+  local docker_rc
+  set +e
   docker "${docker_args[@]}" 2>&1 | tee "${rank_dir}/${container_log}"
+  docker_rc="${PIPESTATUS[0]}"
+  set -e
+  return "${docker_rc}"
 }
 
 run_spur_job() {
@@ -325,10 +354,12 @@ EOF
     fi
     SPUR_CLEANUP_DONE=1
     echo "=== cleanup rank=${SPUR_NODE_RANK_FOR_CLEANUP} rc=${rc} ==="
+    # Publish before cleanup: Spur accounting is unreliable, so the workflow
+    # falls back to these per-rank codes.
+    publish_rank_rc "${SPUR_NODE_RANK_FOR_CLEANUP}" "${rc}"
     for suffix in "" "-benchmark" "-eval"; do
-      docker rm -f \
-        "atomesh-${ATOMESH_CELL_ID}-${JOB_ID}-${SPUR_NODE_RANK_FOR_CLEANUP}${suffix}" \
-        >/dev/null 2>&1 || true
+      bounded_docker_rm \
+        "atomesh-${ATOMESH_CELL_ID}-${JOB_ID}-${SPUR_NODE_RANK_FOR_CLEANUP}${suffix}"
     done
     return "${rc}"
   }
@@ -448,12 +479,20 @@ cleanup() {
   fi
   CLEANUP_DONE=1
   echo "=== cleanup rc=${rc} ==="
+  printf '%s\n' "${rc}" > "${RUN_DIR}/slurm-job.rc.tmp" 2>/dev/null || true
+  mv "${RUN_DIR}/slurm-job.rc.tmp" "${RUN_DIR}/slurm-job.rc" 2>/dev/null || true
   for idx in "${!SELECTED_NODES[@]}"; do
     node="${SELECTED_NODES[$idx]}"
     for suffix in "" "-benchmark" "-eval"; do
       container="atomesh-${ATOMESH_CELL_ID}-${SLURM_JOB_ID}-${idx}${suffix}"
       srun --nodes=1 --ntasks=1 --nodelist="${node}" bash -lc "
-        docker rm -f '${container}' >/dev/null 2>&1 || true
+        if command -v timeout >/dev/null 2>&1; then
+          timeout 20 docker kill '${container}' >/dev/null 2>&1 || true
+          timeout 20 docker rm -f '${container}' >/dev/null 2>&1 || true
+        else
+          docker kill '${container}' >/dev/null 2>&1 || true
+          docker rm -f '${container}' >/dev/null 2>&1 || true
+        fi
       " || true
     done
   done
@@ -494,7 +533,13 @@ for execution_phase in "${EXECUTION_PHASES[@]}"; do
       container="atomesh-'"${ATOMESH_CELL_ID}"'-'"${SLURM_JOB_ID}"'-${rank}${phase_suffix}"
       rank_dir="'"${RUN_DIR}"'/rank-${rank}"
       mkdir -p "${rank_dir}"
-      docker rm -f "${container}" >/dev/null 2>&1 || true
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 20 docker kill "${container}" >/dev/null 2>&1 || true
+        timeout 20 docker rm -f "${container}" >/dev/null 2>&1 || true
+      else
+        docker kill "${container}" >/dev/null 2>&1 || true
+        docker rm -f "${container}" >/dev/null 2>&1 || true
+      fi
       if [[ "${execution_phase}" != "eval" ]]; then
         docker pull "'"${DOCKER_IMAGE}"'"
       fi
@@ -539,7 +584,8 @@ for execution_phase in "${EXECUTION_PHASES[@]}"; do
           fi
         fi
       fi
-      docker run --rm --name "${container}" \
+      set +e
+      docker run --name "${container}" \
         --network host --ipc host --privileged \
         --device /dev/kfd --device /dev/dri --device /dev/infiniband \
         --group-add video --cap-add IPC_LOCK --cap-add NET_ADMIN \
@@ -567,6 +613,16 @@ for execution_phase in "${EXECUTION_PHASES[@]}"; do
         "'"${DOCKER_IMAGE}"'" \
         bash -lc "cd /workspace/ATOM && bash .github/scripts/atomesh/pd_server_atom.sh" \
         2>&1 | tee "${rank_dir}/${container_log}"
+      docker_rc="${PIPESTATUS[0]}"
+      set -e
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 20 docker kill "${container}" >/dev/null 2>&1 || true
+        timeout 20 docker rm -f "${container}" >/dev/null 2>&1 || true
+      else
+        docker kill "${container}" >/dev/null 2>&1 || true
+        docker rm -f "${container}" >/dev/null 2>&1 || true
+      fi
+      exit "${docker_rc}"
     '
 done
 unset ATOMESH_EXECUTION_PHASE ATOMESH_SERVICE_PORT_OFFSET

--- a/.github/scripts/atomesh/pd_slurm_job.sh
+++ b/.github/scripts/atomesh/pd_slurm_job.sh
@@ -230,6 +230,9 @@ EOF
     -v /mnt:/mnt
     -v /data:/data
   )
+  if [[ -d /shared_nfs ]]; then
+    docker_args+=(-v /shared_nfs:/shared_nfs:ro)
+  fi
 
   if [[ "${rank}" -eq 0 \
     && "${EVAL_TASK:-}" == "swebench_lite" \
@@ -549,6 +552,9 @@ for execution_phase in "${EXECUTION_PHASES[@]}"; do
           "'"${REPO_ROOT}"'" "'"${RUN_DIR}"'" "'"${DOCKER_IMAGE}"'" "'"${ENV_FILE}"'" "'"${SLURM_JOB_ID}"'")"
       fi
       nested_docker_args=()
+      if [[ -d /shared_nfs ]]; then
+        nested_docker_args+=(-v /shared_nfs:/shared_nfs:ro)
+      fi
       if [[ "${rank}" -eq 0 \
         && "${EVAL_TASK:-}" == "swebench_lite" \
         && ( "${RUN_EVAL:-false}" == "true" || "${RUN_EVAL:-false}" == "1" ) ]]; then

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -110,7 +110,6 @@ is_crusoe_v2 = slurm_submit_runner == "atomesh-cicd-mi355-crusoe"
 spur_controller_addr = runner.get("spur_controller_addr")
 spur_accounting_addr = os.environ.get("SPUR_ACCOUNTING_ADDR", "")
 if is_crusoe_v2:
-    # Match plugin_ci/submit.sh's plugin_runner_crusoe_v2_01/_02 settings.
     spur_controller_addr = "http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6817"
     spur_accounting_addr = os.environ.get("SPUR_V2_ACCOUNTING_ADDR") or (
         "http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6819"

--- a/.github/scripts/atomesh/pd_submit.sh
+++ b/.github/scripts/atomesh/pd_submit.sh
@@ -106,22 +106,19 @@ def q(value):
     return shlex.quote(str(shell_value(value)))
 
 slurm_submit_runner = runner.get("slurm_submit_runner", "atomesh-cicd")
+is_crusoe_v2 = slurm_submit_runner == "atomesh-cicd-mi355-crusoe"
 spur_controller_addr = runner.get("spur_controller_addr")
-crusoe_runner_labels = {
-    "atomesh-cicd-crusoe-mi355",
-    "atomesh-cicd-mi355-crusoe",
-}
-if slurm_submit_runner in crusoe_runner_labels:
-    default_spur_accounting_addr = "http://crs-m2m-cpu-spur-005.crusoe.amd.com:6819"
-else:
-    default_spur_accounting_addr = "http://134.199.196.72:6819"
-if not spur_controller_addr:
-    if slurm_submit_runner in crusoe_runner_labels:
-        spur_controller_addr = "http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817"
-    else:
-        spur_controller_addr = os.environ.get(
-            "SPUR_CONTROLLER_ADDR", "http://134.199.196.72:6817"
-        )
+spur_accounting_addr = os.environ.get("SPUR_ACCOUNTING_ADDR", "")
+if is_crusoe_v2:
+    # Match plugin_ci/submit.sh's plugin_runner_crusoe_v2_01/_02 settings.
+    spur_controller_addr = "http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6817"
+    spur_accounting_addr = os.environ.get("SPUR_V2_ACCOUNTING_ADDR") or (
+        "http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6819"
+    )
+elif not spur_controller_addr:
+    spur_controller_addr = os.environ.get(
+        "SPUR_CONTROLLER_ADDR", "http://134.199.196.72:6817"
+    )
 
 exports = {
     "ATOMESH_CELL_ID": cell["id"],
@@ -255,17 +252,15 @@ exports = {
     "SWEBENCH_MAX_WORKERS": "" if accuracy.get("max_workers") is None else accuracy.get("max_workers"),
     "SWEBENCH_EVAL_TIMEOUT": "" if accuracy.get("instance_timeout") is None else accuracy.get("instance_timeout"),
     "SLURM_SUBMIT_RUNNER": slurm_submit_runner,
-    "SLURM_ACCOUNT": runner.get("slurm_account", "amd-frameworks"),
-    "SLURM_PARTITION": runner.get("slurm_partition", "amd-frameworks"),
+    "SLURM_ACCOUNT": "amd-aifw-dev" if is_crusoe_v2 else runner.get("slurm_account", "amd-frameworks"),
+    "SLURM_PARTITION": "" if is_crusoe_v2 else runner.get("slurm_partition", "amd-frameworks"),
+    "SLURM_QOS": "amd-aifw-dev-qos" if is_crusoe_v2 else "",
     "SLURM_CPUS_PER_TASK": runner.get("cpus_per_task", 114),
     "SLURM_GPUS_PER_NODE": runner.get("gpus_per_node", 8),
     "SLURM_TIME_LIMIT": runner.get("time_limit", "06:00:00"),
     "SLURM_LOG_ROOT": runner.get("log_root", "/it-share/ATOMESH_LOG/"),
     "SPUR_CONTROLLER_ADDR": spur_controller_addr,
-    "SPUR_ACCOUNTING_ADDR": runner.get(
-        "spur_accounting_addr",
-        os.environ.get("SPUR_ACCOUNTING_ADDR", default_spur_accounting_addr),
-    ),
+    "SPUR_ACCOUNTING_ADDR": spur_accounting_addr,
 }
 
 # server_args is mapped key by key above, so a key the mapping never read would
@@ -309,8 +304,10 @@ else
   export SLURM_ERROR="${LOG_ROOT}/slurm-%j.err"
 fi
 SLURM_LOG_POLL_INTERVAL="${SLURM_LOG_POLL_INTERVAL:-30}"
+SLURM_ACCOUNTING_TIMEOUT="${SLURM_ACCOUNTING_TIMEOUT:-180}"
+SLURM_ACCOUNTING_POLL_INTERVAL="${SLURM_ACCOUNTING_POLL_INTERVAL:-2}"
 USES_SPUR_CONTROLLER=0
-if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-crusoe-mi355" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
+if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
   USES_SPUR_CONTROLLER=1
 fi
 
@@ -319,14 +316,14 @@ echo "cell=${ATOMESH_CELL_ID}"
 echo "model=${MODEL_NAME}"
 echo "topology=${DISPLAY_TOPOLOGY}"
 echo "nodes=${NODE_LIST}"
+echo "slurm_account=${SLURM_ACCOUNT:-default}"
+echo "slurm_partition=${SLURM_PARTITION:-default}"
+echo "slurm_qos=${SLURM_QOS:-default}"
 echo "isl=${ISL_LIST} osl=${OSL} concurrency=${CONC_LIST}"
 echo "slurm_job_name=${SLURM_JOB_NAME}"
 echo "log_root=${LOG_ROOT}"
 if [[ "${USES_SPUR_CONTROLLER}" == "1" ]]; then
   echo "spur_controller=${SPUR_CONTROLLER_ADDR}"
-fi
-if [[ "${USES_SPUR_CONTROLLER}" == "1" ]]; then
-  echo "spur_accounting=${SPUR_ACCOUNTING_ADDR}"
 fi
 
 mkdir -p "${RESULT_DIR}"
@@ -432,8 +429,8 @@ else
   if [[ -n "${SLURM_PARTITION}" ]]; then
     SBATCH_CMD+=(--partition "${SLURM_PARTITION}")
   fi
-  if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-crusoe-mi355" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
-    SBATCH_CMD+=(-q amd-burst-qos --reservation=atomesh-ci)
+  if [[ -n "${SLURM_QOS}" ]]; then
+    SBATCH_CMD+=(--qos "${SLURM_QOS}")
   fi
   SBATCH_CMD+=(
     --nodes "${NUM_NODES}"
@@ -476,7 +473,10 @@ write_slurm_cancel_helper "${JOB_ID}"
 
 set_slurm_job_log_paths "${JOB_ID}"
 monitor_slurm_job "${JOB_ID}"
+
+# Fall back to published results if accounting has no final state.
 read_slurm_exit_code "${JOB_ID}"
+read_slurm_status_files "${LOG_ROOT}/slurm_job-${JOB_ID}" "${NUM_NODES}"
 SLURM_JOB_ACTIVE=0
 SBATCH_RC="${SLURM_JOB_RC}"
 echo "slurm_state=${SLURM_STATE}"

--- a/.github/scripts/slurm_submit_helpers.sh
+++ b/.github/scripts/slurm_submit_helpers.sh
@@ -333,42 +333,62 @@ monitor_slurm_job() {
 
 read_slurm_exit_code() {
   local job_id="$1"
-  local sacct_line exit_status exit_signal
-  local attempt state
+  local sacct_line exit_status exit_signal deadline
+  local state=""
 
   SLURM_STATE="unknown"
   SLURM_EXIT_CODE="unknown"
-  SLURM_JOB_RC=1
+  SLURM_JOB_RC=2
+
+  SLURM_ACCOUNTING_TIMEOUT="${SLURM_ACCOUNTING_TIMEOUT:-30}"
+  SLURM_ACCOUNTING_POLL_INTERVAL="${SLURM_ACCOUNTING_POLL_INTERVAL:-2}"
 
   if ! command -v sacct >/dev/null 2>&1; then
     echo "WARNING: sacct not found; unable to read Slurm job exit code" >&2
     return 0
   fi
 
-  for ((attempt = 1; attempt <= ${SLURM_SACCT_MAX_ATTEMPTS:-12}; attempt++)); do
+  deadline=$(( $(date +%s) + SLURM_ACCOUNTING_TIMEOUT ))
+  while true; do
     if [[ "${USES_SPUR_CONTROLLER}" == "1" ]]; then
-      sacct_line="$(sacct --accounting "${SPUR_ACCOUNTING_ADDR}" --brief --noheader 2>/dev/null | awk -v job_id="${job_id}" '$1 == job_id { print $2 "|" $3; exit }' || true)"
+      if [[ -n "${SLURM_ACCOUNT:-}" ]]; then
+        sacct_line="$(sacct --account "${SLURM_ACCOUNT}" --brief --noheader 2>/dev/null | awk -v job_id="${job_id}" '$1 == job_id { print $2 "|" $3; exit }' || true)"
+      elif [[ -n "${SPUR_ACCOUNTING_ADDR:-}" ]]; then
+        sacct_line="$(sacct --accounting "${SPUR_ACCOUNTING_ADDR}" --brief --noheader 2>/dev/null | awk -v job_id="${job_id}" '$1 == job_id { print $2 "|" $3; exit }' || true)"
+      else
+        sacct_line="$(sacct -j "${job_id}" -X -n -P -o State,ExitCode 2>/dev/null | awk -F'|' 'NF { print; exit }' || true)"
+      fi
     else
       sacct_line="$(sacct -j "${job_id}" -X -n -P -o State,ExitCode 2>/dev/null | awk -F'|' 'NF { print; exit }' || true)"
     fi
     if [[ -n "${sacct_line}" ]]; then
       state="${sacct_line%%|*}"
+      state="${state%%+*}"
       case "${state}" in
         COMPLETE|COMPLETED|FAILED|CANCELLED|TIMEOUT|OUT_OF_MEMORY|NODE_FAIL|PREEMPTED|BOOT_FAIL|DEADLINE)
           break
           ;;
       esac
     fi
-    if [[ "${attempt}" -lt "${SLURM_SACCT_MAX_ATTEMPTS:-12}" ]]; then
-      sleep "${SLURM_SACCT_RETRY_INTERVAL:-5}"
+
+    if [[ "$(date +%s)" -ge "${deadline}" ]]; then
+      if [[ -z "${sacct_line}" ]]; then
+        echo "ERROR: unable to read final Slurm state for job ${job_id} after ${SLURM_ACCOUNTING_TIMEOUT}s" >&2
+        return 0
+      fi
+      # COMPLETING (and similar) is not a final state on Spur; let callers
+      # fall back to rank-rc / batch-script status instead of treating 0:0 as fail.
+      echo "WARNING: Slurm job ${job_id} still in ${state:-unknown} after ${SLURM_ACCOUNTING_TIMEOUT}s; treating accounting as unavailable" >&2
+      SLURM_STATE="unknown"
+      SLURM_EXIT_CODE="unknown"
+      SLURM_JOB_RC=2
+      return 0
     fi
+    sleep "${SLURM_ACCOUNTING_POLL_INTERVAL}"
   done
-  if [[ -z "${sacct_line}" ]]; then
-    echo "WARNING: no Slurm accounting record found for job ${job_id}" >&2
-    return 0
-  fi
 
   SLURM_STATE="${sacct_line%%|*}"
+  SLURM_STATE="${SLURM_STATE%%+*}"
   SLURM_EXIT_CODE="${sacct_line##*|}"
   exit_status="${SLURM_EXIT_CODE%%:*}"
   exit_signal="${SLURM_EXIT_CODE##*:}"
@@ -383,5 +403,54 @@ read_slurm_exit_code() {
 
   if [[ "${SLURM_STATE}" != COMPLETE && "${SLURM_STATE}" != COMPLETED && "${SLURM_JOB_RC}" -eq 0 ]]; then
     SLURM_JOB_RC=1
+  fi
+}
+
+# Spur runs its batch script once per node. When accounting is unavailable,
+# accept a batch result or a complete set of atomically published rank results.
+read_slurm_status_files() {
+  local status_dir="$1"
+  local num_ranks="$2"
+  local rc_file rc rank
+  local ranks_reported=0 worst_rank_rc=0
+
+  [[ "${SLURM_STATE}" == "unknown" ]] || return 0
+
+  rc_file="${status_dir}/slurm-job.rc"
+  if [[ -s "${rc_file}" ]]; then
+    rc="$(tr -d '[:space:]' < "${rc_file}")"
+    if [[ "${rc}" =~ ^(0|[1-9][0-9]{0,2})$ && "${rc}" -le 255 ]]; then
+      worst_rank_rc="${rc}"
+      echo "Using batch script exit status because Slurm accounting is unavailable."
+    else
+      echo "WARNING: invalid batch script exit status: ${rc}" >&2
+      return 0
+    fi
+  else
+    # Read each expected rank exactly once; ignore .tmp and unrelated files.
+    for ((rank = 0; rank < num_ranks; rank++)); do
+      rc_file="${status_dir}/rank-rc-${rank}"
+      [[ -s "${rc_file}" ]] || continue
+      rc="$(tr -d '[:space:]' < "${rc_file}")"
+      [[ "${rc}" =~ ^(0|[1-9][0-9]{0,2})$ && "${rc}" -le 255 ]] || continue
+      ranks_reported=$((ranks_reported + 1))
+      echo "Slurm rank status: rank-${rank}=${rc}"
+      if [[ "${rc}" -gt "${worst_rank_rc}" ]]; then
+        worst_rank_rc="${rc}"
+      fi
+    done
+    if [[ "${ranks_reported}" -ne "${num_ranks}" || "${num_ranks}" -le 0 ]]; then
+      echo "WARNING: only ${ranks_reported}/${num_ranks} ranks reported an exit status" >&2
+      return 0
+    fi
+    echo "Using per-rank exit status because Slurm accounting is unavailable."
+  fi
+
+  SLURM_JOB_RC="${worst_rank_rc}"
+  SLURM_EXIT_CODE="${worst_rank_rc}:0"
+  if [[ "${worst_rank_rc}" -eq 0 ]]; then
+    SLURM_STATE="COMPLETED"
+  else
+    SLURM_STATE="FAILED"
   fi
 }

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -96,17 +96,16 @@ on:
         default: rocm/atom-dev:latest
         type: string
       atomesh_slurm_submit_runner:
-        description: 'GitHub runner label used to submit Slurm jobs: atomesh-cicd = TW MI355X, atomesh-cicd-mi350 = Spur MI350X, atomesh-cicd-crusoe-mi355/atomesh-cicd-mi355-crusoe = Crusoe MI355X'
+        description: 'GitHub runner label used to submit Slurm jobs: atomesh-cicd = TW MI355X, atomesh-cicd-mi350 = Spur MI350X, atomesh-cicd-mi355-crusoe = Crusoe MI355X'
         required: false
         default: atomesh-cicd
         type: choice
         options:
           - atomesh-cicd
           - atomesh-cicd-mi350
-          - atomesh-cicd-crusoe-mi355
           - atomesh-cicd-mi355-crusoe
       atomesh_slurm_account:
-        description: 'Slurm account: amd-frameworks[42/44/47], amd-tw[36/43]'
+        description: 'TW Slurm account: amd-frameworks[42/44/47], amd-tw[36/43]; Crusoe v2 uses amd-aifw-dev'
         required: false
         default: auto
         type: choice
@@ -115,7 +114,7 @@ on:
           - amd-frameworks
           - amd-tw
       atomesh_slurm_partition:
-        description: 'Slurm partition: amd-frameworks[42/44/47], amd-tw[36/43]'
+        description: 'TW Slurm partition: amd-frameworks[42/44/47], amd-tw[36/43]; Crusoe v2 uses the default partition'
         required: false
         default: auto
         type: choice
@@ -169,15 +168,15 @@ on:
         type: boolean
 
 env:
-  ATOMESH_SLURM_ACCOUNT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_account != 'auto' && inputs.atomesh_slurm_account || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd' && 'amd-frameworks' || '') }}
-  ATOMESH_SLURM_PARTITION: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_partition != 'auto' && inputs.atomesh_slurm_partition || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd' && 'amd-frameworks' || (((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-crusoe-mi355' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && 'amd-spur' || '')) }}
+  ATOMESH_SLURM_ACCOUNT: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe' && 'amd-aifw-dev' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_account != 'auto' && inputs.atomesh_slurm_account || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd' && 'amd-frameworks' || '')) }}
+  ATOMESH_SLURM_PARTITION: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) != 'atomesh-cicd-mi355-crusoe' && (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_partition != 'auto' && inputs.atomesh_slurm_partition || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd' && 'amd-frameworks' || '')) || '' }}
   ATOMESH_SLURM_SUBMIT_RUNNER: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd') }}
   ATOMESH_DASHBOARD_HARDWARE: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'MI350X' || 'MI355X' }}
   ATOMESH_PD_RANK_MAPPING_POLICY: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'idx2idx' || 'none' }}
-  ATOMESH_LOG_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_log_root != '' && inputs.atomesh_log_root || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/${USER}/logs/ATOMESH_LOG/' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe' && '/home/junyyang/ATOMesh_ACTION_RUNNER/ATOMesh_LOG/' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-crusoe-mi355' && '/shared_nfs/ATOMESH_CI/LOG/' || '/it-share/ATOMESH_LOG/') }}
-  ATOMESH_MODEL_ROOT: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/models2' || (((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-crusoe-mi355' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && '/shared_nfs/huggingface_models/amd' || '/mnt/models') }}
-  ATOMESH_1P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes != 'auto' && inputs.atomesh_1p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-5,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-6,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-7,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-8,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16' || (!((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-crusoe-mi355' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && 'mia1-p02-g42,mia1-p02-g44' || '')) }}
-  ATOMESH_2P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes != 'auto' && inputs.atomesh_2p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-5,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-6,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-7,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-8,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16' || (((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-crusoe-mi355' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && '' || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47')) }}
+  ATOMESH_LOG_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_log_root != '' && inputs.atomesh_log_root || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/${USER}/logs/ATOMESH_LOG/' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe' && '/home/junyyang/ATOMesh_ACTION_RUNNER/ATOMesh_LOG/' || '/it-share/ATOMESH_LOG/') }}
+  ATOMESH_MODEL_ROOT: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/models2' || (((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && '/shared_nfs/huggingface_models/amd' || '/mnt/models') }}
+  ATOMESH_1P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes != 'auto' && inputs.atomesh_1p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-5,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-6,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-7,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-8,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16' || (!((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && 'mia1-p02-g42,mia1-p02-g44' || '')) }}
+  ATOMESH_2P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes != 'auto' && inputs.atomesh_2p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-5,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-6,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-7,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-8,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16' || (((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && '' || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47')) }}
 
 concurrency:
   # Keep manual benchmark dispatches independent so different cases on the same branch can run together.
@@ -454,6 +453,7 @@ jobs:
           log_root="${log_root//\$USER/${current_user}}"
           run_dir="${log_root%/}/rdma-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           mkdir -p "${run_dir}"
+          chmod 0777 "${run_dir}"
           export RDMA_SMOKE_RUN_DIR="${run_dir}"
           export RDMA_SMOKE_NODE_COUNT="${node_count}"
           CURRENT_USER="${current_user}"
@@ -464,6 +464,9 @@ jobs:
           SLURM_ERROR="${run_dir}/slurm-%j.err"
           SLURM_CANCEL_HELPER="${run_dir}/slurm-cancel.sh"
           SLURM_LOG_POLL_INTERVAL="${SLURM_LOG_POLL_INTERVAL:-15}"
+          SLURM_ACCOUNT="${ATOMESH_SLURM_ACCOUNT:-}"
+          SLURM_PARTITION="${ATOMESH_SLURM_PARTITION:-}"
+          SLURM_QOS=""
           USES_SPUR_CONTROLLER=0
           SPUR_CONTROLLER_ADDR=""
           SPUR_ACCOUNTING_ADDR=""
@@ -473,8 +476,11 @@ jobs:
             SPUR_ACCOUNTING_ADDR="http://134.199.196.72:6819"
           elif [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
             USES_SPUR_CONTROLLER=1
-            SPUR_CONTROLLER_ADDR="http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817"
-            SPUR_ACCOUNTING_ADDR="http://crs-m2m-cpu-spur-005.crusoe.amd.com:6819"
+            SPUR_CONTROLLER_ADDR="http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6817"
+            SPUR_ACCOUNTING_ADDR="${SPUR_V2_ACCOUNTING_ADDR:-http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6819}"
+            SLURM_ACCOUNT="amd-aifw-dev"
+            SLURM_PARTITION=""
+            SLURM_QOS="amd-aifw-dev-qos"
           fi
           source "${GITHUB_WORKSPACE}/.github/scripts/slurm_submit_helpers.sh"
           install_slurm_cancel_traps
@@ -489,10 +495,15 @@ jobs:
           container="atomesh-rdma-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${job_id}-${rank}-$$"
           rank_host="$(hostname)"
           cleanup() {
-            if docker container inspect "${container}" >/dev/null 2>&1; then
-              docker rm -f "${container}" || {
-                echo "WARNING: failed to remove RDMA smoke container ${container}" >&2
-              }
+            echo "=== Removing RDMA smoke container ${container} ==="
+            # Do not wait on D-state RDMA leftovers: kill/rm with a bound so
+            # the Slurm task can exit instead of sitting in COMPLETING.
+            if command -v timeout >/dev/null 2>&1; then
+              timeout 20 docker kill "${container}" >/dev/null 2>&1 || true
+              timeout 20 docker rm -f "${container}" >/dev/null 2>&1 || true
+            else
+              docker kill "${container}" >/dev/null 2>&1 || true
+              docker rm -f "${container}" >/dev/null 2>&1 || true
             fi
           }
           on_error() {
@@ -507,10 +518,21 @@ jobs:
             echo "ERROR: RDMA smoke rank ${rank} received ${signal} on ${rank_host}" >&2
             exit "${rc}"
           }
+          publish_rank_rc() {
+            local rc="$1"
+            local rc_file
+            [[ -n "${RDMA_SMOKE_RUN_DIR:-}" ]] || return 0
+            rc_file="${RDMA_SMOKE_RUN_DIR}/rank-rc-${rank}"
+            printf '%s\n' "${rc}" > "${rc_file}.tmp" 2>/dev/null || return 0
+            mv "${rc_file}.tmp" "${rc_file}" 2>/dev/null || true
+          }
           on_exit() {
             local rc=$?
             trap - EXIT
             echo "=== RDMA smoke rank exit: rank=${rank} host=${rank_host} pid=$$ job=${job_id} container=${container} rc=${rc} ==="
+            # Publish before cleanup: Slurm accounting is unreliable on Spur, so
+            # the workflow falls back to these per-rank codes.
+            publish_rank_rc "${rc}"
             cleanup
             exit "${rc}"
           }
@@ -526,7 +548,7 @@ jobs:
           docker pull "${RDMA_SMOKE_IMAGE}"
           echo "=== RDMA smoke image pull complete on rank ${rank} ==="
           docker_args=(
-            run --rm -i --name "${container}"
+            run -i --name "${container}"
             --network host --ipc host
             --privileged
             --device=/dev/kfd
@@ -984,6 +1006,15 @@ jobs:
           slurm_status_file="${run_dir}/slurm-job.rc"
           rm -f "${slurm_status_file}" "${slurm_status_file}.tmp"
           batch_script="${run_dir}/rdma-smoke.sbatch.sh"
+          rm -f "${run_dir}"/rank-rc-*
+          if [[ "${USES_SPUR_CONTROLLER}" == "1" ]]; then
+            # Spur launches one script per node; compute nodes have no srun.
+            cat > "${batch_script}" <<EOF
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exec "${rank_script}"
+          EOF
+          else
           cat > "${batch_script}" <<EOF
           #!/usr/bin/env bash
           set -euo pipefail
@@ -996,6 +1027,7 @@ jobs:
           mv "${slurm_status_file}.tmp" "${slurm_status_file}"
           exit "\${srun_rc}"
           EOF
+          fi
           chmod +x "${batch_script}"
 
           sbatch_cmd=(
@@ -1017,13 +1049,13 @@ jobs:
           if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
             sbatch_cmd+=(--controller "${SPUR_CONTROLLER_ADDR}")
           else
-            [[ -z "${ATOMESH_SLURM_ACCOUNT}" ]] || sbatch_cmd+=(--account "${ATOMESH_SLURM_ACCOUNT}")
-            [[ -z "${ATOMESH_SLURM_PARTITION}" ]] || sbatch_cmd+=(--partition "${ATOMESH_SLURM_PARTITION}")
+            [[ -z "${SLURM_ACCOUNT}" ]] || sbatch_cmd+=(--account "${SLURM_ACCOUNT}")
+            [[ -z "${SLURM_PARTITION}" ]] || sbatch_cmd+=(--partition "${SLURM_PARTITION}")
             sbatch_cmd+=(--gres gpu:8)
             if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
               sbatch_cmd+=(
                 --controller "${SPUR_CONTROLLER_ADDR}"
-                -q amd-burst-qos
+                --qos "${SLURM_QOS}"
               )
             fi
           fi
@@ -1048,22 +1080,12 @@ jobs:
           write_slurm_cancel_helper "${JOB_ID}"
           set_slurm_job_log_paths "${JOB_ID}"
           monitor_slurm_job "${JOB_ID}"
+
+          # Spur leaves the job in COMPLETING while RDMA leftovers are reaped,
+          # so give sacct longer than the 30s default to publish a final state.
+          SLURM_ACCOUNTING_TIMEOUT="${SLURM_ACCOUNTING_TIMEOUT:-180}"
           read_slurm_exit_code "${JOB_ID}"
-          if [[ "${SLURM_STATE}" == "unknown" && -s "${slurm_status_file}" ]]; then
-            batch_rc="$(tr -d '[:space:]' < "${slurm_status_file}")"
-            if [[ "${batch_rc}" =~ ^[0-9]+$ ]]; then
-              SLURM_JOB_RC="${batch_rc}"
-              SLURM_EXIT_CODE="${batch_rc}:0"
-              if [[ "${batch_rc}" -eq 0 ]]; then
-                SLURM_STATE="COMPLETED"
-              else
-                SLURM_STATE="FAILED"
-              fi
-              echo "Using batch script exit status because Slurm accounting is unavailable."
-            else
-              echo "WARNING: invalid batch script exit status: ${batch_rc}" >&2
-            fi
-          fi
+          read_slurm_status_files "${run_dir}" "${node_count}"
           SLURM_JOB_ACTIVE=0
           echo "slurm_state=${SLURM_STATE}"
           echo "slurm_exit_code=${SLURM_EXIT_CODE}"
@@ -1117,8 +1139,8 @@ jobs:
 
           squeue_cmd=(squeue)
           scancel_cmd=(scancel)
-          if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-crusoe-mi355" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
-            controller="http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817"
+          if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
+            controller="http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6817"
             squeue_cmd+=(--controller "${controller}")
             scancel_cmd+=(--controller "${controller}")
           fi
@@ -1230,8 +1252,8 @@ jobs:
           SLURM_CANCEL_HELPER="${RESULT_DIR}/${{ matrix.id }}.slurm-cancel.sh"
           SLURM_JOB_NAME="${{ matrix.id }}-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
           SPUR_CONTROLLER_ADDR="${SPUR_CONTROLLER_ADDR:-}"
-          if [[ -z "${SPUR_CONTROLLER_ADDR}" && ( "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-crusoe-mi355" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ) ]]; then
-            SPUR_CONTROLLER_ADDR="http://crs-m2m-cpu-spur-005.crusoe.amd.com:6817"
+          if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
+            SPUR_CONTROLLER_ADDR="http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6817"
           elif [[ -z "${SPUR_CONTROLLER_ADDR}" && "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" ]]; then
             SPUR_CONTROLLER_ADDR="http://134.199.196.72:6817"
           fi
@@ -1239,7 +1261,7 @@ jobs:
           scancel_slurm_by_name_from_wrapper() {
             command -v scancel >/dev/null 2>&1 || return 0
             local -a scancel_cmd=(scancel)
-            if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-crusoe-mi355" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
+            if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi350" || "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" ]]; then
               scancel_cmd+=(--controller "${SPUR_CONTROLLER_ADDR}")
             fi
             scancel_cmd+=(--user "${CURRENT_USER}" --name "${SLURM_JOB_NAME}")

--- a/.github/workflows/atomesh-benchmark.yaml
+++ b/.github/workflows/atomesh-benchmark.yaml
@@ -128,7 +128,7 @@ on:
         default: ''
         type: string
       atomesh_1p1d_nodes:
-        description: 'ATOMesh 1P1D node pair'
+        description: 'TW 1P1D node pair; Crusoe v2 selects from its configured candidate pool'
         required: false
         default: auto
         type: choice
@@ -139,7 +139,7 @@ on:
           - mia1-p02-g44,mia1-p02-g47
           - mia1-p01-g36,mia1-p01-g43
       atomesh_2p1d_nodes:
-        description: 'ATOMesh 2P1D nodes'
+        description: 'TW 2P1D nodes; Crusoe v2 selects from its configured candidate pool'
         required: false
         default: auto
         type: choice
@@ -175,8 +175,8 @@ env:
   ATOMESH_PD_RANK_MAPPING_POLICY: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'idx2idx' || 'none' }}
   ATOMESH_LOG_ROOT: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_log_root != '' && inputs.atomesh_log_root || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/${USER}/logs/ATOMESH_LOG/' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe' && '/home/junyyang/ATOMesh_ACTION_RUNNER/ATOMesh_LOG/' || '/it-share/ATOMESH_LOG/') }}
   ATOMESH_MODEL_ROOT: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && '/data/models2' || (((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && '/shared_nfs/huggingface_models/amd' || '/mnt/models') }}
-  ATOMESH_1P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes != 'auto' && inputs.atomesh_1p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-5,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-6,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-7,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-8,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16' || (!((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && 'mia1-p02-g42,mia1-p02-g44' || '')) }}
-  ATOMESH_2P1D_NODES: ${{ github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes != 'auto' && inputs.atomesh_2p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-5,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-6,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-7,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-8,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16' || (((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe') && '' || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47')) }}
+  ATOMESH_1P1D_NODES: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe' && 'crsuse2-m2m-v2-002,crsuse2-m2m-v2-027,crsuse2-m2m-v2-030,crsuse2-m2m-v2-031,crsuse2-m2m-v2-032,crsuse2-m2m-v2-044' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_1p1d_nodes != 'auto' && inputs.atomesh_1p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-5,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-6,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-7,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-8,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16' || 'mia1-p02-g42,mia1-p02-g44')) }}
+  ATOMESH_2P1D_NODES: ${{ (github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi355-crusoe' && 'crsuse2-m2m-v2-002,crsuse2-m2m-v2-027,crsuse2-m2m-v2-030,crsuse2-m2m-v2-031,crsuse2-m2m-v2-032,crsuse2-m2m-v2-044' || (github.event_name == 'workflow_dispatch' && inputs.atomesh_2p1d_nodes != 'auto' && inputs.atomesh_2p1d_nodes || ((github.event_name == 'workflow_dispatch' && inputs.atomesh_slurm_submit_runner || (github.event_name == 'schedule' && github.event.schedule == '10 16 * * *' && 'atomesh-cicd-mi350' || 'atomesh-cicd')) == 'atomesh-cicd-mi350' && 'ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-5,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-6,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-7,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-8,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-13,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-14,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-15,ml-ai-ubuntu-gpu-mi350x8-2304gb-fabric-16' || 'mia1-p02-g42,mia1-p02-g44,mia1-p02-g47')) }}
 
 concurrency:
   # Keep manual benchmark dispatches independent so different cases on the same branch can run together.
@@ -439,6 +439,10 @@ jobs:
           if [[ -n "${nodes}" ]]; then
             IFS=',' read -r -a node_list <<< "${nodes}"
             node_count="${#node_list[@]}"
+            if [[ "${SLURM_SUBMIT_RUNNER}" == "atomesh-cicd-mi355-crusoe" && "${node_count}" -gt 2 ]]; then
+              # Request two nodes from the candidate pool for cross-node smoke.
+              node_count=2
+            fi
           else
             # Allocate two nodes by default so both local and cross-node GDR are validated.
             node_count=2

--- a/tests/test_slurm_submit_helpers.py
+++ b/tests/test_slurm_submit_helpers.py
@@ -4,11 +4,10 @@
 """CPU-only Slurm result tests; also runnable directly with Python."""
 
 import os
-from pathlib import Path
 import subprocess
 import tempfile
 import unittest
-
+from pathlib import Path
 
 HELPERS = (
     Path(__file__).resolve().parents[1] / ".github/scripts/slurm_submit_helpers.sh"
@@ -39,6 +38,7 @@ class SlurmResultsTest(unittest.TestCase):
                 **env,
             },
             capture_output=True,
+            check=False,
             text=True,
             timeout=10,
         )
@@ -141,7 +141,7 @@ read_slurm_exit_code 5147
                     (status_dir / name).write_text(value + "\n")
                 self.assertEqual(
                     self.run_shell(
-                        'sacct() { return 1; }\nread_slurm_exit_code 5147\n'
+                        "sacct() { return 1; }\nread_slurm_exit_code 5147\n"
                         'read_slurm_status_files "$STATUS_DIR" 2',
                         STATUS_DIR=str(status_dir),
                     ),

--- a/tests/test_slurm_submit_helpers.py
+++ b/tests/test_slurm_submit_helpers.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""CPU-only Slurm result tests; also runnable directly with Python."""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+HELPERS = (
+    Path(__file__).resolve().parents[1] / ".github/scripts/slurm_submit_helpers.sh"
+)
+
+
+class SlurmResultsTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+
+    def run_shell(self, body, **env):
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'set -euo pipefail\nsource "$HELPERS"\n'
+                + body
+                + '\nprintf "RESULT=%s|%s|%s\\n" '
+                '"$SLURM_STATE" "$SLURM_EXIT_CODE" "$SLURM_JOB_RC"',
+            ],
+            env={
+                "PATH": os.environ["PATH"],
+                "HELPERS": str(HELPERS),
+                "TEST_DIR": str(self.root),
+                "SLURM_ACCOUNTING_TIMEOUT": "0",
+                **env,
+            },
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        return result.stdout.split("RESULT=")[-1].strip()
+
+    def test_accounting_interfaces(self):
+        cases = [
+            (
+                {"USES_SPUR_CONTROLLER": "1", "SLURM_ACCOUNT": "amd-aifw-dev"},
+                "--account amd-aifw-dev --brief --noheader",
+                "999 FAILED 1:0\n5147 COMPLETED 0:0",
+            ),
+            (
+                {"USES_SPUR_CONTROLLER": "1", "SPUR_ACCOUNTING_ADDR": "http://test"},
+                "--accounting http://test --brief --noheader",
+                "5147 COMPLETE 0:0",
+            ),
+            (
+                {"USES_SPUR_CONTROLLER": "1"},
+                "-j 5147 -X -n -P -o State,ExitCode",
+                "COMPLETED|0:0",
+            ),
+            (
+                {"USES_SPUR_CONTROLLER": "0", "SLURM_ACCOUNT": "amd-frameworks"},
+                "-j 5147 -X -n -P -o State,ExitCode",
+                "COMPLETED|0:0",
+            ),
+        ]
+        for env, expected_args, reply in cases:
+            with self.subTest(env=env):
+                result = self.run_shell(
+                    'sacct() { printf "%s" "$*" > "$TEST_DIR/args"; '
+                    'printf "%s\\n" "$REPLY"; }\nread_slurm_exit_code 5147',
+                    REPLY=reply,
+                    **env,
+                )
+                self.assertIn(result, ("COMPLETED|0:0|0", "COMPLETE|0:0|0"))
+                self.assertEqual((self.root / "args").read_text(), expected_args)
+
+    def test_terminal_and_unavailable_states(self):
+        cases = {
+            "COMPLETED+|0:0": "COMPLETED|0:0|0",
+            "FAILED|7:0": "FAILED|7:0|7",
+            "FAILED|0:0": "FAILED|0:0|1",
+            "CANCELLED|0:15": "CANCELLED|0:15|143",
+            "COMPLETING|0:0": "unknown|unknown|2",
+            "RUNNING|0:0": "unknown|unknown|2",
+            "": "unknown|unknown|2",
+        }
+        for reply, expected in cases.items():
+            with self.subTest(reply=reply):
+                self.assertEqual(
+                    self.run_shell(
+                        'sacct() { printf "%s\\n" "$REPLY"; }\n'
+                        "read_slurm_exit_code 5147",
+                        REPLY=reply,
+                    ),
+                    expected,
+                )
+
+    def test_delayed_accounting(self):
+        result = self.run_shell(
+            """
+sacct() {
+  if [[ -f "$TEST_DIR/queried" ]]; then
+    echo 'COMPLETED|0:0'
+  else
+    touch "$TEST_DIR/queried"
+    echo 'COMPLETING|0:0'
+  fi
+}
+read_slurm_exit_code 5147
+""",
+            SLURM_ACCOUNTING_TIMEOUT="5",
+            SLURM_ACCOUNTING_POLL_INTERVAL="0",
+        )
+        self.assertEqual(result, "COMPLETED|0:0|0")
+
+    def test_status_file_fallback(self):
+        cases = [
+            ({"rank-rc-0": "0", "rank-rc-1": "0"}, "COMPLETED|0:0|0"),
+            ({"rank-rc-0": "0", "rank-rc-1": "7"}, "FAILED|7:0|7"),
+            ({"rank-rc-0": "0", "rank-rc-1.tmp": "0"}, "unknown|unknown|2"),
+            ({"rank-rc-0": "0", "rank-rc-2": "0"}, "unknown|unknown|2"),
+            ({"rank-rc-0": "0", "rank-rc-1": "bad"}, "unknown|unknown|2"),
+            ({"rank-rc-0": "0", "rank-rc-1": "256"}, "unknown|unknown|2"),
+            ({"slurm-job.rc": "0"}, "COMPLETED|0:0|0"),
+            (
+                {"slurm-job.rc": "9", "rank-rc-0": "0", "rank-rc-1": "0"},
+                "FAILED|9:0|9",
+            ),
+            ({"slurm-job.rc": "bad"}, "unknown|unknown|2"),
+        ]
+        for index, (files, expected) in enumerate(cases):
+            with self.subTest(files=files):
+                status_dir = self.root / str(index)
+                status_dir.mkdir()
+                for name, value in files.items():
+                    (status_dir / name).write_text(value + "\n")
+                self.assertEqual(
+                    self.run_shell(
+                        'sacct() { return 1; }\nread_slurm_exit_code 5147\n'
+                        'read_slurm_status_files "$STATUS_DIR" 2',
+                        STATUS_DIR=str(status_dir),
+                    ),
+                    expected,
+                )
+
+    def test_accounting_failure_is_not_overridden_by_files(self):
+        (self.root / "slurm-job.rc").write_text("0\n")
+        self.assertEqual(
+            self.run_shell(
+                "sacct() { echo 'FAILED|42:0'; }\nread_slurm_exit_code 5147\n"
+                'read_slurm_status_files "$TEST_DIR" 2'
+            ),
+            "FAILED|42:0|42",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
ATOMesh's Crusoe runner still submits to the legacy Spur controller and can request an incompatible account/partition. This change aligns `atomesh-cicd-mi355-crusoe` with the existing Crusoe v2 plugin CI configuration and restricts scheduling to the intended candidate nodes.

- Use controller `http://crs-m2m-cpu-spur-v2-001.crusoe.amd.com:6817`, account `amd-aifw-dev`, QoS `amd-aifw-dev-qos`, and omit `--partition`. Keep `SPUR_V2_ACCOUNTING_ADDR` as the accounting endpoint override. Apply the same controller to benchmark submission, RDMA smoke, and cancellation paths.
- Mount `/shared_nfs` read-only into benchmark containers when present, so Crusoe model paths are visible to the server.
- Remove the duplicate `atomesh-cicd-crusoe-mi355` runner label.
- Preserve the full candidate pool in the benchmark matrix: `crsuse2-m2m-v2-002`, `027`, `030`, `031`, `032`, and `044`. Each case's topology determines `--nodes` and `--ntasks`. The separate RDMA smoke job requests at most two nodes from the pool.
- Prefer account-based Spur accounting queries, retry delayed final states, and fall back to published batch or complete per-rank exit codes. Ignore temporary and unrelated rank files, and preserve terminal failures reported by accounting.
- Publish results before container cleanup, bound Docker cleanup commands with timeouts, and launch smoke ranks directly on Spur while retaining `srun` for traditional Slurm.

Validation:
- Five CPU-only Slurm result regression tests pass (`python3 tests/test_slurm_submit_helpers.py`).
- Shell syntax checks, workflow YAML parsing, and `git diff --check` pass.
- Mock submissions match the plugin CI's Crusoe v2 parameters, including accounting overrides and cancellation controller selection.
- All 36 nightly matrix cells retain the six-node pool and request 1, 2, or 3 nodes according to topology. Mock one-node, two-node, and smoke submissions verify the resulting arguments.
- Mock smoke launches verify exit codes 0, 7, and 143, result publication, cleanup calls, and Spur versus traditional Slurm launch behavior.

No live GPU benchmark was submitted as part of this validation.

