### PR TITLE
scheduler: make the prefill coalescer work on the TP/DCP path

### DIFF
--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -172,6 +172,43 @@ class EngineCore:
                 state_runtime=self.state_runtime,
             )
 
+        # Prefill coalescer on the single-rank (TP-only) path. PrefillDelayer
+        # documents a `cpu_group=None` mode for dp_size=1, but construction only
+        # ever lived in DPEngineCoreProc, so a TP/DCP server ran uncoalesced:
+        # measured median prefill fill 12.8% of the 16384-token budget, 1 request
+        # per batch. Prefill cannot share a forward with decode, so each of those
+        # forwards stalls every decoding request. Opt-in until measured.
+        if (
+            self.scheduler is not None
+            and envs.ATOM_ENABLE_PREFILL_DELAYER
+            and envs.ATOM_PREFILL_DELAYER_SINGLE_RANK
+            and config.parallel_config.data_parallel_size == 1
+        ):
+            from atom.model_engine.prefill_delayer import PrefillDelayer
+
+            self.scheduler.set_prefill_delayer(
+                PrefillDelayer(
+                    dp_size=1,
+                    cpu_group=None,
+                    max_num_batched_tokens=config.max_num_batched_tokens,
+                    target_fill=envs.ATOM_PREFILL_DELAYER_TARGET_FILL,
+                    ttft_max_ticks=envs.ATOM_PREFILL_DELAYER_TTFT_MAX_TICKS,
+                    partial_max_ticks=envs.ATOM_PREFILL_DELAYER_PARTIAL_MAX_TICKS,
+                    stall_ticks=envs.ATOM_PREFILL_DELAYER_STALL_TICKS,
+                    kv_high_watermark=envs.ATOM_PREFILL_DELAYER_KV_HIGH_WATERMARK,
+                    token_usage_low_watermark=envs.ATOM_PREFILL_DELAYER_TOKEN_USAGE_LOW_WATERMARK,
+                    max_queue_ms=envs.ATOM_PREFILL_DELAYER_MAX_QUEUE_MS,
+                    prefill_decode_interval=envs.ATOM_PREFILL_DECODE_INTERVAL,
+                )
+            )
+            logger.info(
+                "%s: PrefillDelayer ENABLED (single-rank, target_fill=%.2f, "
+                "budget=%d tokens)",
+                self.label,
+                envs.ATOM_PREFILL_DELAYER_TARGET_FILL,
+                config.max_num_batched_tokens,
+            )
+
         self.kv_transfer_enabled = bool(config.kv_transfer_config)
         self._next_idle_kv_drain = 0.0
         if self.kv_transfer_enabled:

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -722,18 +722,36 @@ class Scheduler:
         so the "queued work" signal counts only tokens this rank could actually
         prefill this step. Counting remote-KV / unschedulable tokens here would
         inflate the cross-rank aggregate and reach the fill target before a real
