### PR TITLE
feat: enable BF16 mHC computation and fix tracing copies

### DIFF
--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -3874,9 +3874,29 @@ class Block(nn.Module):
         self.enable_fused_hc = (
             hasattr(aiter, "mhc_fused_post_pre") and self.layer_id != 0
         )
+        self.enable_hc_fn_pack_bf16 = (
+            hasattr(aiter, "mhc_pre_convert_fn") if _dim_ok else False
+        )
 
     # mHC `hc_post_mult_value`: V4 uses `2.0 * sigmoid(post)` for the post gate.
     HC_POST_MULT = 2.0
+
+    def process_weights_after_loading(self):
+        """Pack the fp32 mHC fn weights into int32 (bf16 hi<<16 | lo) in place.
+
+        The bf16 mHC kernels then bit-extract hi/lo instead of recomputing the
+        fp32->bf16 split per token (passed with is_fn_pack_bf16=1). fn are constant
+        weights, so this runs once here (after the checkpoint is loaded and the
+        module is on-device). No-op unless enable_hc_fn_pack_bf16.
+        """
+        if not self.enable_hc_fn_pack_bf16:
+            return
+        for name in ("hc_attn_fn", "hc_ffn_fn"):
+            fn = getattr(self, name).data
+            packed = torch.empty(fn.shape, dtype=torch.int32, device=fn.device)
+            # mhc_pre_convert_fn requires contiguous fp32 in.
+            aiter.mhc_pre_convert_fn(packed, fn.contiguous().float())
+            setattr(self, name, atom_parameter(packed))
 
     def hc_pre(
         self,
@@ -3902,6 +3922,10 @@ class Block(nn.Module):
         if self._mhc_pre is not None:
             # aiter mhc_pre wants [M, hc, dim] and returns
             # (post [M, hc, 1], comb [M, hc, hc], y [M, dim]).
+            # hc_fn is pre-packed int32 (bf16 hi/lo) when enable_hc_fn_pack_bf16 -> pass
+            # is_fn_pack_bf16=1. Only add the kwarg when enabled so the fp32 path stays
+            # identical to the pre-bf16 call.
+            pack_kw = {"is_fn_pack_bf16": 1} if self.enable_hc_fn_pack_bf16 else {}
             post, comb, y = self._mhc_pre(
                 residual,
                 hc_fn,
@@ -3914,6 +3938,7 @@ class Block(nn.Module):
                 int(self.hc_sinkhorn_iters),
                 norm_weight,
                 norm_eps,
+                **pack_kw,
             )
             return y, post.squeeze(-1), comb
 
@@ -3984,6 +4009,7 @@ class Block(nn.Module):
         norm_eps: float = 1e-6,
         prefix: str = "",
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        pack_kw = {"is_fn_pack_bf16": 1} if self.enable_hc_fn_pack_bf16 else {}
         return self._mhc_fused_post_pre(
             x,
             residual,
@@ -3999,6 +4025,7 @@ class Block(nn.Module):
             int(self.hc_sinkhorn_iters),
             norm_weight,
             norm_eps,
+            **pack_kw,
         )
 
     @mark_trace

--- a/atom/models/deepseek_v4.py
+++ b/atom/models/deepseek_v4.py
@@ -3848,7 +3848,8 @@ class Block(nn.Module):
         self.hc_eps = args.hc_eps
         mix_hc = (2 + hc_mult) * hc_mult
         hc_dim = hc_mult * args.dim
-        # All HC params stored in fp32 (matches reference's `set_dtype(torch.float32)`).
+        # Load HC params in FP32. BF16 mode replaces fn storage after loading;
+        # base and scale remain FP32.
         self.hc_attn_fn = atom_parameter(
             torch.empty(mix_hc, hc_dim, dtype=torch.float32)
         )
@@ -3871,32 +3872,33 @@ class Block(nn.Module):
         self._mhc_fused_post_pre = (
             getattr(aiter, "mhc_fused_post_pre", None) if _dim_ok else None
         )
-        self.enable_fused_hc = (
-            hasattr(aiter, "mhc_fused_post_pre") and self.layer_id != 0
-        )
         self.enable_hc_fn_pack_bf16 = (
-            hasattr(aiter, "mhc_pre_convert_fn") if _dim_ok else False
+            envs.ATOM_MHC_USE_BF16
+            and self._mhc_pre is not None
+            and hasattr(aiter, "mhc_shuffle_fn")
+        )
+        self.enable_fused_hc = (
+            self._mhc_fused_post_pre is not None and self.layer_id != 0
         )
 
     # mHC `hc_post_mult_value`: V4 uses `2.0 * sigmoid(post)` for the post gate.
     HC_POST_MULT = 2.0
 
     def process_weights_after_loading(self):
-        """Pack the fp32 mHC fn weights into int32 (bf16 hi<<16 | lo) in place.
+        """Pack constant mHC fn weights into AITER's BF16 hi/lo block layout.
 
-        The bf16 mHC kernels then bit-extract hi/lo instead of recomputing the
-        fp32->bf16 split per token (passed with is_fn_pack_bf16=1). fn are constant
-        weights, so this runs once here (after the checkpoint is loaded and the
-        module is on-device). No-op unless enable_hc_fn_pack_bf16.
+        AITER selects the block size for the runtime GPU architecture. Pack once
+        after loading, then use w_preshuffle_bf16=1 without shuffling residuals.
+        No-op unless enable_hc_fn_pack_bf16.
         """
         if not self.enable_hc_fn_pack_bf16:
             return
         for name in ("hc_attn_fn", "hc_ffn_fn"):
-            fn = getattr(self, name).data
-            packed = torch.empty(fn.shape, dtype=torch.int32, device=fn.device)
-            # mhc_pre_convert_fn requires contiguous fp32 in.
-            aiter.mhc_pre_convert_fn(packed, fn.contiguous().float())
-            setattr(self, name, atom_parameter(packed))
+            fn = getattr(self, name)
+            if fn.dtype == torch.int32:
+                continue
+            # Replace storage on the existing Parameter: retain no FP32 copy.
+            fn.data = aiter.mhc_shuffle_fn(fn.data.contiguous().float())
 
     def hc_pre(
         self,
@@ -3922,10 +3924,10 @@ class Block(nn.Module):
         if self._mhc_pre is not None:
             # aiter mhc_pre wants [M, hc, dim] and returns
             # (post [M, hc, 1], comb [M, hc, hc], y [M, dim]).
-            # hc_fn is pre-packed int32 (bf16 hi/lo) when enable_hc_fn_pack_bf16 -> pass
-            # is_fn_pack_bf16=1. Only add the kwarg when enabled so the fp32 path stays
-            # identical to the pre-bf16 call.
-            pack_kw = {"is_fn_pack_bf16": 1} if self.enable_hc_fn_pack_bf16 else {}
+            # The standalone pre kernel uses ordinary residual layout even with
+            # w_preshuffle_bf16=1; only fn is packed into BF16 hi/lo.
+            # Omit the flag when packing is unavailable to preserve the FP32 path.
+            pack_kw = {"w_preshuffle_bf16": 1} if self.enable_hc_fn_pack_bf16 else {}
             post, comb, y = self._mhc_pre(
                 residual,
                 hc_fn,
@@ -4009,7 +4011,12 @@ class Block(nn.Module):
         norm_eps: float = 1e-6,
         prefix: str = "",
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        pack_kw = {"is_fn_pack_bf16": 1} if self.enable_hc_fn_pack_bf16 else {}
+        # BF16 weight packing is independent of the residual layout.
+        pack_kw = (
+            {"w_preshuffle_bf16": True, "res_preshuffle": False}
+            if self.enable_hc_fn_pack_bf16
+            else {}
+        )
         return self._mhc_fused_post_pre(
             x,
             residual,
@@ -4077,6 +4084,8 @@ class Block(nn.Module):
                 norm_eps,
                 prefix=f"{self.prefix}.mhc_fused_post_pre",
             )
+            # Match hc_pre's [tokens, hc] state for subsequent post/pre calls.
+            post = post.squeeze(-1)
         else:
             x, post, comb, res = self.mhc_post_pre(
                 x,
@@ -4177,7 +4186,14 @@ class ParallelHead(ParallelLMHead):
         via Sigmoid-gated weighted sum (vs Block.hc_pre's Sinkhorn variant).
         """
         _, _, y = aiter.mhc_pre(
-            x, hc_fn, hc_scale, hc_base, self.norm_eps, self.hc_eps, sinkhorn_repeat=0
+            x,
+            hc_fn,
+            hc_scale,
+            hc_base,
+            self.norm_eps,
+            self.hc_eps,
+            sinkhorn_repeat=0,
+            **({"w_preshuffle_bf16": 1} if hc_fn.dtype == torch.int32 else {}),
         )
         return y
 
@@ -4380,6 +4396,19 @@ class DeepseekV4Model(nn.Module):
         )
         self.hc_head_base = atom_parameter(torch.empty(hc_mult, dtype=torch.float32))
         self.hc_head_scale = atom_parameter(torch.empty(1, dtype=torch.float32))
