### PR TITLE
feat(v4): enable asm sparse prefill on gfx1250

### DIFF
--- a/atom/model_ops/v4_kernels/paged_prefill.py
+++ b/atom/model_ops/v4_kernels/paged_prefill.py
@@ -62,8 +62,20 @@ except ImportError:
     pa_sparse_prefill_opus = None
     _HAS_OPUS = False
 
+try:
+    from aiter.ops.mla_sparse_prefill import mla_sparse_prefill_fp8_asm
+
+    _HAS_PREFILL_ASM = True
+except ImportError:
+    mla_sparse_prefill_fp8_asm = None
+    _HAS_PREFILL_ASM = False
+
 from aiter.jit.utils.chip_info import get_gfx
 from aiter.ops.triton.attention.pa_prefill_sparse import pa_prefill_sparse
+
+# Local head count the aiter asm fp8 prefill kernel ships for; anything else
+# raises there rather than dispatching, so we filter on it up front.
+_PREFILL_ASM_HEADS = 128
 
 # Fixed best-known Triton meta for DeepSeek-V4 TP=8 / local H=8 prefill.
 _BLOCK_H = 16
@@ -638,7 +650,20 @@ def sparse_attn_v4_paged_prefill(
         # and extend K fed directly. No dequant of the prefix, no torch quant.
         from aiter.ops.pa_sparse_prefill_opus import pa_sparse_prefill_fp8_opus
 
-        return pa_sparse_prefill_fp8_opus(
+        # aiter's asm kernel is signature-compatible with the OPUS one, so the
+        # argument list below is shared. It is gfx1250-only and hard-requires
+        # H == 128 (one workgroup serves one query token x all heads), which a
+        # TP shard below 128 local heads cannot satisfy -- those keep OPUS.
+        fp8_prefill = pa_sparse_prefill_fp8_opus
+        if (
+            _HAS_PREFILL_ASM
+            and not envs.ATOM_FORCE_V4_PREFILL_OPUS
+            and get_gfx() == "gfx1250"
+            and q_packed.shape[1] == _PREFILL_ASM_HEADS
+        ):
+            fp8_prefill = mla_sparse_prefill_fp8_asm
+
+        return fp8_prefill(
             q_packed,
             q_rope,
             unified_kv,

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -343,6 +343,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Force Triton attention fallbacks where available. Set to 1 to bypass
     # optional ASM/OPUS fast paths during debugging.
     "ATOM_FORCE_ATTN_TRITON": lambda: (os.getenv("ATOM_FORCE_ATTN_TRITON", "0") == "1"),
+    # Force the OPUS kernel for DeepSeek-V4 fp8 sparse prefill instead of the
+    # aiter asm kernel (`mla_sparse_prefill_fp8_asm`, the default). Escape hatch
+    # for the asm path; that kernel is gfx1250-only and hard-requires H == 128,
+    # so smaller local head counts fall back to OPUS regardless of this flag.
+    "ATOM_FORCE_V4_PREFILL_OPUS": lambda: (
+        os.getenv("ATOM_FORCE_V4_PREFILL_OPUS", "0") == "1"
+    ),
     # Use gluon pa decode for some models
     "ATOM_USE_GLUON_PA_DECODE": lambda: (
         os.getenv("ATOM_USE_GLUON_PA_DECODE", "0") == "1"


### PR DESCRIPTION
## Summary
- dispatch the aiter FP8 sparse prefill ASM kernel on gfx1250 when the local head count is 128
- keep OPUS as the fallback for unsupported configurations
- add `ATOM_FORCE_V4_PREFILL_OPUS` as an escape hatch

## Validation
- `git diff --check`
- `python -m compileall -q atom/model_ops/v4_kernels/paged_prefill.py atom/utils/envs.py`