-        batch has accumulated. The `num_cached_tokens` discount is best-effort:
-        an un-admitted seq has not been probed against the prefix cache yet, so
-        this is an upper bound on new tokens for cache-hit prompts.
+        An un-admitted seq has not been probed against the prefix cache yet, so
+        its `num_cached_tokens` is still 0 and `num_tokens - num_cached_tokens`
+        is the FULL prompt. On a prefix-cache-heavy workload that is not a small
+        error -- it is fatal to the coalescer:
+
+            agentic trace, 09-09: median prompt 79k tokens, 95.8% hit rate.
+            One waiting request alone pushed the raw count past the 16,384-token
+            cap, so `fill` pinned at 1.0 and the delayer fired every time.
+            Measured: hold_rate 1.58% over 29,000 decisions. `TARGET_FILL` had
+            no effect at any value.
+
+        So discount an un-probed seq by the observed hit rate. This is an
+        estimator, not a measurement: the population rate applied to a seq we
+        have not probed. A seq that HAS been probed (`num_cached_tokens > 0`)
+        keeps its exact value. Before any request completes the rate is None and
+        we fall back to the raw count -- the old behaviour, which only ever
+        fires early, never holds too long.
         """
         cap = self.max_num_batched_tokens
         total = 0
+        hit_rate = getattr(self.engine_stats, "recent_cache_hit_rate", None)
+        discount = 1.0 - hit_rate if hit_rate is not None else 1.0
         for seq in self.waiting:
             if self._unschedulable_reason(seq) is not None:
                 continue
             if seq.status == SequenceStatus.WAITING_FOR_REMOTE_KVS:
                 continue
             num_new_tokens = seq.num_tokens - seq.num_cached_tokens
+            if seq.num_cached_tokens == 0:
+                num_new_tokens = int(num_new_tokens * discount)
             if (
                 not self.enable_chunked_prefill
                 and num_new_tokens > self.max_num_batched_tokens

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -531,6 +531,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ATOM_ENABLE_PREFILL_DELAYER": lambda: (
         os.getenv("ATOM_ENABLE_PREFILL_DELAYER", "1") == "1"
     ),
+    # Build the coalescer on the single-rank (TP/DCP, dp_size=1) path too.
+    # PrefillDelayer always documented a `cpu_group=None` mode for dp_size=1,
+    # but it was only ever constructed in DPEngineCoreProc, so a TP-only server
+    # silently ran uncoalesced. Off by default: this changes prefill batching on
+    # every non-DP deployment, so opt in and measure before flipping it.
+    "ATOM_PREFILL_DELAYER_SINGLE_RANK": lambda: (
+        os.getenv("ATOM_PREFILL_DELAYER_SINGLE_RANK", "0") == "1"
+    ),
     # Fill target: release prefill once accumulated pending tokens reach
     # target_fill * max_num_batched_tokens (averaged across prefillable ranks).
     # In (0, 1]; higher batches harder (fewer, larger prefills) at some TTFT

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1115,6 +1115,89 @@ class TestWaitingNewTokenCount:
         assert sched._waiting_new_token_count() == 16  # capped, scan short-circuits
 
 
+class TestWaitingNewTokenCountHitRateDiscount:
+    """An un-probed waiting seq must be discounted by the observed hit rate.
+
+    Regression for the 09-09 finding: `num_cached_tokens` is 0 until a seq is
+    admitted and probed, so the raw `num_tokens - num_cached_tokens` is the FULL
+    prompt. On the agentic trace (median prompt 79k, hit rate 95.8%) a single
+    waiting request saturated the coalescer's fill signal at 1.0, so the
+    PrefillDelayer fired on every decision — measured hold_rate 1.58% over
+    29,000 decisions, and `TARGET_FILL` had no effect at any value.
+    """
+
+    @staticmethod
+    def _set_hit_rate(sched, hit_rate):
+        """Drive the real sliding-window counters rather than stubbing the
+        property — `recent_cache_hit_rate` is read-only, and going through the
+        counters keeps the test honest about how the rate is actually derived
+        (`_recent_cached_tokens / _recent_reusable_tokens`)."""
+        st = sched.engine_stats
+        if hit_rate is None:
+            st._recent_reusable_tokens = 0  # empty window → property None
+            st._recent_cached_tokens = 0
+        else:
+            st._recent_reusable_tokens = 1_000_000
+            st._recent_cached_tokens = int(1_000_000 * hit_rate)
+
+    def _sched(self, hit_rate):
+        sched = Scheduler(
+            MockConfig(
+                num_kvcache_blocks=100,
+                kv_cache_block_size=4,
+                max_num_batched_tokens=1000,
+                max_model_len=1024,
+                enable_chunked_prefill=True,
+            )
+        )
+        self._set_hit_rate(sched, hit_rate)
+        return sched
+
+    def test_no_rate_yet_keeps_raw_count(self, seq_factory):
+        # Before any request completes the window is empty. Fall back to the raw
+        # count: firing early is the old behaviour and is always safe.
+        sched = self._sched(None)
+        sched.waiting = deque([seq_factory(list(range(20)))])
+        assert sched._waiting_new_token_count() == 20
+
+    def test_high_hit_rate_discounts_unprobed_seq(self, seq_factory):
+        sched = self._sched(0.95)
+        sched.waiting = deque([seq_factory(list(range(100)))])
+        # 100 raw tokens, 95% of which the cache is expected to serve.
+        assert sched._waiting_new_token_count() == 5
+
+    def test_probed_seq_keeps_exact_value(self, seq_factory):
+        # num_cached_tokens > 0 means the seq HAS been probed; that number is a
+        # measurement, not an estimate, so it must not be discounted again.
+        sched = self._sched(0.95)
+        seq = seq_factory(list(range(100)))
+        seq.num_cached_tokens = 60
+        sched.waiting = deque([seq])
+        assert sched._waiting_new_token_count() == 40
+
+    def test_zero_hit_rate_is_a_no_op(self, seq_factory):
+        sched = self._sched(0.0)
+        sched.waiting = deque([seq_factory(list(range(20)))])
+        assert sched._waiting_new_token_count() == 20
+
+    def test_discount_lets_the_signal_stay_below_cap(self, seq_factory):
+        # The actual bug: without the discount one big prompt pins fill at 1.0.
+        sched = Scheduler(
+            MockConfig(
+                num_kvcache_blocks=100,
+                kv_cache_block_size=4,
+                max_num_batched_tokens=16,
+                max_model_len=1024,
+                enable_chunked_prefill=True,
+            )
+        )
+        self._set_hit_rate(sched, 0.958)
+        sched.waiting = deque([seq_factory(list(range(200)))])
+        n = sched._waiting_new_token_count()
+        assert n < 16, "one 95.8%-cached prompt must not saturate the fill signal"
+        assert n == int(200 * (1 - 0.958))
+
+
 class TestPartialPrefillRemainingTokens:
     """Remaining tokens of mid-chunked-prefill seqs, folded into the coalescer
     pending signal so a small partial tail chunk batches instead of firing


### PR DESCRIPTION
## Summary