+
+    def process_weights_after_loading(self):
+        """Pack the head's constant fn using AITER's architecture-specific layout."""
+        if (
+            not envs.ATOM_MHC_USE_BF16
+            or not hasattr(aiter, "mhc_shuffle_fn")
+            or self.hc_head_fn.dtype == torch.int32
+        ):
+            return
+        # Replace storage instead of keeping a second packed Parameter.
+        self.hc_head_fn.data = aiter.mhc_shuffle_fn(
+            self.hc_head_fn.data.contiguous().float()
+        )
 
     def forward(
         self,

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -101,6 +101,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # gather, i.e. the untouched upstream baseline.
     "ATOM_MORI_V2_FUSED": lambda: os.getenv("ATOM_MORI_V2_FUSED", "0") == "1",
     "ATOM_MLA_PAGE_SIZE": lambda: int(os.getenv("ATOM_MLA_PAGE_SIZE", "1")),
+    # Pack mHC fn weights once after loading and use BF16 hi/lo computation.
+    # Set to 0 before model loading to retain FP32 fn and FP32 mHC computation.
+    "ATOM_MHC_USE_BF16": lambda: os.getenv("ATOM_MHC_USE_BF16", "1") == "1",
     # --- Kernel Fusion Toggles ---
     # fused_compress_attn: switch between Triton (default historical) and a
     # flydsl drop-in for V4-Pro Compressor (Main BF16 + Indexer FP8) paths.

--- a/atom/utils/graph_marker.py
+++ b/atom/utils/graph_marker.py
@@ -1,14 +1,9 @@
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2024-2025, Advanced Micro Devices, Inc.
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc.
 #
-# A tiny, graph-friendly marker op for debugging/graph inspection.
-# It is an identity at runtime, but it shows up in FX/graph dumps.
-
-# from __future__ import annotations
+# A graph marker for profiling compiled code without copying activations.
 
 import torch
-
-from aiter.jit.utils.torch_guard import torch_compile_guard
 
 _GRAPH_MARKER_ENABLED: bool = False
 
@@ -23,26 +18,27 @@ def is_graph_marker_enabled() -> bool:
     return _GRAPH_MARKER_ENABLED
 
 
-def _graph_marker_impl(x: torch.Tensor) -> torch.Tensor:
-    # Runtime behavior: identity.
-    # Keep this side-effect free to avoid graph breaks.
-    return x
+@torch.library.custom_op("aiter::graph_marker", mutates_args=("x",))
+def _graph_marker(x: torch.Tensor, name: str) -> None:
+    # An in-place barrier keeps the marker ordered with operations on x and
+    # prevents dead-code elimination. It does not actually change any data.
+    # Return nothing: returning x from a custom op would introduce an output
+    # alias that functionalization cannot represent with this schema.
+    pass
 
 
-def _graph_marker_fake(x: torch.Tensor, name: str) -> torch.Tensor:
-    # FakeTensor / meta behavior: identity with preserved shape/stride/dtype.
-    return x
+@_graph_marker.register_fake
+def _graph_marker_fake(x: torch.Tensor, name: str) -> None:
+    pass
 
 
-@torch_compile_guard(gen_fake=_graph_marker_fake)
 def graph_marker(x: torch.Tensor, name: str) -> torch.Tensor:
-    """Insert a no-op marker node into the compiled/traced graph.
+    """Mark a tensor's position in the graph, preserving its identity and layout.
 
-    The marker `name` is embedded as a constant in the graph dump so you can
-    grep it in `computation_graph.py` / generated wrapper files.
+    The compiler sees an in-place barrier with no aliased output. Returning the
+    original tensor here keeps its existing views and lets Inductor reuse its
+    storage, instead of cloning an opaque custom op's returned alias.
     """
-    # When disabled, return early so the marker does not even appear in the
-    # traced/compiled graph.
-    if not _GRAPH_MARKER_ENABLED:
-        return x
-    return _graph_marker_impl(x)
+    if _GRAPH_MARKER_ENABLED:
+        _graph_marker(x, name)
+    return x

--- a/atom/utils/graph_marker_instrumentation.py
+++ b/atom/utils/graph_marker_instrumentation.py
@@ -342,13 +342,20 @@ def _strip_runtime_graph_markers(lines: list[str]) -> bool:
     """
     Remove runtime overhead of graph markers in generated wrapper code.
 
-    - Replace `x = torch.ops.aiter.graph_marker.default(y, '...')` with `x = y`
+    - Remove standalone, void graph marker calls.
+    - Replace legacy `x = torch.ops.aiter.graph_marker.default(y, '...')` with `x = y`
     - Drop assert_size_stride / assert_alignment lines that specifically refer to
       `torch.ops.aiter.graph_marker.default` (they become redundant).
     """
     out: list[str] = []
     changed = False
     for line in lines:
+        if _parse_graph_marker_call_expr(line.strip()) is not None:
+            # Preserve a valid suite even when a marker is its only statement.
+            indent = line[: len(line) - len(line.lstrip())]
+            out.append(f"{indent}pass  # graph marker\n")
+            changed = True
+            continue
         parsed = _parse_graph_marker_assignment_line(line)
         if parsed is not None:
             out.append(f"{parsed.indent}{parsed.lhs} = {parsed.arg}\n")

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -69,6 +69,7 @@ no wall-clock skew). See `atom/model_engine/prefill_delayer.py`. Active only whe
 |----------|------|---------|-------------|
 | **ATOM_USE_TRITON_GEMM** | bool | 0 (false) | If set to `1`, use AITER Triton FP4 weight preshuffled GEMM. Otherwise use AITER ASM FP4 weight preshuffled GEMM. |
 | **ATOM_USE_FP4_NON_SHUFFLE_TRITON_GEMM** | bool | 0 (false) | If set to `1`, use AITER Triton FP4 GEMM with non-shuffled weights. Takes precedence over the FP4 preshuffled GEMM path selected by `ATOM_USE_TRITON_GEMM`. |
+| **ATOM_MHC_USE_BF16** | bool | 1 (true) | Use AITER BF16 hi/lo mHC computation for attention, FFN and head. After loading, replace FP32 fn storage with `mhc_shuffle_fn` output; no FP32 copy is retained. Set to `0` for FP32 mHC. Takes effect at model load; restart to change modes. Residual shuffle remains disabled. |
 | **ATOM_USE_TRITON_MXFP4_BMM** | bool | 0 (false) | If set to `1`, use FP4 BMM in MLA attention module. |
 
 ### GLM-5.3

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -13,6 +13,7 @@ _ATOM_ENV_VARS = [
     "ATOM_DP_BASE_PORT",
     "ATOM_USE_TRITON_GEMM",
     "ATOM_USE_TRITON_MXFP4_BMM",
+    "ATOM_MHC_USE_BF16",
     "ATOM_ENABLE_QK_NORM_ROPE_CACHE_QUANT_FUSION",
     "ATOM_ENABLE_DS_INPUT_RMSNORM_QUANT_FUSION",
     "ATOM_ENABLE_DS_QKNORM_QUANT_FUSION",
@@ -67,6 +68,9 @@ class TestEnvsDefaults:
     def test_dp_base_port_default(self):
         assert _get_envs().ATOM_DP_BASE_PORT == 0
 
+    def test_mhc_use_bf16_default(self):
+        assert _get_envs().ATOM_MHC_USE_BF16 is True
+
     def test_use_triton_gemm_default(self):
         assert _get_envs().ATOM_USE_TRITON_GEMM is False
 
@@ -107,6 +111,11 @@ class TestEnvsDefaults:
 
 class TestEnvsOverrides:
     """Test that env vars are read dynamically (lazy evaluation)."""
+
+    @pytest.mark.parametrize("value, expected", [("0", False), ("1", True)])
+    def test_mhc_use_bf16_override(self, monkeypatch, value, expected):
+        monkeypatch.setenv("ATOM_MHC_USE_BF16", value)
+        assert _get_envs().ATOM_MHC_USE_BF16 is expected
 
     def test_dp_rank_override(self, monkeypatch):
         monkeypatch.setenv("ATOM_DP_RANK", "3")

--- a/tests/test_graph_marker.py
+++ b/tests/test_graph_marker.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+"""Graph markers must preserve aliases without adding activation copies."""
+
+import runpy
+import warnings
+
+import pytest
+import torch
+from torch._inductor.utils import run_and_get_code
+
+from atom.utils.graph_marker import (
+    graph_marker,
+    is_graph_marker_enabled,
+    set_graph_marker_enabled,
+)
+from atom.utils.graph_marker_instrumentation import instrument_record_functions_in_file
+
+
+@torch.library.custom_op("atom_test::marker_consumer", mutates_args=())
+def _consume(x: torch.Tensor) -> torch.Tensor:
+    return x * 2
+
+
+@_consume.register_fake
+def _consume_fake(x: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(x)
+
+
+@pytest.fixture(autouse=True)
+def restore_marker_setting():
+    previous = is_graph_marker_enabled()
+    set_graph_marker_enabled(True)
+    yield
+    set_graph_marker_enabled(previous)
+    torch._dynamo.reset()
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_marker_preserves_identity_and_views(enabled):
+    set_graph_marker_enabled(enabled)
+    base = torch.arange(32.0)
+    x = base[1::2]
+    y = graph_marker(x, "view_start")
+    assert y is x
+    y.add_(1)
+    torch.testing.assert_close(base[1::2], torch.arange(1.0, 32, 2) + 1)
+
+
+@pytest.mark.parametrize("strided", [False, True])
+def test_compiled_marker_has_no_copy_and_retains_profile_ranges(tmp_path, strided):
+    def fn(x):
+        x = graph_marker(x, "mhc_start")
+        y = _consume(x)
+        return graph_marker(y, "mhc_end")
+
+    x = torch.arange(32.0)
+    if strided:
+        x = x[1::2]
+    before = x.clone()
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=".*may not alias.*")
+        out, codes = run_and_get_code(torch.compile(fn, fullgraph=True), x)
+    torch.testing.assert_close(out, before * 2)
+    torch.testing.assert_close(x, before)
+    code = "\n".join(codes)
+    # Only the two marker barriers and the consumer should be emitted. Any
+    # compiled pointwise kernel here is an unnecessary clone/copy/layout fixup.
+    assert "async_compile.cpp" not in code
+    assert "async_compile.triton" not in code
+    assert "torch.ops.aiter.graph_marker.default(" in code
+    assert "mhc_start" in code and "mhc_end" in code
+
+    wrapper = tmp_path / "compiled.py"
+    wrapper.write_text(code)
+    assert instrument_record_functions_in_file(str(wrapper))
+    instrumented = wrapper.read_text()
+    assert 'with record_function("mhc"):' in instrumented
+    assert "torch.ops.aiter.graph_marker.default(" not in instrumented
+    compile(instrumented, str(wrapper), "exec")
+    assert not instrument_record_functions_in_file(str(wrapper))
+
+
+@pytest.mark.parametrize("strided", [False, True])
+def test_compiled_marker_preserves_inplace_aliases(strided):
+    def fn(x):
+        y = x[1::2] if strided else x
+        y = graph_marker(y, "mutation_start")
+        y.add_(1)
+        return x, y
+
+    x = torch.arange(32.0)
+    reference_input = x.clone()
+    expected = fn(reference_input)
+    actual = torch.compile(fn, fullgraph=True)(x)
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(x, reference_input)
+    assert (
+        actual[0].untyped_storage().data_ptr() == actual[1].untyped_storage().data_ptr()
+    )
+
+
+def test_instrumentation_accepts_legacy_marker_assignments(tmp_path):
+    wrapper = tmp_path / "legacy.py"
+    wrapper.write_text(
+        "def call(x):\n"
+        "    y = torch.ops.aiter.graph_marker.default(x, 'mhc_start')\n"
+        "    z = y * 2\n"
+        "    out = torch.ops.aiter.graph_marker.default(z, 'mhc_end')\n"
+        "    return out\n"
+    )
+    assert instrument_record_functions_in_file(str(wrapper))
+    code = wrapper.read_text()
+    assert "y = x" in code and "out = z" in code
+    namespace = runpy.run_path(str(wrapper))
+    assert namespace["call"](3) == 6


### PR DESCRIPTION
Superseded by https://github.com/ROCm/ATOM/pull/2195 so this change is submitted directly from `jun/mhc_bf16`. The replacement contains the same complete BF16 mHC implementation and compiler-copy fix.

Enable configurable BF16 mHC computation throughout DeepSeek V4 using AITER's packed fn API, and fix the extra compiler-generated activation copies observed after attention when tracing is enabled.

`ATOM_MHC_USE_BF16` defaults to `1`. At model load, attention, FFN, and head fn weights are packed once with `aiter.mhc_shuffle_fn`; the existing Parameter's storage is replaced, so no second FP32 fn copy is retained. Setting the variable to `0` before loading selects FP32 fn weights and computation. Packing follows AITER's runtime architecture support without an ATOM gfx1250-only restriction. ATOM uses ordinary residual layout (`res_preshuffle=False`), and post-mix tensors are normalized to the same shape across pre/fused paths. The environment variable and load-time behavior are documented and tested.

For tracing, replace the tensor-returning marker with a void in-place ordering barrier and return the original tensor from the Python wrapper. The old custom op declared a fresh output but actually returned its input, causing functionalization to clone the alias and copy it back to the graph input. This removes the observed `as_strided_clone_copy` kernel while preserving tensor identity, views, and profiler ranges. Instrumentation handles the new standalone marker calls and legacy assignment-style wrappers.

Validation:
- Environment-variable tests: **39 passed**; graph-marker regressions: **7 passed**. Marker coverage includes zero generated copies, profiler ranges, strided views, in-place alias semantics, and legacy wrappers.
- GPU checks passed with `ATOM_MHC_USE_BF16=0/1` for pre, fused post/pre, and head, including a single fn Parameter/storage and repeated weight-processing calls.
- gfx1250 / PyTorch 2.11.0+ROCm integration: M=65/1024/16384, H=7168, FP32/BF16, plain residuals. Outputs match eager bitwise; inputs are unchanged; generated code and GPU traces have no extra copy kernels; profiler ranges and CUDA graph replay with updated inputs pass.
- Earlier full DeepSeek-V4-Flash GSM8K run with BF16 mHC: **1,255/1,319 strict match (95.1478%)**, 3-shot, temperature 0, max generation 2048. That end-to-end result was collected before the latest rebase and marker fix; the current-code checks are listed above.

AITER BF16 kernels, fn packing, and read-only mHC schemas: https://github.com/ROCm/aiter/pull/5408
