### PR TITLE
fix(dspark): find the stage count when --model names a hub repo

### DIFF
--- a/atom/models/deepseek_v4_dspark.py
+++ b/atom/models/deepseek_v4_dspark.py
@@ -239,23 +239,39 @@ def _linear_out(output):
     return output[0] if isinstance(output, tuple) else output
 
 
+def _ckpt_index_path(model_path: str) -> str:
+    """Locate the shard index of a checkpoint named by directory or hub repo.
+
+    ``--model`` accepts either, and the hub form is not hypothetical: CI passes
+    the bare repo id on any runner without a local model mirror mounted. Only
+    the index is wanted here, so fetch that one file, never the shards.
+    """
+    import os
+
+    if os.path.isdir(model_path):
+        return os.path.join(model_path, "model.safetensors.index.json")
+    from huggingface_hub import hf_hub_download
+
+    return hf_hub_download(model_path, "model.safetensors.index.json")
+
+
 def _count_dspark_stages(model_path, default: int = 0) -> int:
     """Count distinct ``mtp.{i}.*`` stages in the checkpoint index.
 
     DSpark stores its backbone as ``mtp.0 .. mtp.{N-1}`` in the V4 checkpoint
     (N=3 for V4-Pro-DSpark). We must build exactly N stages or the last stage's
     Markov/confidence-head weights get dropped at load. The HF config's
-    ``num_nextn_predict_layers`` is unrelated (it is 1, a serial-MTP field).
+    ``num_nextn_predict_layers`` is unrelated (it is 1, a serial-MTP field),
+    and neither is ``dspark_target_layer_ids``, whose length counts the target
+    hidden states stage 0 concatenates, not the stages downstream of it.
     """
     import json
-    import os
     import re
 
     if not model_path:
         return default
-    idx_path = os.path.join(model_path, "model.safetensors.index.json")
     try:
-        with open(idx_path) as f:
+        with open(_ckpt_index_path(model_path)) as f:
             weight_map = json.load(f)["weight_map"]
     except Exception:  # noqa: BLE001 -- a probe: any unreadable index means "no"
         return default
@@ -1056,7 +1072,9 @@ class DeepseekV4DSpark(DSparkDraftModel):
         )
         if self.num_stages <= 0:
             raise ValueError(
-                "Could not determine DSpark stage count from the checkpoint; "
+                "Could not determine DSpark stage count from the checkpoint at "
+                f"{getattr(config, 'model', None)!r} (no readable "
+                "model.safetensors.index.json holding mtp.{i}.* weights); "
                 "set dspark_num_layers in the config."
             )
 

--- a/tests/test_dspark.py
+++ b/tests/test_dspark.py
@@ -173,6 +173,33 @@ def test_speculative_config_mtp_not_misrouted_to_dspark():
     assert hf.architectures == ["DeepseekV4MTPModel"]
 
 
+def test_the_stage_count_still_comes_off_a_checkpoint_directory(tmp_path):
+    import json
+
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {f"mtp.{i}.attn.wo.weight": "s" for i in (0, 1, 2)}})
+    )
+    from atom.models.deepseek_v4_dspark import _count_dspark_stages
+
+    assert _count_dspark_stages(str(tmp_path), default=0) == 3
+
+
+def test_an_unreachable_checkpoint_falls_back_instead_of_raising(tmp_path, monkeypatch):
+    """The probe stays a probe: nothing on disk, nothing cached, no exception."""
+    from huggingface_hub import constants
+
+    from atom.models.deepseek_v4_dspark import _count_dspark_stages
+
+    # Patched on the module, not in the environment: the env var is read once
+    # at import, so setting it here would leave the probe reading whatever real
+    # cache this machine has and reaching the hub for what it misses.
+    monkeypatch.setattr(constants, "HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setattr(constants, "HF_HUB_OFFLINE", True)
+
+    assert _count_dspark_stages("atom-test/nothing-cached-here", default=7) == 7
+    assert _count_dspark_stages(None, default=7) == 7
+
+
 def test_block_sparse_attention_is_bidirectional_within_block():
     # The block is decoded in one parallel pass, so every draft query position
     # sees every draft KV column, including ones after itself.


### PR DESCRIPTION
The V4 DSpark drafter counts its backbone stages by reading `mtp.{i}.*` out
of the checkpoint's shard index, and looked for that index by joining the
`--model` string with a filename. That only works when `--model` is a
directory. Given a hub repo id it opened a relative path that resolves to
nothing under the server's cwd, fell back to `dspark_num_layers` -- a key the
published DSpark configs do not carry -- and killed the server at drafter
build with "Could not determine DSpark stage count".

Which is not a hypothetical launch: the accuracy workflow passes `--model
/models/<repo>` only when a local model mirror is mounted, and hands over the
bare repo id when it is not. V4-Pro DSpark therefore passes or crashes purely
on which runner it lands on, and it crashed on main in
https://github.com/ROCm/ATOM/actions/runs/34463106880.

Resolve the index through the hub cache when the name is not a directory,
fetching that one file rather than the shards. Weight loading already went
down the hub path either way; only the probe ahead of it did not.