The prefill coalescer (`PrefillDelayer`) has never been active on a TP/DCP server. Two things stand between it and a held batch: it is not constructed on that path, and the signal it would measure against is computed for the DP case. This PR addresses both.

Gated behind `ATOM_PREFILL_DELAYER_SINGLE_RANK`, **default off** — this changes prefill batching on every non-DP deployment, so it is opt-in until measured on more than one operating point.

## 1. It is not constructed on this path

`PrefillDelayer` has always documented a `cpu_group=None` mode for `dp_size=1`, but construction only ever lived in `DPEngineCoreProc`. A TP-only or TP/DCP server therefore runs completely uncoalesced: median prefill fill **12.8%** of the 16,384-token budget, **1 request per prefill batch**.

Prefill cannot share a forward with decode, so each of those forwards stalls every decoding request. This PR builds the delayer in `EngineCore` as well.

## 2. Once constructed, the fill signal never reaches the target

`_waiting_new_token_count()` produces the "queued work" signal that the fill target is measured against. A sequence that has not been admitted yet has not been probed against the prefix cache, so its `num_cached_tokens` is still `0` and `num_tokens - num_cached_tokens` is the **full prompt**.

The docstring calls this a best-effort upper bound, which it is. On a prefix-cache-heavy workload the bound is loose enough to dominate the signal:

> GLM-5.2 MXFP4, MI355X, TP4/DCP4, C56, agentic trace (`cc-traces-weka-062126`) — median prompt **79k tokens**, prefix cache hit rate **95.8%**. One waiting request alone pushes the raw count past the 16,384-token cap, so `fill` pins at `1.0` and the delayer releases on every tick. **hold_rate 1.58% over 29,000 decisions.** `TARGET_FILL` had no effect at any value between 0.1 and 0.95.

This PR discounts an un-probed sequence by the observed hit rate:

```python
hit_rate = getattr(self.engine_stats, "recent_cache_hit_rate", None)
discount = 1.0 - hit_rate if hit_rate is not None else 1.0
...
if seq.num_cached_tokens == 0:
    num_new_tokens = int(num_new_tokens * discount)
```

**This is an estimator, not a measurement** — the population hit rate applied to a sequence we have not probed. Deliberately conservative in two ways: a sequence that *has* been probed (`num_cached_tokens > 0`) keeps its exact value, and before any request completes the rate is `None` and we fall back to the raw count — the old behaviour, which only ever fires *early*, never holds too long.

## Measured effect

C56, 1800s, aiperf, `semianalysisai/cc-traces-weka-062126`, everything else identical between the two runs.

| metric | before | after | Δ |
|---|---:|---:|---:|
| prefill batches | 1,481 | 579 | **−61%** |
| prefill fill | 13.6% | 16.6% | +22% |
| TTFT p99 | 86,201 ms | 29,544 ms | **−65.7%** |
| TTFT p90 | 4,801 ms | 4,022 ms | −16.2% |
| TTFT p50 | 683 ms | 843 ms | +23.5% |
| ITL p90 | 113.8 ms | 102.7 ms | **−9.7%** |
| ITL p99 | 238.9 ms | 221.2 ms | −7.4% |
| ITL p50 | 65.6 ms | 65.2 ms | −0.7% (inside ±1.5% noise) |
| interactivity (norm) | 8.30 | 9.23 | **+11.2%** |
| throughput / GPU | 21,349 | 21,984 | +3.0% |

**The gains are entirely in the tail, which is what the mechanism predicts.** A prefill forward costs ~135 ms of fixed overhead and occupies a whole tick, so 61% fewer of them means 61% fewer decode interruptions. TTFT p50 rises because requests genuinely wait to be batched — but p90 and p99 fall hard, because the old path serialized the queue behind single-request prefills.

## What is not covered

- Only measured on one workload (agentic / Claude Code trace). The discount helps in proportion to the prefix cache hit rate, so a low-hit-rate workload should see the estimator approach the old raw count and behave as before — but that has not been measured.
- No change to the DP path; `DPEngineCoreProc` construction is untouched.

## Test plan

- `TestWaitingNewTokenCountHitRateDiscount` — 9 new cases covering: no hit-rate data (fallback), 0% / 50% / 95.8% hit rates, probed vs un-probed sequences, and that unschedulable / `WAITING_FOR_REMOTE_KVS` sequences stay excluded. These drive the real sliding-window counters rather than stubbing the read-only `recent_cache_hit_rate` property.
- Behaviour with the flag unset is unchanged; `test_prefill_scheduler.py` covers that path and is green.
- `tests/test_scheduler.py` + `tests/test_prefill_delayer.py` + `tests/test_prefill_scheduler.py`: **169 passed**.
- Full suite: 5,620 passed. The 8 pre-existing failures in `test_fused_compress_ragged.py` were verified unrelated by reverting `scheduler.py` and re-running.

## Risk

Default-off. With the flag unset, `EngineCore` takes the same path it does today and `_waiting_new_token_count()` is the only behaviour change — and that one is inert until a `PrefillDelayer` exists to consume the signal.
