### PR TITLE
fix(offload): bound Dense/M3 saves with safe retirement

### DIFF
--- a/atom/config.py
+++ b/atom/config.py
@@ -1589,6 +1589,9 @@ class Config:
     stop_token_ids: list[int] = field(default_factory=list)
     kv_cache_block_size: int = 16
     num_kvcache_blocks: int = -1
+    # Largest per-rank PAGE entry, communicated by the model runner. Save
+    # admission uses this geometry without importing a model-specific codec.
+    kv_cache_block_bytes: int = 0
     kv_cache_dtype: str = "bf16"
     index_cache_dtype: str | None = None
     enable_prefix_caching: bool = True

--- a/atom/entrypoints/openai/metrics.py
+++ b/atom/entrypoints/openai/metrics.py
@@ -367,13 +367,50 @@ class _AtomMetricsCollector:
             ),
             (
                 "atom:lmcache_save_requests",
-                "Number of completed LMCache save operations.",
+                (
+                    "Number of normally completed LMCache store calls; does not "
+                    "prove all candidate tokens were persisted."
+                ),
                 offload.get("save_requests", 0),
             ),
             (
                 "atom:lmcache_saved_tokens",
-                "Number of tokens saved to LMCache.",
+                (
+                    "Number of candidate tokens in normally completed LMCache "
+                    "store calls; not actual persisted tokens."
+                ),
                 offload.get("saved_tokens", 0),
+            ),
+            (
+                "atom:lmcache_save_ops_admitted",
+                "Number of LMCache save operations admitted by the scheduler.",
+                offload.get("save_ops_admitted", 0),
+            ),
+            (
+                "atom:lmcache_save_tokens_admitted",
+                (
+                    "Number of candidate tokens admitted for LMCache save; "
+                    "not actual persisted tokens."
+                ),
+                offload.get("save_tokens_admitted", 0),
+            ),
+            (
+                "atom:lmcache_save_ops_dropped",
+                "Number of LMCache save candidates dropped before submission.",
+                offload.get("save_ops_dropped", 0),
+            ),
+            (
+                "atom:lmcache_save_tokens_dropped",
+                "Number of candidate LMCache save tokens dropped before submission.",
+                offload.get("save_tokens_dropped", 0),
+            ),
+            (
+                "atom:lmcache_save_cancel_requests",
+                (
+                    "Number of LMCache save cancellation requests; does not "
+                    "indicate cancellation completion or source safety."
+                ),
+                offload.get("save_cancel_requests", 0),
             ),
         ):
             metric = CounterMetricFamily(name, documentation)
@@ -388,8 +425,45 @@ class _AtomMetricsCollector:
             ),
             (
                 "atom:lmcache_saves_pending",
-                "Number of LMCache saves currently in flight.",
+                (
+                    "Number of LMCache save operations awaiting terminal completion "
+                    "or cleanup; may include operations whose source is already safe."
+                ),
                 offload.get("saves_pending", 0),
+            ),
+            (
+                "atom:lmcache_save_ops_unretired",
+                "Number of admitted LMCache save operations not yet retired.",
+                offload.get("save_ops_unretired", 0),
+            ),
+            (
+                "atom:lmcache_save_pending_bytes",
+                "Candidate bytes reserved by admitted LMCache saves not yet retired.",
+                offload.get("save_pending_bytes", 0),
+            ),
+            (
+                "atom:lmcache_source_blocks_reserved",
+                (
+                    "Source block reservations for admitted saves not yet source-safe, "
+                    "including active requests; not deduplicated physical blocks."
+                ),
+                offload.get("source_blocks_reserved", 0),
+            ),
+            (
+                "atom:lmcache_source_blocks_leased",
+                (
+                    "Source block lease references retained after requests finish; "
+                    "not deduplicated physical blocks."
+                ),
+                offload.get("source_blocks_leased", 0),
+            ),
+            (
+                "atom:lmcache_save_oldest_age_seconds",
+                (
+                    "Age in seconds of the oldest admitted, unretired LMCache save "
+                    "across scheduler ranks; zero when none is outstanding."
+                ),
+                offload.get("save_oldest_age_ms", 0) / 1000,
             ),
         ):
             metric = GaugeMetricFamily(name, documentation)

--- a/atom/kv_transfer/disaggregation/aggregator.py
+++ b/atom/kv_transfer/disaggregation/aggregator.py
@@ -17,6 +17,7 @@ This module provides:
 from __future__ import annotations
 
 import logging
+from bisect import bisect_left, bisect_right
 from collections import deque
 from collections.abc import Callable, Hashable, Iterable
 from typing import Generic, TypeVar
@@ -30,6 +31,7 @@ from atom.kv_transfer.disaggregation.types import (
     ReqId,
     SaveCompletionId,
     SaveOperationId,
+    SaveSourceGroupId,
 )
 
 logger = logging.getLogger("atom")
@@ -37,6 +39,38 @@ logger = logging.getLogger("atom")
 __all__ = ["KVOutputAggregator"]
 
 _KeyT = TypeVar("_KeyT", bound=Hashable)
+
+# Keep this transport module independent of the offload connector import tree.
+_DENSE_PAGE_SOURCE_SAFE_CHANNEL = "dense.page.source_safe"
+_DENSE_PAGE_RETIRED_CHANNEL = "dense.page.retired"
+
+
+class _RetiredDenseGenerations:
+    """Compact terminal generations while preserving out-of-order holes.
+
+    Dense save generations are unique across one scheduler lifetime. A single
+    maximum would wrongly suppress an older operation still running on another
+    rank. Contiguous retired generations instead collapse to one interval.
+    """
+
+    def __init__(self) -> None:
+        self._intervals: list[tuple[int, int]] = []
+
+    def contains(self, generation: int) -> bool:
+        index = bisect_right(self._intervals, (generation, float("inf"))) - 1
+        return index >= 0 and self._intervals[index][1] >= generation
+
+    def add(self, generation: int) -> None:
+        if self.contains(generation):
+            return
+        index = bisect_left(self._intervals, (generation, generation))
+        start = end = generation
+        if index and self._intervals[index - 1][1] + 1 == generation:
+            index -= 1
+            start = self._intervals.pop(index)[0]
+        if index < len(self._intervals) and self._intervals[index][0] == end + 1:
+            end = self._intervals.pop(index)[1]
+        self._intervals.insert(index, (start, end))
 
 
 class _TPCompletionGroup(Generic[_KeyT]):
@@ -97,6 +131,12 @@ class _TPCompletionGroup(Generic[_KeyT]):
         self._reports.clear()
         self._tombstone_order.clear()
         self._tombstones.clear()
+
+    def discard_matching(self, predicate: Callable[[_KeyT], bool]) -> None:
+        """Forget incomplete reports covered by a stronger terminal fence."""
+        for key in list(self._reports):
+            if predicate(key):
+                del self._reports[key]
 
     @property
     def pending_count(self) -> int:
@@ -160,6 +200,7 @@ class KVOutputAggregator:
             terminal_tombstone_limit,
             lambda _key: True,
         )
+        self._retired_dense_generations = _RetiredDenseGenerations()
 
     @property
     def world_size(self) -> int:
@@ -211,6 +252,8 @@ class KVOutputAggregator:
                 succeeded=False,
             )
             for completion in output.connector_completions:
+                if self._is_retired_dense_report(completion):
+                    continue
                 self._connector_completions.report(
                     worker_idx,
                     completion.key,
@@ -222,6 +265,22 @@ class KVOutputAggregator:
         done_saving, _ = self._saving.drain()
         done_loading, failed_loading = self._loading.drain()
         done_connector_keys, failed_connector_keys = self._connector_completions.drain()
+        retired = {
+            key[1]
+            for key in done_connector_keys
+            if key[0] == _DENSE_PAGE_RETIRED_CHANNEL
+            and isinstance(key[1], SaveOperationId)
+        }
+        if retired:
+            for operation in retired:
+                self._retired_dense_generations.add(operation.generation)
+            # A never-started rank cannot emit the other ranks' chunk groups.
+            # All-rank operation retirement supersedes those missing quorums.
+            self._connector_completions.discard_matching(
+                lambda key: key[0] == _DENSE_PAGE_SOURCE_SAFE_CHANNEL
+                and isinstance(key[1], SaveSourceGroupId)
+                and key[1].save_operation in retired
+            )
         connector_completions = {
             ConnectorCompletion(
                 channel=key[0],
@@ -245,6 +304,22 @@ class KVOutputAggregator:
             connector_completions=connector_completions,
         )
 
+    def _is_retired_dense_report(self, completion: ConnectorCompletion) -> bool:
+        identity = completion.operation_id
+        if completion.channel == _DENSE_PAGE_SOURCE_SAFE_CHANNEL and isinstance(
+            identity, SaveSourceGroupId
+        ):
+            operation = identity.save_operation
+        elif completion.channel == _DENSE_PAGE_RETIRED_CHANNEL and isinstance(
+            identity, SaveOperationId
+        ):
+            operation = identity
+        else:
+            # In particular, a store outcome may legitimately follow a source
+            # retirement. Do not discard it or affect any other connector.
+            return False
+        return self._retired_dense_generations.contains(operation.generation)
+
     def reset(self) -> None:
         """Clear all internal tracking state."""
         self._sending.reset()
@@ -252,6 +327,7 @@ class KVOutputAggregator:
         self._saving.reset()
         self._loading.reset()
         self._connector_completions.reset()
+        self._retired_dense_generations = _RetiredDenseGenerations()
 
     @property
     def terminal_tombstone_count(self) -> tuple[int, int]:

--- a/atom/kv_transfer/disaggregation/multi/multi_connector.py
+++ b/atom/kv_transfer/disaggregation/multi/multi_connector.py
@@ -735,6 +735,13 @@ class MultiConnectorScheduler(KVConnectorSchedulerBase):
                 releases.extend(callback(timeout_s))
         return releases
 
+    @property
+    def requires_save_retirement(self) -> bool:
+        return any(
+            getattr(connector, "requires_save_retirement", False)
+            for connector in self._connectors
+        )
+
     def record_early_release(self, count: int) -> None:
         for connector in self._connectors:
             callback = getattr(connector, "record_early_release", None)

--- a/atom/kv_transfer/disaggregation/pp_kv_aggregator.py
+++ b/atom/kv_transfer/disaggregation/pp_kv_aggregator.py
@@ -10,11 +10,18 @@ whole request, but only once every stage has reached a terminal state.
 
 from __future__ import annotations
 
+from atom.kv_transfer.disaggregation.aggregator import (
+    _DENSE_PAGE_RETIRED_CHANNEL,
+    _DENSE_PAGE_SOURCE_SAFE_CHANNEL,
+    _RetiredDenseGenerations,
+)
 from atom.kv_transfer.disaggregation.types import (
     ConnectorCompletion,
     ConnectorCompletionKey,
     KVConnectorOutput,
     ReqId,
+    SaveOperationId,
+    SaveSourceGroupId,
 )
 
 
@@ -52,6 +59,7 @@ class PPKVAggregator:
         # per generation and PP quorum is just stage coverage.
         self._connector: dict[ConnectorCompletionKey, set[int]] = {}
         self._connector_failed: set[ConnectorCompletionKey] = set()
+        self._retired_dense_generations = _RetiredDenseGenerations()
 
     def ingest(self, pp_rank: int, output: KVConnectorOutput) -> KVConnectorOutput:
         for rid in output.finished_loading:
@@ -61,6 +69,8 @@ class PPKVAggregator:
         for rid in output.finished_saving:
             self._saving.setdefault(rid, set()).add(pp_rank)
         for completion in output.connector_completions:
+            if self._is_retired_dense_report(completion):
+                continue
             self._connector.setdefault(completion.key, set()).add(pp_rank)
             if not completion.succeeded:
                 self._connector_failed.add(completion.key)
@@ -107,6 +117,28 @@ class PPKVAggregator:
             self._connector.pop(key, None)
             self._connector_failed.discard(key)
 
+        retired = {
+            completion.operation_id
+            for completion in connector_completions
+            if completion.channel == _DENSE_PAGE_RETIRED_CHANNEL
+            and completion.succeeded
+            and isinstance(completion.operation_id, SaveOperationId)
+        }
+        if retired:
+            for operation in retired:
+                self._retired_dense_generations.add(operation.generation)
+            # A never-started stage cannot emit the other stages' source
+            # groups. Only successful all-stage retirement supersedes their
+            # missing quorums; store outcomes remain independently pending.
+            for key in list(self._connector):
+                if (
+                    key[0] == _DENSE_PAGE_SOURCE_SAFE_CHANNEL
+                    and isinstance(key[1], SaveSourceGroupId)
+                    and key[1].save_operation in retired
+                ):
+                    del self._connector[key]
+                    self._connector_failed.discard(key)
+
         return KVConnectorOutput(
             finished_loading=done_loading,
             failed_loading=failed,
@@ -114,11 +146,28 @@ class PPKVAggregator:
             connector_completions=connector_completions,
         )
 
+    def _is_retired_dense_report(self, completion: ConnectorCompletion) -> bool:
+        identity = completion.operation_id
+        if completion.channel == _DENSE_PAGE_SOURCE_SAFE_CHANNEL and isinstance(
+            identity, SaveSourceGroupId
+        ):
+            operation = identity.save_operation
+        elif completion.channel == _DENSE_PAGE_RETIRED_CHANNEL and isinstance(
+            identity, SaveOperationId
+        ):
+            operation = identity
+        else:
+            # Store outcomes may follow source retirement. Other connector
+            # channels also retain their independent completion semantics.
+            return False
+        return self._retired_dense_generations.contains(operation.generation)
+
     def has_pending(self) -> bool:
         """True while any request is still short of its per-stage quorum.
 
         The head's busy loop keeps polling downstream stages while this holds;
-        the tallies only drain when the missing stages report in.
+        the tallies drain when the missing stages report in or an all-stage
+        safe retirement supersedes incomplete dense source-group reports.
         """
         return bool(
             self._loading or self._saving or self._failed_loading or self._connector
@@ -130,3 +179,4 @@ class PPKVAggregator:
         self._failed_loading.clear()
         self._connector.clear()
         self._connector_failed.clear()
+        self._retired_dense_generations = _RetiredDenseGenerations()

--- a/atom/kv_transfer/offload/README.md
+++ b/atom/kv_transfer/offload/README.md
@@ -469,6 +469,23 @@ a requested SLOT boundary is reported failed and is never committed. Standalone
 `ATOM_PD_STAGING_POOL`. Other connectors and composite topologies keep their
 existing staging behavior; this change does not adapt them to LMCache offload.
 
+Dense/M3 PAGE saves also reserve scheduler credits before dispatch: an operation
+credit, its candidate bytes, and every unsafe source block (including blocks of
+live requests). The worker queue enforces the same operation limit and physically
+removes cancelled queued tasks. A full budget drops that range and disables new
+save ranges for that request lifecycle. At request finish, a final tail is dropped
+when an earlier save is still outstanding; unsubmitted ranges never acquire a
+source lease. Loads use their independent executor.
+
+PAGE source safety and store outcome are separate. Per-group TP/PP source-safe
+reports release source credits incrementally. All-rank `dense.page.retired`
+proves no future source reads and releases any remaining source references;
+operation/byte credits remain until both retirement and store outcome arrive.
+Store exceptions fence the staging streams before reporting retirement. A timeout
+only requests cancellation; a running or unfenced operation retains its references.
+Normally returned store calls can have skipped ranges in LMCache, so the existing
+`saved_tokens` metric counts candidate tokens, not actual persisted tokens.
+
 ## When Does a Reload Actually Happen?
 
 A lookup hit does **not** guarantee a reload. After block allocation,
@@ -878,6 +895,11 @@ Connector-specific tuning (env):
 | `OFFLOAD_MIN_LOAD_TOKENS` | 8192 | Don't reload a hit smaller than this; recompute is cheaper. |
 | `OFFLOAD_COPY_WORKERS` | 1 | SAVE daemon threads. LOAD is always a single thread (TTFT-critical). |
 | `OFFLOAD_MAX_PENDING_SAVES` | `max(2, 2 × OFFLOAD_COPY_WORKERS)` | Positive integer bound on total admitted worker saves (running + queued), acquired before SLOT snapshot or executor submission. |
+| `OFFLOAD_SAVE_ADMISSION` | 1 | Dense/M3 PAGE operation, byte, source and worker queue gates. `0` disables these limits for controlled comparisons; safety/retirement and queue-age cancellation remain enabled. |
+| `OFFLOAD_MAX_RESERVED_SOURCE_BLOCKS` | 10% of PAGE pool, rounded down (at least 1) | Positive cap on unsafe source blocks reserved across admitted Dense/M3 saves, including active requests. Shared blocks are conservatively charged per operation. |
+| `OFFLOAD_MAX_PENDING_SAVE_BYTES` | source cap × measured worst-rank PAGE block bytes | Positive candidate-byte cap. Source-safe milestones do not return this credit while the backend is still pending. Explicit byte limits require known block geometry. |
+| `OFFLOAD_MAX_PENDING_SAVE_TOKENS` | source cap × virtual block size when bytes are unknown; 131072 if pool geometry is also unknown | Positive optional token cap; compatibility fallback when byte geometry is unavailable. |
+| `OFFLOAD_SAVE_QUEUE_TIMEOUT_S` | 2 | Age since scheduler admission at which Dense/M3 requests cancellation once. `0` disables age-based requests. Successful physical queue removal retires a queued task; running tasks need their own source fence. This is not a hard execution-time limit. |
 | `OFFLOAD_GPU_STAGING_CHUNKS` | 2 | Chunks per bounded GPU staging buffer. Sizes **each** buffer — load and save own separate ones, so resident HBM ≈ `(1 + OFFLOAD_COPY_WORKERS) × chunks × chunk_bytes`. |
 | `OFFLOAD_GPU_STAGING_MAX_BYTES` | — | Hard cap on staging bytes (clamps the chunk count). |
 | `OFFLOAD_RELEASE_GPU_STAGING_AFTER_TRANSFER` | 0 | Free the staging buffer after each transfer (lower idle HBM, higher churn). |
@@ -893,6 +915,9 @@ Connector-specific tuning (env):
 `"committed_sidecar_index_capacity": N` overrides
 `OFFLOAD_COMMITTED_SIDECAR_CAPACITY`. `"max_pending_saves": N` overrides
 `OFFLOAD_MAX_PENDING_SAVES`. All apply only to that connector.
+For Dense/M3, `max_reserved_source_blocks`, `max_pending_save_bytes` and
+`max_pending_save_tokens` in `kv_connector_extra_config` override their respective
+environment limits.
 
 AOS1 follows the engine's location policy exactly. Submission passes
 `store_location` to `StorageManager.batched_put`; discovery searches only

--- a/atom/kv_transfer/offload/_offload_common.py
+++ b/atom/kv_transfer/offload/_offload_common.py
@@ -703,25 +703,13 @@ _save_abandon_timeout_s: float | None = None
 
 
 def offload_save_abandon_timeout_s() -> float:
-    """Seconds a deferred offload save may sit before the engine reclaims it.
+    """Legacy stall threshold derived from LMCache's pin timeout.
 
-    Blocks are freed on `finished_saving`, so a lost report leaves them deferred
-    forever: `has_pending_kv_work()` never clears and the engine busy-loops with
-    every GPU idle.
-
-    Reclaiming cannot race a live copy. `OffloadWorkerMixin._guard` reports on
-    both the success and the exception path, so a report is lost only when
-    `store()` neither returns nor raises -- it is parked inside LMCache. Then
-    either the parked save is not copying (LMCache force-unpinned its source
-    after `pin_timeout_sec`) or a save queued behind it never reached `store()`.
-    Both cases are safe once that window has passed.
-
-    Derived from LMCache's own `LMCACHE_EC_PIN_TIMEOUT_SEC` rather than a knob of
-    its own, because that ordering IS the safety argument -- two independent env
-    vars could be set the wrong way round with nothing to say so. This lives on
-    the offload connector, not the scheduler: it is LMCache knowledge, and the
-    scheduler now asks the connector for it (`save_abandon_timeout_s`).
-    Non-positive disables reclamation.
+    A queued task may still start after this threshold; CPU pin expiry is not
+    proof that GPU source reads have ended. Dense/M3 uses this only to request
+    cancellation and requires explicit source-safe or retired reports before
+    recycling blocks. Other layouts keep their existing timeout behavior.
+    Non-positive pin timeouts disable this threshold.
     """
     global _save_abandon_timeout_s
     if _save_abandon_timeout_s is not None:

--- a/atom/kv_transfer/offload/connector.py
+++ b/atom/kv_transfer/offload/connector.py
@@ -230,6 +230,10 @@ class LMCacheOffloadConnectorScheduler(KVConnectorSchedulerBase):
         callback = getattr(self._impl, "reclaim_stale_leases", None)
         return callback(timeout_s) if callback is not None else []
 
+    @property
+    def requires_save_retirement(self) -> bool:
+        return bool(getattr(self._impl, "requires_save_retirement", False))
+
     def record_early_release(self, count: int) -> None:
         callback = getattr(self._impl, "record_early_release", None)
         if callback is not None:

--- a/atom/kv_transfer/offload/dense/connector.py
+++ b/atom/kv_transfer/offload/dense/connector.py
@@ -26,7 +26,9 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
+from concurrent.futures import Future
 from contextlib import nullcontext
 
 import torch
@@ -48,10 +50,18 @@ from atom.kv_transfer.offload._offload_common import (
     OffloadSchedulerMixin,
     OffloadWorkerMixin,
     build_offload_engine,
+    max_pending_saves,
     pp_aware_rank_and_world,
     validated_kv_role,
 )
 from atom.kv_transfer.offload.dense.kv_byte_codec import DenseKVByteCodec
+from atom.kv_transfer.offload.dense.save_admission import build_save_budget
+from atom.kv_transfer.offload.dense.save_executor import (
+    CancellableSaveExecutor,
+    SaveQueueFull,
+    SeenSaveGenerations,
+    save_admission_enabled,
+)
 from atom.kv_transfer.offload.metadata import (
     LMCacheOffloadMetadata,
     LMCacheReqMeta,
@@ -63,6 +73,7 @@ logger = logging.getLogger("atom")
 
 DENSE_PAGE_SOURCE_SAFE_CHANNEL = "dense.page.source_safe"
 DENSE_PAGE_STORE_CHANNEL = "dense.page.store"
+DENSE_PAGE_RETIRED_CHANNEL = "dense.page.retired"
 
 
 # =====================================================================
@@ -95,6 +106,23 @@ class DenseOffloadConnector(OffloadWorkerMixin, KVConnectorBase):
         self._codec: DenseKVByteCodec | None = None
         self._lookup_server = None
         self._early_release = bool(self._supports_early_block_release)
+        if self._early_release:
+            n_save = int(os.environ.get("OFFLOAD_COPY_WORKERS", "1"))
+            kvc = getattr(config, "kv_transfer_config", {}) or {}
+            self._save_capacity = (
+                max_pending_saves(kvc, n_save) if save_admission_enabled() else None
+            )
+            # The common TPE has not received work. Only PAGE early-release
+            # workers use the physically cancellable queue; K3 keeps its path.
+            self._save_executor.shutdown(wait=True)
+            self._save_executor = CancellableSaveExecutor(
+                max_workers=n_save,
+                capacity=self._save_capacity,
+                thread_name_prefix="offload-save",
+            )
+            self._save_dispatch_lock = threading.RLock()
+            self._save_generations = SeenSaveGenerations()
+            self._save_futures: dict[SaveOperationId, Future] = {}
 
     def close(self) -> None:
         super().close()
@@ -174,6 +202,9 @@ class DenseOffloadConnector(OffloadWorkerMixin, KVConnectorBase):
     def start_load_kv(self, metadata) -> None:
         if not isinstance(metadata, LMCacheOffloadMetadata):
             return
+        if self._early_release:
+            for operation in getattr(metadata, "cancel_save_operations", ()):
+                self._cancel_save_operation(operation)
         load_requests = [
             req
             for req in metadata.requests
@@ -187,7 +218,143 @@ class DenseOffloadConnector(OffloadWorkerMixin, KVConnectorBase):
             if req.load_spec is not None and self._do_load:
                 self._load_executor.submit(self._guard, "load", self._do_load_req, req)
             if req.save_spec is not None and self._do_save:
-                self._save_executor.submit(self._guard, "save", self._do_save_req, req)
+                if self._early_release and isinstance(
+                    req.save_operation, SaveOperationId
+                ):
+                    self._submit_save_operation(req)
+                else:
+                    self._save_executor.submit(
+                        self._guard, "save", self._do_save_req, req
+                    )
+
+    def _trace_save_event(self, event, operation, *, queue_wait_ms=0.0, reason=""):
+        if not self._profile_enabled():
+            return
+        queued, running = self._save_executor.counts()
+        logger.info(
+            "[OFFLOAD-SAVE-QUEUE] rank=%s req=%s generation=%d event=%s "
+            "queued=%d running=%d queue_wait_ms=%.2f reason=%s",
+            getattr(self, "_rank", "?"),
+            operation.req_id,
+            operation.generation,
+            event,
+            queued,
+            running,
+            queue_wait_ms,
+            reason or "-",
+        )
+
+    def _submit_save_operation(self, req: LMCacheReqMeta) -> None:
+        operation = req.save_operation
+        with self._save_dispatch_lock:
+            if not self._save_generations.remember(operation.generation):
+                return
+            enqueued_at = time.perf_counter()
+            try:
+                future = self._save_executor.submit(
+                    self._run_save_operation, req, enqueued_at
+                )
+            except Exception as exc:  # noqa: BLE001 - transactional submit boundary
+                # Our executor rejects before enqueueing. Unlike a TPE whose
+                # thread creation can fail after enqueue, no task can survive
+                # this failed submission and subsequently read source blocks.
+                self._publish_store_outcome(operation, False)
+                self._record_save_retired(operation)
+                reason = (
+                    "worker_queue_full"
+                    if isinstance(exc, SaveQueueFull)
+                    else "submit_failed"
+                )
+                self._trace_save_event("rejected", operation, reason=reason)
+                return
+            self._save_futures[operation] = future
+            future.add_done_callback(
+                lambda done, op=operation: self._save_operation_done(op, done)
+            )
+            self._trace_save_event("enqueued", operation)
+
+    def _cancel_save_operation(self, operation: SaveOperationId) -> None:
+        with self._save_dispatch_lock:
+            future = self._save_futures.get(operation)
+            if future is not None:
+                cancelled = future.cancel()
+                self._trace_save_event(
+                    "cancelled" if cancelled else "cancel_running", operation
+                )
+                return
+            if self._save_generations.remember(operation.generation):
+                # Cancellation may precede dispatch. Keep a generation fence
+                # so a delayed metadata batch cannot start this operation.
+                self._publish_store_outcome(operation, False)
+                self._record_save_retired(operation)
+                self._trace_save_event("cancelled_unseen", operation)
+            # A known completed operation has already reported. A known but
+            # unfenced failure must not become safe merely because it is retried.
+
+    def _run_save_operation(self, req: LMCacheReqMeta, enqueued_at: float) -> bool:
+        # Publish the enqueue record and install Future tracking before the
+        # worker can begin, including for a store that returns immediately.
+        with self._save_dispatch_lock:
+            self._trace_save_event(
+                "started",
+                req.save_operation,
+                queue_wait_ms=(time.perf_counter() - enqueued_at) * 1000,
+            )
+        try:
+            self._do_save_req(req)
+        except Exception:
+            logger.exception("offload save failed for %s", req.save_operation)
+            self._record_store_terminal(req, False)
+            # This runs after the save call unwound, on its own executor
+            # thread. It cannot enqueue more GPU reads after these fences.
+            return self._fence_save_source()
+        return True
+
+    def _fence_save_source(self) -> bool:
+        gpu_connector = getattr(getattr(self, "_engine", None), "gpu_connector", None)
+        state_factory = getattr(gpu_connector, "_thread_state", None)
+        if not callable(state_factory):
+            logger.error("offload save cannot prove source safety: no staging state")
+            return False
+        try:
+            state = state_factory()
+            streams = (
+                ("pack_stream", state.pack_stream),
+                ("copy_stream", state.copy_stream),
+            )
+        except Exception:
+            logger.exception("offload save could not inspect staging streams")
+            return False
+        fenced = True
+        for name, stream in streams:
+            if stream is None:
+                continue
+            try:
+                stream.synchronize()
+            except Exception:
+                fenced = False
+                logger.exception("offload save source fence failed: %s", name)
+        return fenced
+
+    def _save_operation_done(self, operation: SaveOperationId, future: Future) -> None:
+        with self._save_dispatch_lock:
+            self._save_futures.pop(operation, None)
+        if future.cancelled():
+            self._publish_store_outcome(operation, False)
+            safe = True
+        else:
+            try:
+                safe = future.result()
+            except BaseException:
+                # An unexpected executor-level failure has no source fence.
+                self._publish_store_outcome(operation, False)
+                logger.exception("offload save executor failed for %s", operation)
+                safe = False
+        if safe:
+            self._record_save_retired(operation)
+            self._trace_save_event("retired", operation)
+        else:
+            self._trace_save_event("unfenced", operation)
 
     # -- copy daemon thread ----------------------------------------------
     def _source_group_safe(self, identity: SaveSourceGroupId) -> None:
@@ -207,24 +374,28 @@ class DenseOffloadConnector(OffloadWorkerMixin, KVConnectorBase):
         if getattr(self, "_early_release", False) and isinstance(
             operation, SaveOperationId
         ):
-            with self._lock:
-                # Keep the legacy terminal channel as well: MultiConnector's
-                # producer send/save pairing consumes this field before
-                # connector-owned completions reach the scheduler.
-                self._done_save.add(operation)
-                self._connector_completions.add(
-                    ConnectorCompletion(
-                        DENSE_PAGE_STORE_CHANNEL,
-                        operation,
-                        succeeded,
-                    )
-                )
+            self._publish_store_outcome(operation, succeeded)
             return
         with self._lock:
             self._done_save.add(self._save_completion_id(req))
 
     def _record_save_failure(self, req) -> None:
         self._record_store_terminal(req, False)
+
+    def _publish_store_outcome(self, operation: SaveOperationId, succeeded: bool):
+        with self._lock:
+            self._connector_completions.add(
+                ConnectorCompletion(DENSE_PAGE_STORE_CHANNEL, operation, succeeded)
+            )
+
+    def _record_save_retired(self, operation: SaveOperationId) -> None:
+        with self._lock:
+            self._connector_completions.add(
+                ConnectorCompletion(DENSE_PAGE_RETIRED_CHANNEL, operation, True)
+            )
+            # Legacy deferred-free/MultiConnector pairing is a safety signal.
+            # Never publish it from a failed, unfenced store result alone.
+            self._done_save.add(operation)
 
     def _do_load_req(self, req: LMCacheReqMeta) -> None:
         ls = req.load_spec
@@ -447,6 +618,40 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         self._save_lease_owner: dict[int, object] = {}
         self._pending_source_safe_releases: list[frozenset] = []
         self._source_safe_waiting_for_store: dict[SaveOperationId, set[int]] = {}
+        self._save_outcomes: dict[SaveOperationId, bool] = {}
+        self._save_retired: set[SaveOperationId] = set()
+        self._save_cancel_requested: set[SaveOperationId] = set()
+        self._pending_save_cancels: list[SaveOperationId] = []
+        self._prepared_saves: list[LMCacheReqMeta] = []
+        self._save_budget = (
+            build_save_budget(config, self.virtual_block_size)
+            if self._early_release
+            else None
+        )
+        if self._early_release:
+            self._max_pending_saves = self._save_budget.max_operations
+            logger.info(
+                "LMCache PAGE save admission: max_ops=%s source_blocks=%s pending_bytes=%s bytes_per_block=%d",
+                self._max_pending_saves,
+                self._save_budget.max_source_blocks,
+                self._save_budget.max_pending_bytes,
+                self._save_budget.bytes_per_block,
+            )
+        self._save_queue_timeout_s = float(
+            os.environ.get("OFFLOAD_SAVE_QUEUE_TIMEOUT_S", "2")
+        )
+        if self._save_queue_timeout_s < 0:
+            raise ValueError("OFFLOAD_SAVE_QUEUE_TIMEOUT_S must be nonnegative")
+        self._save_admission_stats = dict.fromkeys(
+            (
+                "save_ops_admitted",
+                "save_tokens_admitted",
+                "save_ops_dropped",
+                "save_tokens_dropped",
+                "save_cancel_requests",
+            ),
+            0,
+        )
         self._save_nonce = 0
         self._load_nonce = 0
         self._load_lifecycles: dict[str, object] = {}
@@ -597,10 +802,95 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         )
         if self._do_save:
             entry = self._save_tracker.get(sid)
+            if self._early_release:
+                initial_saved = max(
+                    initial_saved, getattr(seq, "_offload_save_processed", 0)
+                )
             if entry is None or entry[0] is not seq:
                 self._save_tracker[sid] = [seq, initial_saved]
             else:
                 entry[1] = max(int(entry[1]), initial_saved)
+
+    @property
+    def requires_save_retirement(self) -> bool:
+        """Elapsed time alone never authorizes recycling PAGE save sources."""
+        return self._early_release
+
+    def _drop_save_range(self, seq, aligned: int, reason: str) -> None:
+        entry = self._save_tracker.get(str(seq.id))
+        if entry is None or entry[0] is not seq:
+            return
+        tokens = max(0, aligned - int(entry[1]))
+        if tokens:
+            self._save_admission_stats["save_ops_dropped"] += 1
+            self._save_admission_stats["save_tokens_dropped"] += tokens
+            logger.debug(
+                "[OFFLOAD-SAVE-DROP] req=%s tokens=%d reason=%s", seq.id, tokens, reason
+            )
+        entry[1] = max(int(entry[1]), aligned)
+        seq._offload_save_processed = entry[1]
+        seq._offload_save_disabled = True
+
+    def _prepare_save(self, seq, entry) -> LMCacheReqMeta | None:
+        """Reserve credits and freeze source ownership before any block free."""
+        aligned = self._save_frontier(seq)
+        saved = int(entry[1])
+        if aligned <= saved:
+            return None
+        if getattr(seq, "_offload_save_disabled", False):
+            self._drop_save_range(seq, aligned, "lifecycle_disabled")
+            return None
+        operation = SaveOperationId(seq.id, self._save_nonce)
+        block_ids = list(getattr(seq, "_offload_finished_block_ids", seq.block_table))
+        first = saved // self.virtual_block_size
+        end = -(-aligned // self.virtual_block_size)
+        if end > len(block_ids):
+            raise ValueError("save frontier exceeds the allocated PAGE block table")
+        block_map = {index: block_ids[index] for index in range(first, end)}
+        request = LMCacheReqMeta(
+            req_id=seq.id,
+            token_ids=list(seq.token_ids[:aligned]),
+            block_ids=block_ids,
+            save_spec=SaveSpec(skip_leading_tokens=saved, can_save=True),
+            is_last_prefill=aligned >= int(seq.num_prompt_tokens),
+            save_operation=operation,
+        )
+        reason = self._save_budget.reserve(
+            operation, block_map.values(), aligned - saved
+        )
+        if reason is not None:
+            self._drop_save_range(seq, aligned, reason)
+            return None
+        self._save_nonce += 1
+        self._save_admission_stats["save_ops_admitted"] += 1
+        self._save_admission_stats["save_tokens_admitted"] += aligned - saved
+        self._track_save_statistics(operation, aligned - saved)
+        self._save_operation_blocks[operation] = block_map
+        self._save_operation_safe[operation] = set()
+        self._save_operation_owner[operation] = seq
+        self._save_inflight[str(seq.id)] = operation
+        entry[1] = aligned
+        seq._offload_save_processed = aligned
+        self._save_rr_last = str(seq.id)
+        return request
+
+    def _request_save_cancel(self, operation: SaveOperationId) -> None:
+        if (
+            operation not in self._save_operation_blocks
+            or operation in self._save_cancel_requested
+        ):
+            return
+        self._save_cancel_requested.add(operation)
+        self._pending_save_cancels.append(operation)
+        self._save_admission_stats["save_cancel_requests"] += 1
+
+    def _cancel_aged_saves(self) -> None:
+        if not self._early_release or self._save_queue_timeout_s <= 0:
+            return
+        now = time.monotonic()
+        for operation, reservation in self._save_budget.operations.items():
+            if now - reservation.created_at >= self._save_queue_timeout_s:
+                self._request_save_cancel(operation)
 
     def _clear_pending_load(self, sid: str) -> None:
         self._load_specs.pop(sid, None)
@@ -652,16 +942,18 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         return max(1, adjusted)
 
     def _may_emit_save(self) -> bool:
-        """Seam for a subclass to bound how many saves may be outstanding.
-
-        Unbounded here. It matters for a layout whose `should_defer_free` pins
-        a finished request's blocks until its save drains -- an unbounded queue
-        then lets a slow backend hold an unbounded slice of the pool.
-        """
+        """Legacy layout hook; Dense/M3 uses `_prepare_save` admission instead."""
         return True
 
     def build_connector_meta(self) -> LMCacheOffloadMetadata:
         meta = LMCacheOffloadMetadata()
+        early_release = getattr(self, "_early_release", False)
+        if early_release:
+            self._cancel_aged_saves()
+            meta.requests.extend(self._prepared_saves)
+            self._prepared_saves = []
+            meta.cancel_save_operations = self._pending_save_cancels
+            self._pending_save_cancels = []
 
         # Loads
         logger.debug("[OFFLOAD-BUILD] reqs_need_recv=%d", len(self._reqs_need_recv))
@@ -743,11 +1035,18 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
             entry = self._save_tracker[sid]
             if not self._do_save:
                 continue
-            if not self._may_emit_save():
+            if not early_release and not self._may_emit_save():
                 break
             seq, saved = entry
             if sid in self._reqs_need_recv or sid in loading_sids:
                 continue  # loading this step; defer its save
+            if early_release:
+                if any(owner is seq for owner in self._save_operation_owner.values()):
+                    continue
+                request = self._prepare_save(seq, entry)
+                if request is not None:
+                    meta.add_request(request)
+                continue
             if sid in self._save_inflight:
                 continue  # keep at most one save per request in flight
             computed = min(
@@ -818,6 +1117,8 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
             return True
         if not self._do_save:
             return False
+        if getattr(self, "_early_release", False):
+            return bool(self.protected_block_ids(seq))
         sid = str(seq.id)
         operation_blocks = getattr(self, "_save_operation_blocks", {})
         operation_safe = getattr(self, "_save_operation_safe", {})
@@ -836,26 +1137,16 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         )
 
     def protected_block_ids(self, seq) -> frozenset | None:
-        """Exact pending/in-flight source blocks not yet known source-safe.
+        """Only admitted source blocks not yet known source-safe.
 
         None means "this connector cannot narrow the protection" (the layout
         does not support exact leases, or a load is in flight, since a load also
         touches HBM blocks this connector does not track per-range) -- the
-        scheduler falls back to deferring the whole request. This includes a
-        final save that has not been emitted yet: request teardown freezes its
-        full block table and computed frontier so the next metadata build can
-        still dispatch that save after unrelated blocks have been released.
+        scheduler falls back to deferring the whole request. Final saves must
+        acquire admission in request_finished, before block deallocation.
         """
         if not self._early_release or self._has_active_load(seq):
             return None
-        sid = str(seq.id)
-        table = list(getattr(seq, "_offload_finished_block_ids", seq.block_table))
-        if not hasattr(seq, "_offload_finished_block_ids"):
-            seq._offload_finished_block_ids = table
-        seq._offload_finished_cached_tokens = min(
-            int(getattr(seq, "num_cached_tokens", 0)), int(seq.num_prompt_tokens)
-        )
-
         protected: set[int] = set()
         for operation, blocks in self._save_operation_blocks.items():
             if self._save_operation_owner.get(operation) is not seq:
@@ -865,14 +1156,6 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
                 block_id for block_id in blocks.values() if block_id not in safe
             )
 
-        entry = self._save_tracker.get(sid)
-        if entry is not None and entry[0] is seq:
-            saved = int(entry[1])
-            aligned = self._save_frontier(seq)
-            if aligned > saved:
-                start_block = saved // self.virtual_block_size
-                end_block = -(-aligned // self.virtual_block_size)
-                protected.update(table[start_block:end_block])
         return frozenset(protected)
 
     def activate_block_leases(self, seq, block_ids: frozenset[int]) -> None:
@@ -896,19 +1179,7 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         return out
 
     def reclaim_stale_leases(self, timeout_s: float) -> list[frozenset]:
-        """Force-release leases whose save never reported, past `timeout_s`.
-
-        Twin of the scheduler's `_reconcile_stalled_deferred_saves`, but for
-        leases opened by `deallocate_partial`'s early-release path -- those
-        requests are *not* in `deferred_free_blocks` (they were already fully
-        torn down at finish time), so the existing reconciler never sees them.
-        Same safety argument as `_reconcile_stalled_deferred_saves`: past
-        `save_abandon_timeout_s()`, LMCache has force-unpinned the source
-        either way, so the GPU blocks are safe to return. A lease exists only
-        after its request finished, so reclamation also drops that lifecycle's
-        frozen tracker entry; re-emitting it would read blocks just returned to
-        the pool.
-        """
+        """Request cancellation of old leases; time is not a source-read fence."""
         if timeout_s <= 0 or not self._save_lease_at:
             return []
         now = time.monotonic()
@@ -917,36 +1188,11 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
             for lease_key, at in self._save_lease_at.items()
             if now - at >= timeout_s
         ]
-        released: list[frozenset] = []
         for lease_key in stale_keys:
-            self._save_lease_at.pop(lease_key, None)
-            blocks = self._save_lease_blocks.pop(lease_key, None)
-            owner = self._save_lease_owner.pop(lease_key, None)
-            owned_operations = [
-                op
-                for op, owner in self._save_operation_owner.items()
-                if id(owner) == lease_key
-            ]
-            sid = str(owner.id) if owner is not None else None
-            operation = self._save_inflight.get(sid) if sid is not None else None
-            if operation in owned_operations:
-                self._save_inflight.pop(sid, None)
-                self._cancel_save_statistics(operation)
-            for candidate in [
-                op for op in self._save_operation_blocks if op in owned_operations
-            ]:
-                self._save_operation_blocks.pop(candidate, None)
-                self._save_operation_safe.pop(candidate, None)
-                self._save_operation_owner.pop(candidate, None)
-                self._source_safe_waiting_for_store.pop(candidate, None)
-            if sid is not None:
-                entry = self._save_tracker.get(sid)
-                if entry is not None and entry[0] is owner:
-                    self._save_tracker.pop(sid, None)
-            if blocks:
-                released.append(frozenset(blocks))
-                self.total_abnormal_lease_reclaims += len(blocks)
-        return released
+            for operation, owner in self._save_operation_owner.items():
+                if id(owner) == lease_key:
+                    self._request_save_cancel(operation)
+        return []
 
     def release_stalled_save(self, seq) -> None:
         """Drop bookkeeping for a stall-escaped save the scheduler is freeing.
@@ -958,34 +1204,22 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         """
 
     def has_pending_work(self) -> bool:
-        """True while a load/cleanup is dispatchable or a save is unreported.
-
-        Feeds ``EngineCore.has_pending_kv_work()``, so it reads only state
-        that clears itself: ``_reqs_need_recv`` is emptied by every
-        ``build_connector_meta`` and ``_save_inflight`` by ``save_finished``
-        (or ``abandon_save`` when the scheduler reclaims a stalled save).
-        With early release, a finished request's final not-yet-emitted save is
-        no longer represented by ``deferred_free_blocks``; its frozen tracker
-        entry must therefore keep the engine polling until it is dispatched.
-
-        A pre-allocation lookup belongs to a waiting request. Keep its pin,
-        but do not advertise idle work until allocation or cancellation makes
-        a load or cleanup dispatchable in ``build_connector_meta``.
-        """
-        pending_finished_save = getattr(self, "_early_release", False) and any(
-            hasattr(entry[0], "_offload_finished_block_ids")
-            and self._has_pending_save(entry[0])
-            for entry in self._save_tracker.values()
-        )
+        """Keep polling admitted saves, cancellation acknowledgements and loads."""
         return (
             bool(self._reqs_need_recv)
             or bool(self._save_inflight)
             or bool(getattr(self, "_save_lease_blocks", {}))
-            or pending_finished_save
+            or bool(self._prepared_saves)
+            or bool(self._pending_save_cancels)
+            or bool(self._save_operation_blocks)
             or any(sid not in self._load_specs for sid in self._lookup_in_step)
         )
 
     def save_finished(self, req_id) -> None:
+        if self._early_release and isinstance(req_id, SaveOperationId):
+            # Legacy notification wakes the engine, but does not replace the
+            # independent outcome and no-future-source-read quorums.
+            return
         sid = str(req_id.req_id if isinstance(req_id, SaveOperationId) else req_id)
         active = self._save_inflight.get(sid)
         if isinstance(req_id, SaveOperationId):
@@ -997,12 +1231,6 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
             # entries should one be restored from older scheduler state.
             return
         self._save_inflight.pop(sid, None)
-        if getattr(self, "_early_release", False):
-            # Store success/failure and lease release travel on the dedicated
-            # connector channel. This legacy terminal exists for deferred-free
-            # and MultiConnector send/save pairing only.
-            self._finish_retired_request(sid)
-            return
         self._finish_save_statistics(req_id)
         self._release_operation_lease(req_id)
         self._finish_retired_request(sid)
@@ -1014,8 +1242,20 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
             identity = completion.operation_id
             if not isinstance(identity, SaveSourceGroupId):
                 return False
-            self._source_group_finished(identity)
+            if completion.succeeded:
+                self._source_group_finished(identity)
             return None
+        if completion.channel == DENSE_PAGE_RETIRED_CHANNEL:
+            operation = completion.operation_id
+            if not isinstance(operation, SaveOperationId):
+                return False
+            if completion.succeeded and operation in self._save_operation_blocks:
+                self._save_retired.add(operation)
+                self._mark_sources_safe(
+                    operation, self._save_operation_blocks[operation].values()
+                )
+                self._try_retire_save(operation)
+            return True
         if completion.channel != DENSE_PAGE_STORE_CHANNEL:
             return False
         operation = completion.operation_id
@@ -1038,16 +1278,36 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
                 for index in range(start_block, end_block)
                 if index in block_map
             )
+        self._mark_sources_safe(operation, source_blocks)
+
+    def _mark_sources_safe(self, operation, source_blocks) -> None:
         safe = self._save_operation_safe.setdefault(operation, set())
+        source_blocks = set(source_blocks)
         newly_safe = source_blocks - safe
         safe.update(newly_safe)
+        self._save_budget.source_safe(operation, newly_safe)
         if not newly_safe:
             return
-        sid = str(operation.req_id)
         owner = self._save_operation_owner.get(operation)
+        self._release_safe_owner_leases(owner)
+        if operation not in self._save_outcomes:
+            self._source_safe_waiting_for_store.setdefault(operation, set()).update(
+                newly_safe
+            )
+
+    def _release_safe_owner_leases(self, owner) -> None:
         lease_key = id(owner) if owner is not None else None
         leased = self._save_lease_blocks.get(lease_key)
-        releasable = newly_safe & leased if leased is not None else set()
+        if not leased:
+            return
+        unsafe = set()
+        for operation, candidate_owner in self._save_operation_owner.items():
+            if candidate_owner is owner:
+                unsafe.update(
+                    set(self._save_operation_blocks[operation].values())
+                    - self._save_operation_safe.get(operation, set())
+                )
+        releasable = leased - unsafe
         if releasable:
             leased.difference_update(releasable)
             self._pending_source_safe_releases.append(frozenset(releasable))
@@ -1056,65 +1316,55 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
                 self._save_lease_blocks.pop(lease_key, None)
                 self._save_lease_at.pop(lease_key, None)
                 self._save_lease_owner.pop(lease_key, None)
-        if self._save_inflight.get(sid) == operation:
-            self._source_safe_waiting_for_store.setdefault(operation, set()).update(
-                newly_safe
-            )
-        elif set(block_map.values()).issubset(safe):
-            self._save_operation_blocks.pop(operation, None)
-            self._save_operation_safe.pop(operation, None)
-            self._save_operation_owner.pop(operation, None)
 
     def _store_finished(self, operation: SaveOperationId, *, succeeded: bool) -> None:
-        sid = str(operation.req_id)
-        active = self._save_inflight.get(sid)
-        if (
-            active != operation
-            and operation not in self._save_operation_blocks
-            and operation not in self._save_inflight_tokens
-        ):
+        if operation not in self._save_operation_blocks:
             return
-        if active == operation:
-            self._save_inflight.pop(sid, None)
+        self._save_outcomes[operation] = (
+            self._save_outcomes.get(operation, True) and succeeded
+        )
         self._source_safe_waiting_for_store.pop(operation, None)
+        self._try_retire_save(operation)
+
+    def _try_retire_save(self, operation) -> None:
+        if operation not in self._save_retired or operation not in self._save_outcomes:
+            return
+        succeeded = self._save_outcomes.pop(operation)
+        self._save_retired.discard(operation)
+        self._save_cancel_requested.discard(operation)
+        self._pending_save_cancels = [
+            op for op in self._pending_save_cancels if op != operation
+        ]
+        owner = self._save_operation_owner.get(operation)
+        if not succeeded and owner is not None:
+            self._drop_save_range(owner, self._save_frontier(owner), "store_failed")
         if succeeded:
             self._finish_save_statistics(operation)
-            # A returned store is also a source-safety fence, including the
-            # case where LMCache found a chunk already present and never called
-            # the GPU connector for that range.
-            self._release_operation_lease(operation)
         else:
             self._cancel_save_statistics(operation)
-            # Do not infer source-safety from a failed store. Any ranges whose
-            # GPU staging callback already reached quorum were released above;
-            # the rest stay leased until the conservative abandon timeout.
+        self._save_budget.retire(operation)
+        self._release_operation_lease(operation)
+        self._source_safe_waiting_for_store.pop(operation, None)
+        sid = str(operation.req_id)
+        if self._save_inflight.get(sid) == operation:
+            self._save_inflight.pop(sid, None)
         self._finish_retired_request(sid)
 
     def _release_operation_lease(self, operation) -> None:
         if not isinstance(operation, SaveOperationId):
             return
-        block_map = self._save_operation_blocks.pop(operation, {})
+        self._save_operation_blocks.pop(operation, None)
         self._save_operation_safe.pop(operation, None)
         owner = self._save_operation_owner.pop(operation, None)
-        lease_key = id(owner) if owner is not None else None
-        leased = self._save_lease_blocks.get(lease_key)
-        releasable = set(block_map.values()) & leased if leased is not None else set()
-        if releasable:
-            leased.difference_update(releasable)
-            self._pending_source_safe_releases.append(frozenset(releasable))
-            self.total_source_safe_released_blocks += len(releasable)
-            if not leased:
-                self._save_lease_blocks.pop(lease_key, None)
-                self._save_lease_at.pop(lease_key, None)
-                self._save_lease_owner.pop(lease_key, None)
+        self._release_safe_owner_leases(owner)
 
     def _finish_retired_request(self, sid: str) -> None:
         entry = self._save_tracker.get(sid)
         if entry is None:
             return
         seq = entry[0]
-        if hasattr(seq, "_offload_finished_block_ids") and not self._has_pending_save(
-            seq
+        if hasattr(seq, "_offload_finished_block_ids") and not any(
+            owner is seq for owner in self._save_operation_owner.values()
         ):
             self._save_tracker.pop(sid, None)
 
@@ -1123,24 +1373,30 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
             len(blocks) for blocks in self._source_safe_waiting_for_store.values()
         )
 
-    def abandon_save(self, req_id) -> None:
-        """Force-drop a save the scheduler reclaimed after it stalled.
+    def get_statistics(self) -> dict[str, int]:
+        statistics = super().get_statistics()
+        if self._early_release:
+            statistics.update(self._save_admission_stats)
+            statistics.update(
+                save_ops_unretired=len(self._save_budget.operations),
+                save_pending_bytes=self._save_budget.pending_bytes,
+                source_blocks_reserved=self._save_budget.source_blocks,
+                source_blocks_leased=sum(map(len, self._save_lease_blocks.values())),
+                save_oldest_age_ms=self._save_budget.oldest_age_ms(),
+            )
+        return statistics
 
-        `save_finished` is the completion path: it matches the exact
-        `SaveOperationId` and, handed a raw request id while an exact generation
-        is parked, deliberately refuses -- a delayed TP notification must not
-        complete a newer lifecycle. Reclamation is the opposite need. The
-        scheduler's `_reconcile_stalled_deferred_saves` has already freed the
-        blocks of a save the backend never reported (LMCache force-unpins a
-        stalled save without a completion) and holds only the raw request id, so
-        drop the entry unconditionally. Without this the entry lingers,
-        `should_defer_free` stays True and `has_pending_work` never clears, and
-        the engine busy-loops with every GPU idle. Not a completion: the bytes
-        were never persisted, so the statistics are *cancelled*, not finished,
-        and the tracker entry is dropped so the save loop cannot re-emit it
-        against freed blocks.
-        """
+    def abandon_save(self, req_id) -> None:
+        """Request PAGE cancellation, or abandon an unsupported legacy layout."""
         sid = str(req_id.req_id if isinstance(req_id, SaveOperationId) else req_id)
+        if self._early_release:
+            for operation in self._save_operation_blocks:
+                if operation == req_id or (
+                    not isinstance(req_id, SaveOperationId)
+                    and str(operation.req_id) == sid
+                ):
+                    self._request_save_cancel(operation)
+            return
         operation = self._save_inflight.pop(sid, None)
         if operation is not None:
             self._cancel_save_statistics(operation)
@@ -1172,11 +1428,19 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         self._finish_load_statistics(req_id, succeeded=False)
         floor = self._load_save_floors.get(sid)
         entry = self._save_tracker.get(sid)
-        if floor is not None and entry is not None:
+        if (
+            floor is not None
+            and entry is not None
+            and not getattr(entry[0], "_offload_save_disabled", False)
+        ):
             # The LMCache hit was not actually loaded. Let the recomputed
             # [HBM, LMC) chunks be saved again instead of permanently treating
             # them as already persisted.
             entry[1] = self._chunk_floor(floor)
+            if self._early_release:
+                entry[1] = max(
+                    entry[1], getattr(entry[0], "_offload_save_processed", 0)
+                )
         self._clear_pending_load(sid)
         return True
 
@@ -1218,17 +1482,24 @@ class DenseOffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         entry = self._save_tracker.get(sid)
         if entry is not None and entry[0] is seq:
             if self._early_release:
-                # Freeze the final computed frontier before BlockManager
-                # clears it during partial deallocation. Keep the tracker when
-                # a final chunk still needs emission; a later metadata build
-                # uses the frozen block table recorded by
-                # `protected_block_ids`.
-                seq._offload_finished_cached_tokens = min(
-                    int(getattr(seq, "num_cached_tokens", 0)),
-                    int(seq.num_prompt_tokens),
-                )
-                if not self.should_defer_free(seq):
-                    self._save_tracker.pop(sid, None)
+                if not hasattr(seq, "_offload_finished_block_ids"):
+                    seq._offload_finished_block_ids = list(seq.block_table)
+                    seq._offload_finished_cached_tokens = min(
+                        int(getattr(seq, "num_cached_tokens", 0)),
+                        int(seq.num_prompt_tokens),
+                    )
+                if self._has_pending_save(seq):
+                    if any(
+                        owner is seq for owner in self._save_operation_owner.values()
+                    ):
+                        self._drop_save_range(
+                            seq, self._save_frontier(seq), "final_save_busy"
+                        )
+                    else:
+                        request = self._prepare_save(seq, entry)
+                        if request is not None:
+                            self._prepared_saves.append(request)
+                self._finish_retired_request(sid)
             elif not self.should_defer_free(seq):
                 self._save_tracker.pop(sid, None)
         if hasattr(seq, "_load_operation"):

--- a/atom/kv_transfer/offload/dense/save_admission.py
+++ b/atom/kv_transfer/offload/dense/save_admission.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Scheduler-owned credits for saves, including sources of live requests."""
+
+import os
+from dataclasses import dataclass
+from time import monotonic
+
+from atom.kv_transfer.disaggregation.types import SaveOperationId
+from atom.kv_transfer.offload._offload_common import max_pending_saves
+from atom.kv_transfer.offload.dense.save_executor import save_admission_enabled
+
+
+def build_save_budget(config, virtual_block_size: int) -> "SaveAdmissionBudget":
+    kvc = getattr(config, "kv_transfer_config", {}) or {}
+    extra = kvc.get("kv_connector_extra_config", kvc) or {}
+
+    def limit(name, env, default):
+        raw = extra.get(name, os.environ.get(env, default))
+        if raw is None:
+            return None
+        if isinstance(raw, bool) or str(raw) != str(int(raw)) or int(raw) <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+        return int(raw)
+
+    pool_blocks = int(getattr(config, "num_kvcache_blocks", 0) or 0)
+    block_bytes = int(getattr(config, "kv_cache_block_bytes", 0) or 0)
+    source_cap = limit(
+        "max_reserved_source_blocks",
+        "OFFLOAD_MAX_RESERVED_SOURCE_BLOCKS",
+        max(1, pool_blocks // 10) if pool_blocks else None,
+    )
+    byte_cap = limit(
+        "max_pending_save_bytes",
+        "OFFLOAD_MAX_PENDING_SAVE_BYTES",
+        source_cap * block_bytes if source_cap and block_bytes else None,
+    )
+    token_cap = limit(
+        "max_pending_save_tokens",
+        "OFFLOAD_MAX_PENDING_SAVE_TOKENS",
+        (
+            (source_cap * virtual_block_size if source_cap else 131072)
+            if not block_bytes
+            else None
+        ),
+    )
+    enabled = save_admission_enabled()
+    return SaveAdmissionBudget(
+        max_operations=(
+            max_pending_saves(kvc, int(os.environ.get("OFFLOAD_COPY_WORKERS", "1")))
+            if enabled
+            else None
+        ),
+        max_source_blocks=source_cap if enabled else None,
+        max_pending_bytes=byte_cap if enabled else None,
+        max_pending_tokens=token_cap if enabled else None,
+        bytes_per_block=block_bytes,
+    )
+
+
+@dataclass
+class SaveReservation:
+    unsafe_blocks: set[int]
+    tokens: int
+    byte_count: int
+    created_at: float
+
+
+class SaveAdmissionBudget:
+    """Single scheduler-thread accounting; failed stores retain their credits.
+
+    Source credits retire incrementally, but operation/payload credits remain
+    until all workers have both terminated and proved no future source reads.
+    Shared physical blocks are conservatively charged once per operation.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_operations: int | None,
+        max_source_blocks: int | None,
+        max_pending_bytes: int | None,
+        max_pending_tokens: int | None,
+        bytes_per_block: int,
+    ) -> None:
+        for cap in (
+            max_operations,
+            max_source_blocks,
+            max_pending_bytes,
+            max_pending_tokens,
+        ):
+            if cap is not None and cap <= 0:
+                raise ValueError("save admission limits must be positive")
+        if bytes_per_block < 0 or (max_pending_bytes and not bytes_per_block):
+            raise ValueError("a byte limit requires measured PAGE block bytes")
+        self.max_operations = max_operations
+        self.max_source_blocks = max_source_blocks
+        self.max_pending_bytes = max_pending_bytes
+        self.max_pending_tokens = max_pending_tokens
+        self.bytes_per_block = bytes_per_block
+        self.operations: dict[SaveOperationId, SaveReservation] = {}
+        self.source_blocks = 0
+        self.pending_bytes = 0
+        self.pending_tokens = 0
+
+    def reserve(self, operation, block_ids, tokens: int) -> str | None:
+        if operation in self.operations:
+            raise ValueError("save operation already reserved")
+        blocks = set(block_ids)
+        byte_count = len(blocks) * self.bytes_per_block
+        for value, cap, reason in (
+            (len(self.operations) + 1, self.max_operations, "pending_ops"),
+            (self.source_blocks + len(blocks), self.max_source_blocks, "source_blocks"),
+            (self.pending_bytes + byte_count, self.max_pending_bytes, "pending_bytes"),
+            (self.pending_tokens + tokens, self.max_pending_tokens, "pending_tokens"),
+        ):
+            if cap is not None and value > cap:
+                return reason
+        self.operations[operation] = SaveReservation(
+            blocks, tokens, byte_count, monotonic()
+        )
+        self.source_blocks += len(blocks)
+        self.pending_bytes += byte_count
+        self.pending_tokens += tokens
+        return None
+
+    def source_safe(self, operation, block_ids) -> set[int]:
+        reservation = self.operations.get(operation)
+        if reservation is None:
+            return set()
+        safe = reservation.unsafe_blocks.intersection(block_ids)
+        reservation.unsafe_blocks.difference_update(safe)
+        self.source_blocks -= len(safe)
+        return safe
+
+    def retire(self, operation) -> None:
+        reservation = self.operations.pop(operation, None)
+        if reservation is not None:
+            self.source_blocks -= len(reservation.unsafe_blocks)
+            self.pending_bytes -= reservation.byte_count
+            self.pending_tokens -= reservation.tokens
+
+    def oldest_age_ms(self) -> int:
+        if not self.operations:
+            return 0
+        oldest = min(item.created_at for item in self.operations.values())
+        return max(0, int((monotonic() - oldest) * 1000))

--- a/atom/kv_transfer/offload/dense/save_executor.py
+++ b/atom/kv_transfer/offload/dense/save_executor.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+"""Save executor whose cancelled tasks release their queue storage immediately."""
+
+from __future__ import annotations
+
+import os
+import threading
+from bisect import bisect_left, bisect_right
+from collections import deque
+from collections.abc import Callable
+from concurrent.futures import Future
+from dataclasses import dataclass
+from typing import Any
+
+
+def save_admission_enabled() -> bool:
+    value = os.environ.get("OFFLOAD_SAVE_ADMISSION", "1").strip().lower()
+    return bool(value) and value not in {"0", "false", "no", "off"}
+
+
+class SaveQueueFull(RuntimeError):
+    """The running-plus-queued save capacity has already been reserved."""
+
+
+class SeenSaveGenerations:
+    """Remember dispatch/cancel generations without retaining request metadata.
+
+    A Dense scheduler issues globally unique, increasing generations. Adjacent
+    generations compact to one interval, including rejected and cancelled jobs.
+    Unlike a high watermark, intervals also handle cancellation before dispatch
+    without suppressing an unseen earlier generation.
+    """
+
+    def __init__(self) -> None:
+        self._intervals: list[tuple[int, int]] = []
+
+    def remember(self, generation: int) -> bool:
+        """Return True exactly once for each generation. Caller owns locking."""
+        index = bisect_right(self._intervals, (generation, float("inf"))) - 1
+        if index >= 0 and self._intervals[index][1] >= generation:
+            return False
+        index = bisect_left(self._intervals, (generation, generation))
+        start = end = generation
+        if index and self._intervals[index - 1][1] + 1 == generation:
+            index -= 1
+            start = self._intervals.pop(index)[0]
+        if index < len(self._intervals) and self._intervals[index][0] == end + 1:
+            end = self._intervals.pop(index)[1]
+        self._intervals.insert(index, (start, end))
+        return True
+
+
+class _SaveFuture(Future):
+    def __init__(self, executor: CancellableSaveExecutor) -> None:
+        super().__init__()
+        self._executor = executor
+
+    def cancel(self) -> bool:
+        return self._executor._cancel(self)
+
+
+@dataclass
+class _SaveTask:
+    future: _SaveFuture
+    fn: Callable[..., Any]
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+
+
+class CancellableSaveExecutor:
+    """Nonblocking admission with a physical running-plus-queued bound.
+
+    Future.cancel() removes a queued task, including its function arguments,
+    before invoking callbacks. Worker slots are released before done callbacks,
+    so a retirement callback cannot free scheduler credit ahead of this slot.
+    capacity=None retains the same cancellation protocol for a control run with
+    admission disabled. The load executor is intentionally separate.
+    """
+
+    def __init__(
+        self, *, max_workers: int, capacity: int | None, thread_name_prefix: str
+    ) -> None:
+        if max_workers <= 0 or (capacity is not None and capacity <= 0):
+            raise ValueError("save workers and capacity must be positive")
+        self._capacity = capacity
+        self._condition = threading.Condition()
+        self._queue: deque[_SaveTask] = deque()
+        self._queued: dict[_SaveFuture, _SaveTask] = {}
+        self._running = 0
+        self._shutdown = False
+        self._threads: list[threading.Thread] = []
+        try:
+            # Start before accepting any work: thread creation failure cannot
+            # leave an executable task behind an unsuccessful submit().
+            for index in range(max_workers):
+                thread = threading.Thread(
+                    target=self._run,
+                    name=f"{thread_name_prefix}_{index}",
+                    daemon=True,
+                )
+                thread.start()
+                self._threads.append(thread)
+        except BaseException:
+            self.shutdown(wait=True, cancel_futures=True)
+            raise
+
+    def counts(self) -> tuple[int, int]:
+        with self._condition:
+            return len(self._queue), self._running
+
+    def submit(self, fn: Callable[..., Any], /, *args, **kwargs) -> Future:
+        with self._condition:
+            if self._shutdown:
+                raise RuntimeError("cannot schedule saves after shutdown")
+            if (
+                self._capacity is not None
+                and len(self._queue) + self._running >= self._capacity
+            ):
+                raise SaveQueueFull("save queue capacity exhausted")
+            future = _SaveFuture(self)
+            task = _SaveTask(future, fn, args, kwargs)
+            self._queued[future] = task
+            try:
+                self._queue.append(task)
+            except BaseException:
+                self._queued.pop(future, None)
+                raise
+            self._condition.notify()
+            return future
+
+    def _cancel(self, future: _SaveFuture) -> bool:
+        with self._condition:
+            task = self._queued.pop(future, None)
+            if task is not None:
+                self._queue.remove(task)
+                self._condition.notify_all()
+            # The worker marks a popped task RUNNING under this same lock.
+            # A cancelled queued task cannot be observed by any worker now.
+        return Future.cancel(future)
+
+    def _run(self) -> None:
+        while True:
+            with self._condition:
+                self._condition.wait_for(lambda: self._queue or self._shutdown)
+                if not self._queue:
+                    return
+                task = self._queue.popleft()
+                self._queued.pop(task.future)
+                if not task.future.set_running_or_notify_cancel():
+                    continue
+                self._running += 1
+            result = None
+            error = None
+            try:
+                result = task.fn(*task.args, **task.kwargs)
+            except BaseException as exc:  # noqa: BLE001 - publish through the Future
+                error = exc
+            finally:
+                with self._condition:
+                    self._running -= 1
+                    self._condition.notify_all()
+            if error is None:
+                task.future.set_result(result)
+            else:
+                task.future.set_exception(error)
+            # Do not retain the previous request while this thread is idle.
+            del task, result, error
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        with self._condition:
+            self._shutdown = True
+            pending = list(self._queued) if cancel_futures else []
+            self._condition.notify_all()
+        for future in pending:
+            future.cancel()
+        if wait:
+            for thread in self._threads:
+                thread.join()

--- a/atom/kv_transfer/offload/metadata.py
+++ b/atom/kv_transfer/offload/metadata.py
@@ -163,6 +163,7 @@ class LMCacheOffloadMetadata(ConnectorMetadata):
     #: asked to produce.
     WORK_FIELDS = ConnectorMetadata.WORK_FIELDS + (
         "requests",
+        "cancel_save_operations",
         "lookup_requests_in_step",
         "state_loads",
         "state_stores",
@@ -171,6 +172,8 @@ class LMCacheOffloadMetadata(ConnectorMetadata):
     def __init__(self) -> None:
         super().__init__()
         self.requests: list[LMCacheReqMeta] = []
+        # Cancellation is a request, never a source-safety acknowledgement.
+        self.cancel_save_operations: list[SaveOperationId] = []
         # req_ids whose worker-side lookup pin can be released this step.
         self.lookup_requests_in_step: list[str] = []
         # (req_id, state_hash, target_group) for the K3 state tier. A separate

--- a/atom/model_engine/engine_core.py
+++ b/atom/model_engine/engine_core.py
@@ -131,6 +131,7 @@ class EngineCore:
             self._post_model_load_hook()
             block_info = self.runner_mgr.call_func("get_num_blocks", wait_out=True)
             num_blocks = block_info["num_kvcache_blocks"]
+            config.kv_cache_block_bytes = int(block_info.get("kv_cache_block_bytes", 0))
             # Sizing happens in the runner subprocess, so nothing it wrote to
             # its own `config` is visible here. Carry the per-class entry table
             # across; BlockManager (built in Scheduler below) and the

--- a/atom/model_engine/llm_engine.py
+++ b/atom/model_engine/llm_engine.py
@@ -570,11 +570,26 @@ class LLMEngine:
             "saved_tokens",
             "loads_pending",
             "saves_pending",
+            "save_ops_admitted",
+            "save_tokens_admitted",
+            "save_ops_dropped",
+            "save_tokens_dropped",
+            "save_cancel_requests",
+            "save_ops_unretired",
+            "save_pending_bytes",
+            "source_blocks_reserved",
+            "source_blocks_leased",
         )
         offload_totals = {
             key: sum(int(stats.get(key, 0)) for stats in offload_rank_stats)
             for key in offload_keys
         }
+        # Ages share a wall-clock unit across independent DP schedulers. The
+        # oldest outstanding operation is their maximum, not a sum of ages.
+        offload_totals["save_oldest_age_ms"] = max(
+            (float(stats.get("save_oldest_age_ms", 0)) for stats in offload_rank_stats),
+            default=0.0,
+        )
 
         return {
             "enabled": bool(rank_stats),

--- a/atom/model_engine/model_runner.py
+++ b/atom/model_engine/model_runner.py
@@ -1633,6 +1633,16 @@ class ModelRunner:
             plan = plan.with_paged_entries(num_kvcache_blocks)
 
         block_bytes = plan.entry_bytes[plan.paged_class]
+        offload_block_bytes = block_bytes
+        if (
+            getattr(config, "kv_transfer_config", None)
+            and torch.distributed.is_initialized()
+        ):
+            byte_size = torch.tensor(
+                [block_bytes], dtype=torch.int64, device=self.device
+            )
+            torch.distributed.all_reduce(byte_size, op=torch.distributed.ReduceOp.MAX)
+            offload_block_bytes = int(byte_size.item())
         # The whole plan travels to the engine process; BlockManager, the
         # sliding-window pool and the attention builder each index it by the
         # class name they declared. Nothing here needs to know those names.
@@ -1755,6 +1765,7 @@ class ModelRunner:
         # the class they declared.
         return {
             "num_kvcache_blocks": num_kvcache_blocks,
+            "kv_cache_block_bytes": offload_block_bytes,
             "pool_entries": dict(plan.entries),
             "pool_entries_per_req": dict(plan.entries_per_req),
             "state_runtime": state_runtime.to_wire(),

--- a/atom/model_engine/scheduler.py
+++ b/atom/model_engine/scheduler.py
@@ -923,45 +923,21 @@ class Scheduler:
         self.block_manager.deallocate(seq)
 
     def _save_abandon_timeout_s(self) -> float:
-        """Seconds a deferred save may sit before reclamation, or 0 to disable.
+        """Connector-owned stall threshold, or zero when no connector defines it.
 
-        Sourced from the offload connector (`save_abandon_timeout_s`), not
-        re-derived here: the window is a function of LMCache's own pin timeout,
-        which is the connector's knowledge, and keeping the derivation in one
-        place is what stops the safety ordering (reclaim strictly after LMCache
-        force-unpins) from silently drifting. Returns 0 when no offload connector
-        is attached, which disables reclamation -- there is nothing to reclaim.
+        This threshold is not a GPU source fence. Connectors requiring safe
+        retirement use it to request cancellation and retain unsafe references.
         """
         callback = getattr(self.kv_connector, "save_abandon_timeout_s", None)
         return callback() if callable(callback) else 0.0
 
     def _reconcile_stalled_deferred_saves(self) -> int:
-        """Reclaim blocks whose offload save has stalled past the abandon timeout.
+        """Request cancellation of stalled saves, respecting source ownership.
 
-        `_maybe_release_deferred` cannot do this: the connector still reports the
-        save as pending (`should_defer_free` stays True), which is exactly why
-        the blocks were never released. Once the save has been deferred longer
-        than `_save_abandon_timeout_s()` -- set above LMCache's pin
-        timeout, so upstream has force-unpinned and released the source bytes --
-        the blocks are safe to return to the pool. Without this, a single
-        never-reported save keeps `has_pending_kv_work()` True forever and the
-        engine busy-loops with every GPU idle.
-
-        Mirrors the producer `finished_sending` reclaim (pop + deallocate),
-        deliberately not re-invoking `request_finished`: it was already called
-        when the request finished, before the block free was deferred. It does
-        notify the connector via `abandon_save`, though -- freeing the blocks
-        here is not enough on its own: the connector still holds the save in
-        `_save_inflight` (and, on K3, in the stall latch), so `should_defer_free`
-        would stay True and `has_pending_kv_work()` would never clear without
-        that drop.
-
-        The complement of the K3 connector's stall escape
-        (`kimi_k3.connector.save_stall_seconds()`), not a duplicate of it: that
-        one releases the blocks of a save the backend never took, on a shorter
-        clock, and leaves a save already handed out alone -- precisely the case
-        this reclaims once the report is not coming. Between them every deferred
-        save has a way out.
+        Dense/M3 advertises `requires_save_retirement`: neither exact leases nor
+        whole-request fallback allocations may be freed by elapsed time. Other
+        layouts retain their legacy abandonment behavior here. Request cleanup
+        has already run, so this hook must not create another final save.
         """
         timeout = self._save_abandon_timeout_s()
         if timeout <= 0:
@@ -997,10 +973,15 @@ class Scheduler:
             and now - seq._deferred_save_at >= timeout
         ]
         for seq in stalled:
+            if getattr(self.kv_connector, "requires_save_retirement", False):
+                self._connector_abandon_save(seq)
+                continue
             self.deferred_free_blocks.pop(seq.id, None)
             self._connector_abandon_save(seq)
             self.block_manager.deallocate(seq)
             self._abandoned_saves += 1
+        if getattr(self.kv_connector, "requires_save_retirement", False):
+            return lease_reclaims
         if stalled:
             logger.warning(
                 "Reclaimed %d offload save(s) still deferred after %.0fs with no "

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -202,8 +202,13 @@ discoverable from the central env reference despite bypassing the registry.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| **LMCACHE_EC_PIN_TIMEOUT_SEC** | float | LMCache's own (300) | LMCache's source-pin timeout. ATOM reads it only to derive the engine's save-abandon window (`pin + 30s`), so the two stay ordered — a lost store report is reclaimed only after LMCache would already have force-unpinned its source. Non-positive disables ATOM's reclamation. ATOM sets no default of its own; when unset it assumes LMCache's. |
+| **LMCACHE_EC_PIN_TIMEOUT_SEC** | float | LMCache's own (300) | LMCache's pin timeout, also used to derive ATOM's legacy save-abandon threshold (`pin + 30s`). This timeout does not prove GPU sources are safe: Dense/M3 only requests cancellation and waits for all-rank source safety. Non-positive disables the legacy threshold. |
 | **OFFLOAD_MAX_PENDING_SAVES** | int | **2**, flat, for the engine-side/state-tier reader (`scheduler.py`); `max(2, 2 × OFFLOAD_COPY_WORKERS)` for the KV-leg reader (`_offload_common.py`) | Bound on total in-flight offload transfers (running + queued) held before a SLOT snapshot or executor submission. A KV save and a state store both pin bytes out of the same pool while they run, so the KV leg and the K3 state tier share this one number rather than each carrying its own. Two readers compute it, though: the KV leg's canonical `_offload_common.max_pending_saves` derives the shown default from `OFFLOAD_COPY_WORKERS` and **raises** on an unparseable value, while the scheduler's state-tier reader (`_offload_max_pending_saves`) has a simpler fallback — a flat default of **2** (no `OFFLOAD_COPY_WORKERS` scaling) that **warns and uses 2** on an unparseable value rather than raising. Set the env to an explicit integer to pin both. |
+| **OFFLOAD_SAVE_ADMISSION** | bool | 1 | Dense/M3 PAGE save capacity gates; `0` disables limits while retaining safe cancellation and retirement. |
+| **OFFLOAD_MAX_RESERVED_SOURCE_BLOCKS** | int | 10% of PAGE pool, rounded down, minimum 1 | Unsafe source-block budget, including sources of live requests. |
+| **OFFLOAD_MAX_PENDING_SAVE_BYTES** | int | source cap × measured block bytes | Candidate bytes reserved until store outcome and safe retirement. |
+| **OFFLOAD_MAX_PENDING_SAVE_TOKENS** | int | source cap × virtual block size (131072 with unknown pool), only when byte geometry is absent | Optional token budget / byte-geometry fallback. |
+| **OFFLOAD_SAVE_QUEUE_TIMEOUT_S** | float | 2 | Attempt cancellation once at this age after admission; `0` disables age-based attempts. A running save is never freed merely because it is old. |
 
 ## Profiling & debugging
 

--- a/tests/entrypoints/test_metrics.py
+++ b/tests/entrypoints/test_metrics.py
@@ -12,10 +12,11 @@ invisible until someone profiles a scrape.
 from __future__ import annotations
 
 import gc
+from types import SimpleNamespace
 
 from prometheus_client import CollectorRegistry, generate_latest
 
-from atom.entrypoints.openai.metrics import _gc_metrics
+from atom.entrypoints.openai.metrics import AtomMetricsExporter, _gc_metrics
 
 
 def _render() -> str:
@@ -82,3 +83,118 @@ def test_every_generation_is_labelled_rather_than_summed():
 
     for generation in ("0", "1", "2"):
         assert f'atom:gc_collections_total{{generation="{generation}"}}' in exposition
+
+
+def _offload_snapshot(*offload_stats):
+    from atom.model_engine.llm_engine import LLMEngine
+
+    engine = SimpleNamespace(
+        core_mgr=SimpleNamespace(
+            latest_metrics={
+                rank: {"enabled": True, "offload": stats}
+                for rank, stats in enumerate(offload_stats)
+            },
+            get_dp_router_statistics=dict,
+        )
+    )
+    return LLMEngine.get_metrics_statistics(engine)
+
+
+def _offload_samples(exporter):
+    from prometheus_client.parser import text_string_to_metric_families
+
+    exposition = exporter.render().decode()
+    families = {
+        family.name: family
+        for family in text_string_to_metric_families(exposition)
+        if family.name.startswith("atom:lmcache_")
+    }
+    values = {
+        sample.name: sample.value
+        for family in families.values()
+        for sample in family.samples
+    }
+    return families, values
+
+
+def test_offload_admission_metrics_reach_prometheus_with_correct_dp_aggregation():
+    """Exercise the runtime snapshot -> public metric contract, including units.
+
+    Missing aggregator keys previously made valid scheduler counters invisible.
+    Capacity counts sum across DP schedulers, while the oldest age must not.
+    """
+    exporter = AtomMetricsExporter()
+    exporter.update(
+        _offload_snapshot(
+            {
+                "save_ops_admitted": 10,
+                "save_tokens_admitted": 1024,
+                "save_ops_dropped": 2,
+                "save_tokens_dropped": 256,
+                "save_cancel_requests": 1,
+                "save_ops_unretired": 2,
+                "save_pending_bytes": 4096,
+                "source_blocks_reserved": 12,
+                "source_blocks_leased": 5,
+                "save_oldest_age_ms": 1750.5,
+            },
+            {
+                "save_ops_admitted": 4,
+                "save_tokens_admitted": 512,
+                "save_ops_dropped": 3,
+                "save_tokens_dropped": 128,
+                "save_cancel_requests": 2,
+                "save_ops_unretired": 1,
+                "save_pending_bytes": 2048,
+                "source_blocks_reserved": 4,
+                "source_blocks_leased": 2,
+                "save_oldest_age_ms": 2500.25,
+            },
+        )
+    )
+    families, samples = _offload_samples(exporter)
+    expected_counters = {
+        "save_ops_admitted": 14,
+        "save_tokens_admitted": 1536,
+        "save_ops_dropped": 5,
+        "save_tokens_dropped": 384,
+        "save_cancel_requests": 3,
+    }
+    expected_gauges = {
+        "save_ops_unretired": 3,
+        "save_pending_bytes": 6144,
+        "source_blocks_reserved": 16,
+        "source_blocks_leased": 7,
+        "save_oldest_age_seconds": 2.50025,
+    }
+    for suffix, value in expected_counters.items():
+        name = f"atom:lmcache_{suffix}"
+        assert families[name].type == "counter"
+        assert samples[f"{name}_total"] == value
+    for suffix, value in expected_gauges.items():
+        name = f"atom:lmcache_{suffix}"
+        assert families[name].type == "gauge"
+        assert samples[name] == value
+
+    exporter.update(_offload_snapshot({"saved_tokens": 64}, {}))
+    _, idle_samples = _offload_samples(exporter)
+    for suffix in expected_gauges:
+        assert idle_samples[f"atom:lmcache_{suffix}"] == 0
+
+
+def test_offload_metrics_keep_legacy_snapshots_and_explain_store_counts():
+    exporter = AtomMetricsExporter()
+    exporter.update(_offload_snapshot({"save_requests": 2, "saved_tokens": 128}))
+    families, samples = _offload_samples(exporter)
+    assert samples["atom:lmcache_save_requests_total"] == 2
+    assert samples["atom:lmcache_saved_tokens_total"] == 128
+    assert samples["atom:lmcache_save_ops_admitted_total"] == 0
+    assert samples["atom:lmcache_save_oldest_age_seconds"] == 0
+    assert "candidate tokens" in families["atom:lmcache_saved_tokens"].documentation
+    assert (
+        "not actual persisted tokens"
+        in families["atom:lmcache_saved_tokens"].documentation
+    )
+    assert (
+        "source is already safe" in families["atom:lmcache_saves_pending"].documentation
+    )

--- a/tests/test_dense_offload_connector.py
+++ b/tests/test_dense_offload_connector.py
@@ -7,16 +7,20 @@ import pytest
 
 from atom.kv_transfer.disaggregation.aggregator import KVOutputAggregator
 from atom.kv_transfer.disaggregation.types import (
+    ConnectorCompletion,
     KVConnectorOutput,
     LoadOperationId,
     SaveOperationId,
 )
 from atom.kv_transfer.offload import config as offcfg
 from atom.kv_transfer.offload.dense.connector import (
+    DENSE_PAGE_RETIRED_CHANNEL,
+    DENSE_PAGE_STORE_CHANNEL,
     DenseOffloadConnector,
     DenseOffloadScheduler,
 )
 from atom.kv_transfer.offload.metadata import (
+    LMCacheOffloadMetadata,
     LMCacheReqMeta,
     LoadSpec,
     SaveSpec,
@@ -76,6 +80,15 @@ def _engine_scheduler(connector):
     scheduler.failed_recving_kv_req_ids = []
     scheduler.deferred_free_blocks = {}
     return scheduler
+
+
+def _retire_save(scheduler, operation):
+    scheduler.connector_completion(
+        ConnectorCompletion(DENSE_PAGE_STORE_CHANNEL, operation, True)
+    )
+    scheduler.connector_completion(
+        ConnectorCompletion(DENSE_PAGE_RETIRED_CHANNEL, operation, True)
+    )
 
 
 @pytest.mark.parametrize(
@@ -251,6 +264,8 @@ def test_dense_build_save_metadata_uses_increasing_exact_generations(monkeypatch
     first_meta = scheduler.build_connector_meta()
     first = first_meta.requests[0].save_operation
     scheduler.save_finished(first)
+    assert scheduler._save_inflight["12"] == first
+    _retire_save(scheduler, first)
     seq.num_cached_tokens = 16
     second_meta = scheduler.build_connector_meta()
     second = second_meta.requests[0].save_operation
@@ -268,16 +283,19 @@ def test_dense_stale_or_raw_save_completion_cannot_clear_exact_lifecycle(
     scheduler.update_state_after_alloc(seq)
     seq.num_cached_tokens = 8
     stale = scheduler.build_connector_meta().requests[0].save_operation
-    scheduler.save_finished(stale)
+    _retire_save(scheduler, stale)
 
     seq.num_cached_tokens = 16
     current = scheduler.build_connector_meta().requests[0].save_operation
     scheduler.save_finished(stale)
     scheduler.save_finished(seq.id)
+    _retire_save(scheduler, stale)
 
     assert scheduler._save_inflight["13"] == current
 
     scheduler.save_finished(current)
+    assert scheduler._save_inflight["13"] == current
+    _retire_save(scheduler, current)
     assert "13" not in scheduler._save_inflight
 
     # A raw completion remains compatible with an explicitly legacy lifecycle.
@@ -304,7 +322,8 @@ def test_dense_worker_exact_save_generations_do_not_form_cross_tp_quorum():
                     gpu_connector=None,
                     store=lambda _tokens, **_kwargs: None,
                 )
-            worker._do_save_req(
+            metadata = LMCacheOffloadMetadata()
+            metadata.add_request(
                 LMCacheReqMeta(
                     req_id=14,
                     token_ids=list(range(8)),
@@ -313,6 +332,8 @@ def test_dense_worker_exact_save_generations_do_not_form_cross_tp_quorum():
                     save_operation=operation,
                 )
             )
+            worker.start_load_kv(metadata)
+            worker.close()
             outputs.append(worker.get_finished())
 
         assert outputs[0].finished_saving == {operations[0]}

--- a/tests/test_dense_save_admission.py
+++ b/tests/test_dense_save_admission.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+"""Admission protects foreground capacity without weakening source ownership."""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from atom.kv_transfer.disaggregation.types import ConnectorCompletion, SaveOperationId
+from atom.kv_transfer.offload import config as offcfg
+from atom.kv_transfer.offload.dense.connector import (
+    DENSE_PAGE_RETIRED_CHANNEL,
+    DENSE_PAGE_STORE_CHANNEL,
+    DenseOffloadScheduler,
+)
+from atom.kv_transfer.offload.dense.save_admission import build_save_budget
+from atom.model_engine.scheduler import Scheduler
+
+
+def scheduler(monkeypatch, **env):
+    for key, value in env.items():
+        monkeypatch.setenv(key, str(value))
+    monkeypatch.setattr(
+        offcfg, "build_lmcache_config", lambda _: SimpleNamespace(chunk_size=8)
+    )
+    monkeypatch.setattr(offcfg, "build_lmcache_metadata", lambda *_: object())
+    config = SimpleNamespace(
+        kv_transfer_config={"kv_role": "kv_producer"},
+        kv_cache_block_size=4,
+        tensor_parallel_size=1,
+        num_kvcache_blocks=1000,
+        kv_cache_block_bytes=128,
+    )
+    return DenseOffloadScheduler(config)
+
+
+def seq(req_id, tokens=8, first=0):
+    return SimpleNamespace(
+        id=req_id,
+        num_cached_tokens=tokens,
+        num_prompt_tokens=tokens,
+        token_ids=list(range(tokens)),
+        block_table=list(range(first, first + tokens // 4)),
+    )
+
+
+def outcome(s, op, ok=True):
+    s.connector_completion(ConnectorCompletion(DENSE_PAGE_STORE_CHANNEL, op, ok))
+
+
+def retired(s, op):
+    s.connector_completion(ConnectorCompletion(DENSE_PAGE_RETIRED_CHANNEL, op, True))
+
+
+def test_ten_finishes_admit_two_and_never_lease_the_other_eight(monkeypatch):
+    s = scheduler(monkeypatch)
+    requests = [seq(i, first=2 * i) for i in range(10)]
+    for request in requests:
+        s.update_state_after_alloc(request)
+        s.request_finished(request)
+        s.activate_block_leases(request, s.protected_block_ids(request))
+    metadata = s.build_connector_meta()
+    assert [r.req_id for r in metadata.requests] == [0, 1]
+    assert [len(s.protected_block_ids(q)) for q in requests] == [2, 2] + [0] * 8
+    stats = s.get_statistics()
+    assert stats["save_ops_admitted"] == 2
+    assert stats["save_ops_dropped"] == 8
+    assert stats["save_tokens_dropped"] == 64
+    assert stats["source_blocks_reserved"] == stats["source_blocks_leased"] == 4
+    assert stats["save_pending_bytes"] == 512
+    for request in metadata.requests:
+        outcome(s, request.save_operation)
+        retired(s, request.save_operation)
+    assert s.take_source_safe_releases() == [frozenset({0, 1}), frozenset({2, 3})]
+    assert not s.has_pending_work()
+
+
+def test_source_budget_counts_live_requests_before_any_lease(monkeypatch):
+    s = scheduler(monkeypatch, OFFLOAD_MAX_RESERVED_SOURCE_BLOCKS=100)
+    for i in range(2):
+        s.update_state_after_alloc(seq(i, tokens=240, first=i * 60))
+    metadata = s.build_connector_meta()
+    assert len(metadata.requests) == 1
+    assert s.get_statistics()["source_blocks_reserved"] == 60
+    assert s.get_statistics()["source_blocks_leased"] == 0
+    assert s.get_statistics()["save_tokens_dropped"] == 240
+
+
+@pytest.mark.parametrize("first", ["outcome", "retired"])
+@pytest.mark.parametrize("ok", [False, True])
+def test_credit_requires_both_outcome_and_source_retirement(monkeypatch, first, ok):
+    s = scheduler(monkeypatch, OFFLOAD_MAX_PENDING_SAVES=1)
+    q = seq(1)
+    s.update_state_after_alloc(q)
+    op = s.build_connector_meta().requests[0].save_operation
+    if first == "outcome":
+        outcome(s, op, ok)
+        assert s.get_statistics()["source_blocks_reserved"] == 2
+    else:
+        retired(s, op)
+        assert s.get_statistics()["source_blocks_reserved"] == 0
+    assert s.get_statistics()["save_ops_unretired"] == 1
+    assert s.get_statistics()["save_pending_bytes"] == 256
+    assert s.total_save_requests == 0
+    if first == "outcome":
+        retired(s, op)
+    else:
+        outcome(s, op, ok)
+    assert s.get_statistics()["save_ops_unretired"] == 0
+    assert s.get_statistics()["save_pending_bytes"] == 0
+    assert s.total_save_requests == int(ok)
+    # Duplicate reports cannot return a second operation credit.
+    retired(s, op)
+    outcome(s, op, ok)
+    assert s.total_save_requests == int(ok)
+
+
+def test_final_tail_is_dropped_while_a_prior_save_owns_sources(monkeypatch):
+    s = scheduler(monkeypatch)
+    q = seq(1, tokens=32)
+    q.num_cached_tokens = 8
+    s.update_state_after_alloc(q)
+    op = s.build_connector_meta().requests[0].save_operation
+    q.num_cached_tokens = 32
+    s.request_finished(q)
+    s.request_finished(q)  # streaming and teardown both invoke this hook
+    assert s.protected_block_ids(q) == frozenset({0, 1})
+    assert s.get_statistics()["save_tokens_dropped"] == 24
+    q.block_table.clear()
+    outcome(s, op)
+    retired(s, op)
+    assert s.build_connector_meta().requests == []
+    assert not s.has_pending_work()
+
+
+def test_drop_survives_realloc_and_failed_load_but_not_request_id_reuse(monkeypatch):
+    s = scheduler(monkeypatch, OFFLOAD_MAX_PENDING_SAVES=1)
+    holding = seq(0)
+    old = seq(1, tokens=16, first=10)
+    old.num_cached_tokens = 8
+    for q in (holding, old):
+        s.update_state_after_alloc(q)
+    op = s.build_connector_meta().requests[0].save_operation
+    outcome(s, op)
+    retired(s, op)
+    old.num_cached_tokens = 16
+    s.update_state_after_alloc(old)
+    s._load_save_floors["1"] = 0
+    assert s.load_failed(1)
+    assert s.build_connector_meta().requests == []
+    assert s.get_statistics()["save_tokens_dropped"] == 16
+    new = seq(1, tokens=8, first=20)
+    s.update_state_after_alloc(new)
+    assert s.build_connector_meta().requests[0].block_ids == [20, 21]
+
+
+def test_reused_id_admits_a_new_lifecycle_without_releasing_the_old_one(monkeypatch):
+    s = scheduler(monkeypatch)
+    old, new = seq(1), seq(1, first=10)
+    s.update_state_after_alloc(old)
+    old_op = s.build_connector_meta().requests[0].save_operation
+    s.request_finished(old)
+    s.activate_block_leases(old, s.protected_block_ids(old))
+    outcome(s, old_op, False)
+    s.update_state_after_alloc(new)
+    new_op = s.build_connector_meta().requests[0].save_operation
+    retired(s, old_op)
+    assert s._save_inflight["1"] == new_op
+    assert s.take_source_safe_releases() == [frozenset({0, 1})]
+    assert s.protected_block_ids(new) == frozenset({10, 11})
+    assert s._save_tracker["1"][0] is new
+
+
+def test_age_requests_cancel_once_and_never_frees_sources(monkeypatch):
+    s = scheduler(monkeypatch)
+    q = seq(1)
+    s.update_state_after_alloc(q)
+    op = s.build_connector_meta().requests[0].save_operation
+    s.request_finished(q)
+    s.activate_block_leases(q, s.protected_block_ids(q))
+    s._save_budget.operations[op].created_at -= 10
+    metadata = s.build_connector_meta()
+    assert metadata.requests == []
+    assert metadata.cancel_save_operations == [op]
+    assert metadata.has_work()
+    assert s.build_connector_meta().cancel_save_operations == []
+    assert s.take_source_safe_releases() == []
+    assert s.get_statistics()["save_cancel_requests"] == 1
+    assert s.get_statistics()["source_blocks_leased"] == 2
+    outcome(s, op, False)
+    assert s.take_source_safe_releases() == []
+    retired(s, op)
+    assert s.take_source_safe_releases() == [frozenset({0, 1})]
+
+
+def test_engine_timeout_cannot_bypass_dense_retirement(monkeypatch):
+    s = scheduler(monkeypatch)
+    q = seq(1)
+    s.update_state_after_alloc(q)
+    s.build_connector_meta()
+    q._deferred_save_at = time.monotonic() - 1000
+    engine = Scheduler.__new__(Scheduler)
+    engine.kv_connector = s
+    engine.deferred_free_blocks = {q.id: q}
+    engine._next_save_reconcile_at = 0
+    engine._abandoned_saves = 0
+    engine.block_manager = SimpleNamespace(
+        deallocate=lambda _: pytest.fail("unsafe block free")
+    )
+    assert engine._reconcile_stalled_deferred_saves() == 0
+    assert engine.deferred_free_blocks == {q.id: q}
+    assert s.get_statistics()["save_cancel_requests"] == 1
+
+
+def test_byte_budget_remains_after_source_safe_until_backend_retires(monkeypatch):
+    s = scheduler(monkeypatch, OFFLOAD_MAX_PENDING_SAVE_BYTES=256)
+    first = seq(1)
+    s.update_state_after_alloc(first)
+    op = s.build_connector_meta().requests[0].save_operation
+    retired(s, op)
+    s.update_state_after_alloc(seq(2, first=10))
+    assert s.build_connector_meta().requests == []
+    assert s.get_statistics()["source_blocks_reserved"] == 0
+    assert s.get_statistics()["save_pending_bytes"] == 256
+    assert s.get_statistics()["save_ops_dropped"] == 1
+
+
+def test_geometry_sets_byte_budget_and_control_preserves_accounting(monkeypatch):
+    s = scheduler(monkeypatch)
+    assert s._save_budget.max_source_blocks == 100
+    assert s._save_budget.max_pending_bytes == 12800
+    monkeypatch.setenv("OFFLOAD_SAVE_ADMISSION", "0")
+    budget = build_save_budget(s._config, 4)
+    for generation in range(10):
+        assert (
+            budget.reserve(SaveOperationId(generation, generation), range(1000), 4000)
+            is None
+        )
+    assert budget.source_blocks == 10000
+    assert budget.pending_bytes == 1280000
+
+
+def test_metadata_construction_failure_does_not_reserve_or_advance(monkeypatch):
+    from atom.kv_transfer.offload.dense import connector
+
+    s = scheduler(monkeypatch)
+    q = seq(1)
+    s.update_state_after_alloc(q)
+
+    def fail(**kwargs):
+        raise RuntimeError("metadata construction failed")
+
+    monkeypatch.setattr(connector, "LMCacheReqMeta", fail)
+    with pytest.raises(RuntimeError, match="metadata construction failed"):
+        s.build_connector_meta()
+    assert s._save_budget.operations == {}
+    assert s._save_operation_blocks == {}
+    assert s._save_tracker["1"][1] == 0
+    assert s.get_statistics()["save_ops_admitted"] == 0
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        "OFFLOAD_MAX_PENDING_SAVE_BYTES",
+        "OFFLOAD_MAX_RESERVED_SOURCE_BLOCKS",
+        "OFFLOAD_MAX_PENDING_SAVE_TOKENS",
+    ],
+)
+def test_invalid_budget_fails_at_startup(monkeypatch, env):
+    with pytest.raises(ValueError, match="positive integer"):
+        scheduler(monkeypatch, **{env: 0})

--- a/tests/test_dense_save_aggregation.py
+++ b/tests/test_dense_save_aggregation.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+from atom.kv_transfer.disaggregation.aggregator import KVOutputAggregator
+from atom.kv_transfer.disaggregation.types import (
+    ConnectorCompletion,
+    KVConnectorOutput,
+    SaveOperationId,
+    SaveSourceGroupId,
+)
+
+
+def _report(channel, operation, succeeded=True):
+    return ConnectorCompletion(channel, operation, succeeded)
+
+
+def _output(*completions):
+    return KVConnectorOutput(connector_completions=set(completions))
+
+
+def _source(operation, start=0):
+    return _report(
+        "dense.page.source_safe", SaveSourceGroupId(operation, ((start, start + 8),))
+    )
+
+
+def _retired(operation, succeeded=True):
+    return _report("dense.page.retired", operation, succeeded)
+
+
+def test_mixed_never_started_rank_drops_groups_only_after_full_retirement():
+    aggregator = KVOutputAggregator(world_size=2)
+    operation = SaveOperationId("request", 1)
+    first, second = _source(operation), _source(operation, 8)
+    never_started = _report("dense.page.store", operation, False)
+
+    result = aggregator.aggregate(
+        [_output(first, second), _output(never_started, _retired(operation))]
+    )
+    assert result.connector_completions == set()
+    assert aggregator.pending_count == (0, 4)
+
+    result = aggregator.aggregate([_output(_retired(operation)), _output()])
+    assert result.connector_completions == {_retired(operation)}
+    assert aggregator.pending_count == (0, 1)  # unfinished store outcome survives
+
+    result = aggregator.aggregate(
+        [_output(_report("dense.page.store", operation)), _output()]
+    )
+    assert result.connector_completions == {never_started}
+    assert aggregator.pending_count == (0, 0)
+    assert aggregator.aggregate([_output(first, second), _output()]).is_empty()
+    assert aggregator.pending_count == (0, 0)
+
+
+def test_older_running_generation_is_not_suppressed_by_newer_retirement():
+    aggregator = KVOutputAggregator(world_size=2)
+    older, newer = SaveOperationId("old", 1), SaveOperationId("new", 2)
+    older_group, newer_group = _source(older), _source(newer)
+    aggregator.aggregate([_output(older_group, newer_group), _output()])
+    aggregator.aggregate([_output(_retired(newer)), _output(_retired(newer))])
+    assert aggregator.pending_count == (0, 1)
+
+    result = aggregator.aggregate([_output(), _output(older_group)])
+    assert result.connector_completions == {older_group}
+    result = aggregator.aggregate([_output(_retired(older)), _output(_retired(older))])
+    assert result.connector_completions == {_retired(older)}
+    assert aggregator.pending_count == (0, 0)
+    assert aggregator._retired_dense_generations._intervals == [(1, 2)]
+
+
+def test_retirement_tombstones_survive_bounded_group_tombstone_eviction():
+    aggregator = KVOutputAggregator(world_size=2, terminal_tombstone_limit=2)
+    oldest = SaveOperationId("1", 1)
+    for generation in range(1, 101):
+        operation = SaveOperationId(str(generation), generation)
+        aggregator.aggregate([_output(_source(operation)), _output()])
+        result = aggregator.aggregate(
+            [_output(_retired(operation)), _output(_retired(operation))]
+        )
+        assert result.connector_completions == {_retired(operation)}
+        assert aggregator.pending_count == (0, 0)
+    assert aggregator._retired_dense_generations._intervals == [(1, 100)]
+
+    late = _output(_source(oldest), _retired(oldest))
+    assert aggregator.aggregate([late, _output()]).is_empty()
+    assert aggregator.aggregate([_output(), late]).is_empty()
+    assert aggregator.pending_count == (0, 0)
+
+
+def test_failed_retirement_does_not_authorize_group_cleanup():
+    aggregator = KVOutputAggregator(world_size=2)
+    operation = SaveOperationId("request", 1)
+    group = _source(operation)
+    result = aggregator.aggregate(
+        [_output(group, _retired(operation)), _output(_retired(operation, False))]
+    )
+    assert result.connector_completions == {_retired(operation, False)}
+    assert aggregator.pending_count == (0, 1)
+    result = aggregator.aggregate([_output(), _output(group)])
+    assert result.connector_completions == {group}
+    assert aggregator.pending_count == (0, 0)
+
+
+def test_retirement_does_not_discard_other_channels_or_store_results():
+    aggregator = KVOutputAggregator(world_size=2)
+    operation = SaveOperationId("request", 1)
+    unrelated = _report("other.page.source_safe", _source(operation).operation_id)
+    store = _report("dense.page.store", operation)
+    aggregator.aggregate([_output(unrelated, store), _output()])
+    aggregator.aggregate([_output(_retired(operation)), _output(_retired(operation))])
+    assert aggregator.pending_count == (0, 2)
+    result = aggregator.aggregate([_output(), _output(unrelated, store)])
+    assert result.connector_completions == {unrelated, store}
+    assert aggregator.pending_count == (0, 0)
+
+
+def test_reset_clears_retired_generation_fences_for_new_scheduler_lifetime():
+    aggregator = KVOutputAggregator(world_size=2)
+    operation = SaveOperationId("request", 1)
+    aggregator.aggregate([_output(_retired(operation)), _output(_retired(operation))])
+    aggregator.reset()
+    group = _source(operation)
+    result = aggregator.aggregate([_output(group), _output(group)])
+    assert result.connector_completions == {group}

--- a/tests/test_dense_save_worker.py
+++ b/tests/test_dense_save_worker.py
@@ -1,0 +1,498 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+
+import threading
+import weakref
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+from atom.kv_transfer.disaggregation.types import (
+    ConnectorCompletion,
+    SaveOperationId,
+    SaveSourceGroupId,
+)
+from atom.kv_transfer.offload.dense.connector import (
+    DENSE_PAGE_RETIRED_CHANNEL,
+    DENSE_PAGE_SOURCE_SAFE_CHANNEL,
+    DENSE_PAGE_STORE_CHANNEL,
+    DenseOffloadConnector,
+)
+from atom.kv_transfer.offload.dense.save_executor import (
+    CancellableSaveExecutor,
+    SaveQueueFull,
+    SeenSaveGenerations,
+)
+from atom.kv_transfer.offload.metadata import (
+    LMCacheOffloadMetadata,
+    LMCacheReqMeta,
+    LoadSpec,
+    SaveSpec,
+)
+
+
+def _worker(monkeypatch, *, capacity=2, admission=True, cls=DenseOffloadConnector):
+    monkeypatch.setenv("OFFLOAD_COPY_WORKERS", "1")
+    monkeypatch.setenv("OFFLOAD_SAVE_ADMISSION", "1" if admission else "0")
+    monkeypatch.setenv("OFFLOAD_MAX_PENDING_SAVES", str(capacity))
+    worker = cls(
+        SimpleNamespace(
+            kv_transfer_config={"kv_role": "offload"},
+            kv_cache_block_size=4,
+            decode_context_parallel_size=1,
+        )
+    )
+    worker.chunk_size = 8
+    return worker
+
+
+def _request(generation):
+    return LMCacheReqMeta(
+        req_id=str(generation),
+        token_ids=list(range(8)),
+        block_ids=[2 * generation, 2 * generation + 1],
+        save_spec=SaveSpec(skip_leading_tokens=0),
+        save_operation=SaveOperationId(str(generation), generation),
+    )
+
+
+def _metadata(*requests, cancellations=()):
+    metadata = LMCacheOffloadMetadata()
+    metadata.requests.extend(requests)
+    metadata.cancel_save_operations = list(cancellations)
+    return metadata
+
+
+def _completion(channel, operation, succeeded=True):
+    return ConnectorCompletion(channel, operation, succeeded)
+
+
+def test_cancelled_tasks_release_physical_queue_and_request_metadata():
+    executor = CancellableSaveExecutor(
+        max_workers=1, capacity=2, thread_name_prefix="test-save"
+    )
+    entered, release = threading.Event(), threading.Event()
+
+    def block():
+        entered.set()
+        assert release.wait(5)
+
+    class Payload:
+        pass
+
+    try:
+        running = executor.submit(block)
+        assert entered.wait(5)
+        assert not running.cancel()
+        for _ in range(100):
+            payload = Payload()
+            reference = weakref.ref(payload)
+            pending = executor.submit(
+                lambda value: pytest.fail("cancelled task ran"), payload
+            )
+            with pytest.raises(SaveQueueFull):
+                executor.submit(lambda: None)
+            assert pending.cancel()
+            assert pending.cancel()  # repeated cancellation has no extra release
+            del payload
+            assert reference() is None
+            assert executor.counts() == (0, 1)
+            assert len(executor._queue) == len(executor._queued) == 0
+    finally:
+        release.set()
+        executor.shutdown()
+
+
+def test_executor_releases_capacity_before_done_callback():
+    executor = CancellableSaveExecutor(
+        max_workers=1, capacity=1, thread_name_prefix="test-save"
+    )
+    entered, release, callback_done = (
+        threading.Event(),
+        threading.Event(),
+        threading.Event(),
+    )
+    followups = []
+
+    def block():
+        entered.set()
+        assert release.wait(5)
+
+    def completed(_future):
+        followups.append(executor.submit(lambda: 42))
+        callback_done.set()
+
+    try:
+        future = executor.submit(block)
+        assert entered.wait(5)
+        future.add_done_callback(completed)
+        release.set()
+        assert callback_done.wait(5)
+        assert followups[0].result(timeout=5) == 42
+    finally:
+        release.set()
+        executor.shutdown()
+
+
+def test_executor_submission_failure_leaves_no_task_or_capacity_reservation():
+    executor = CancellableSaveExecutor(
+        max_workers=1, capacity=1, thread_name_prefix="test-save"
+    )
+
+    class RejectingQueue(deque):
+        def append(self, _task):
+            raise RuntimeError("cannot enqueue")
+
+    try:
+        executor._queue = RejectingQueue()
+        with pytest.raises(RuntimeError, match="cannot enqueue"):
+            executor.submit(lambda: pytest.fail("failed submission ran"))
+        assert executor.counts() == (0, 0)
+        assert not executor._queued
+        executor._queue = deque()
+        assert executor.submit(lambda: 42).result(timeout=5) == 42
+    finally:
+        executor.shutdown()
+
+
+def test_seen_generation_intervals_allow_out_of_order_cancellation():
+    generations = SeenSaveGenerations()
+    for generation in (5, 1, 2, 4, 3):
+        assert generations.remember(generation)
+    assert generations._intervals == [(1, 5)]
+    for generation in range(1, 6):
+        assert not generations.remember(generation)
+    for generation in range(6, 1000):
+        assert generations.remember(generation)
+    assert generations._intervals == [(1, 999)]
+
+
+def test_worker_normal_return_publishes_result_and_retirement(monkeypatch):
+    worker = _worker(monkeypatch)
+    request = _request(1)
+    observations = []
+
+    def store(_tokens, **_kwargs):
+        observations.append(worker.get_finished())
+
+    worker._engine = SimpleNamespace(gpu_connector=None, store=store)
+    try:
+        worker.start_load_kv(_metadata(request))
+        worker.close()
+        assert observations[0].finished_saving == set()
+        output = worker.get_finished()
+        assert output.finished_saving == {request.save_operation}
+        assert output.connector_completions == {
+            _completion(DENSE_PAGE_STORE_CHANNEL, request.save_operation),
+            _completion(DENSE_PAGE_RETIRED_CHANNEL, request.save_operation),
+        }
+        assert worker._save_futures == {}
+        assert worker._save_executor.counts() == (0, 0)
+    finally:
+        worker.close()
+
+
+def test_worker_queue_rejection_is_safe_without_cancelling_running_save(monkeypatch):
+    worker = _worker(monkeypatch, capacity=1)
+    entered, release = threading.Event(), threading.Event()
+    first, second = _request(1), _request(2)
+    calls = []
+
+    def store(_tokens, *, req_id, **_kwargs):
+        calls.append(req_id)
+        entered.set()
+        assert release.wait(5)
+
+    worker._engine = SimpleNamespace(gpu_connector=None, store=store)
+    try:
+        worker.start_load_kv(_metadata(first))
+        assert entered.wait(5)
+        worker.start_load_kv(_metadata(second))
+        output = worker.get_finished()
+        assert output.finished_saving == {second.save_operation}
+        assert output.connector_completions == {
+            _completion(DENSE_PAGE_STORE_CHANNEL, second.save_operation, False),
+            _completion(DENSE_PAGE_RETIRED_CHANNEL, second.save_operation),
+        }
+        worker.start_load_kv(_metadata(cancellations=[first.save_operation]))
+        assert worker.get_finished().is_empty()
+        assert worker._save_executor.counts() == (0, 1)
+        worker.start_load_kv(_metadata(second))
+        assert worker.get_finished().is_empty()
+        assert calls == ["1"]
+    finally:
+        release.set()
+        worker.close()
+    assert worker.get_finished().finished_saving == {first.save_operation}
+
+
+def test_worker_queued_cancel_removes_future_and_prevents_late_dispatch(monkeypatch):
+    worker = _worker(monkeypatch)
+    entered, release = threading.Event(), threading.Event()
+    first, second = _request(1), _request(2)
+    calls = []
+
+    def store(_tokens, *, req_id, **_kwargs):
+        calls.append(req_id)
+        entered.set()
+        assert release.wait(5)
+
+    worker._engine = SimpleNamespace(gpu_connector=None, store=store)
+    try:
+        worker.start_load_kv(_metadata(first))
+        assert entered.wait(5)
+        worker.start_load_kv(_metadata(second))
+        assert worker._save_executor.counts() == (1, 1)
+        worker.start_load_kv(_metadata(cancellations=[second.save_operation]))
+        assert worker._save_executor.counts() == (0, 1)
+        assert second.save_operation not in worker._save_futures
+        output = worker.get_finished()
+        assert output.finished_saving == {second.save_operation}
+        assert (
+            _completion(DENSE_PAGE_STORE_CHANNEL, second.save_operation, False)
+            in output.connector_completions
+        )
+        worker.start_load_kv(_metadata(second))
+    finally:
+        release.set()
+        worker.close()
+    assert calls == ["1"]
+
+
+def test_worker_cancel_before_dispatch_and_duplicate_completion(monkeypatch):
+    worker = _worker(monkeypatch)
+    request = _request(2)
+    worker._engine = SimpleNamespace(
+        gpu_connector=None,
+        store=lambda *_args, **_kwargs: pytest.fail("cancelled save ran"),
+    )
+    try:
+        worker.start_load_kv(_metadata(request, cancellations=[request.save_operation]))
+        output = worker.get_finished()
+        assert output.finished_saving == {request.save_operation}
+        assert output.connector_completions == {
+            _completion(DENSE_PAGE_STORE_CHANNEL, request.save_operation, False),
+            _completion(DENSE_PAGE_RETIRED_CHANNEL, request.save_operation),
+        }
+        worker.start_load_kv(_metadata(request, cancellations=[request.save_operation]))
+        assert worker.get_finished().is_empty()
+    finally:
+        worker.close()
+
+
+def test_worker_duplicate_active_and_retired_dispatch_runs_once(monkeypatch):
+    worker = _worker(monkeypatch)
+    entered, release = threading.Event(), threading.Event()
+    request = _request(1)
+    calls = []
+
+    def store(_tokens, **_kwargs):
+        calls.append(True)
+        entered.set()
+        assert release.wait(5)
+
+    worker._engine = SimpleNamespace(gpu_connector=None, store=store)
+    try:
+        worker.start_load_kv(_metadata(request))
+        assert entered.wait(5)
+        worker.start_load_kv(_metadata(request))
+        assert worker._save_executor.counts() == (0, 1)
+        release.set()
+        worker.close()
+        assert worker.get_finished().finished_saving == {request.save_operation}
+        worker.start_load_kv(_metadata(request))
+        assert worker.get_finished().is_empty()
+        assert calls == [True]
+    finally:
+        release.set()
+        worker.close()
+
+
+@pytest.mark.parametrize("fence_fails", [False, True])
+def test_failed_store_only_retires_after_both_streams_fence(monkeypatch, fence_fails):
+    worker = _worker(monkeypatch)
+    request = _request(1)
+    threads, fences = [], []
+
+    class Stream:
+        def __init__(self, name):
+            self.name = name
+
+        def synchronize(self):
+            threads.append(threading.get_ident())
+            fences.append(self.name)
+            if fence_fails and self.name == "pack":
+                raise RuntimeError("GPU fence unavailable")
+
+    def store(_tokens, **_kwargs):
+        threads.append(threading.get_ident())
+        raise RuntimeError("store failed after submitting GPU reads")
+
+    state = SimpleNamespace(pack_stream=Stream("pack"), copy_stream=Stream("copy"))
+    worker._engine = SimpleNamespace(
+        gpu_connector=SimpleNamespace(_thread_state=lambda: state), store=store
+    )
+    try:
+        worker.start_load_kv(_metadata(request))
+        worker.close()
+        output = worker.get_finished()
+        assert (
+            _completion(DENSE_PAGE_STORE_CHANNEL, request.save_operation, False)
+            in output.connector_completions
+        )
+        assert fences == ["pack", "copy"]
+        assert len(set(threads)) == 1
+        assert threads[0] != threading.get_ident()
+        if fence_fails:
+            assert output.finished_saving == set()
+            assert output.connector_completions == {
+                _completion(DENSE_PAGE_STORE_CHANNEL, request.save_operation, False)
+            }
+        else:
+            assert output.finished_saving == {request.save_operation}
+            assert (
+                _completion(DENSE_PAGE_RETIRED_CHANNEL, request.save_operation)
+                in output.connector_completions
+            )
+        worker.start_load_kv(_metadata(cancellations=[request.save_operation]))
+        assert worker.get_finished().is_empty()
+    finally:
+        worker.close()
+
+
+def test_incremental_source_report_precedes_store_and_retirement(monkeypatch):
+    worker = _worker(monkeypatch)
+    request = _request(1)
+    identity = SaveSourceGroupId(request.save_operation, ((0, 8),))
+    entered, release = threading.Event(), threading.Event()
+
+    def store(_tokens, **_kwargs):
+        worker._source_group_safe(identity)
+        entered.set()
+        assert release.wait(5)
+
+    worker._engine = SimpleNamespace(gpu_connector=None, store=store)
+    try:
+        worker.start_load_kv(_metadata(request))
+        assert entered.wait(5)
+        output = worker.get_finished()
+        assert output.finished_saving == set()
+        assert output.connector_completions == {
+            _completion(DENSE_PAGE_SOURCE_SAFE_CHANNEL, identity)
+        }
+    finally:
+        release.set()
+        worker.close()
+    assert worker.get_finished().finished_saving == {request.save_operation}
+
+
+def test_worker_submit_after_shutdown_is_never_started_rejection(monkeypatch):
+    worker = _worker(monkeypatch)
+    request = _request(1)
+    try:
+        worker._save_executor.shutdown()
+        worker.start_load_kv(_metadata(request))
+        output = worker.get_finished()
+        assert output.finished_saving == {request.save_operation}
+        assert output.connector_completions == {
+            _completion(DENSE_PAGE_STORE_CHANNEL, request.save_operation, False),
+            _completion(DENSE_PAGE_RETIRED_CHANNEL, request.save_operation),
+        }
+        assert worker._save_futures == {}
+    finally:
+        worker.close()
+
+
+def test_load_executor_progresses_while_save_worker_is_blocked(monkeypatch):
+    worker = _worker(monkeypatch)
+    save_started, release, loaded = (
+        threading.Event(),
+        threading.Event(),
+        threading.Event(),
+    )
+    request = _request(1)
+
+    def store(_tokens, **_kwargs):
+        save_started.set()
+        assert release.wait(5)
+
+    def retrieve(_tokens, *, mask, **_kwargs):
+        loaded.set()
+        return mask.clone()
+
+    worker._engine = SimpleNamespace(
+        gpu_connector=None,
+        store=store,
+        retrieve=retrieve,
+        lookup_unpin=lambda _req: None,
+    )
+    load_request = LMCacheReqMeta(
+        req_id="load",
+        token_ids=list(range(8)),
+        block_ids=[12, 13],
+        load_spec=LoadSpec(hbm_cached_tokens=0, lmcache_cached_tokens=8),
+    )
+    try:
+        worker.start_load_kv(_metadata(request))
+        assert save_started.wait(5)
+        worker.start_load_kv(_metadata(load_request))
+        assert loaded.wait(5)
+        assert worker._save_executor.counts() == (0, 1)
+    finally:
+        release.set()
+        worker.close()
+    assert worker.get_finished().finished_loading == {"load"}
+
+
+def test_admission_disabled_preserves_safe_queue_and_cancellation(monkeypatch):
+    worker = _worker(monkeypatch, capacity=1, admission=False)
+    entered, release = threading.Event(), threading.Event()
+    requests = [_request(generation) for generation in range(1, 6)]
+    calls = []
+
+    def store(_tokens, *, req_id, **_kwargs):
+        calls.append(req_id)
+        entered.set()
+        assert release.wait(5)
+
+    worker._engine = SimpleNamespace(gpu_connector=None, store=store)
+    try:
+        worker.start_load_kv(_metadata(requests[0]))
+        assert entered.wait(5)
+        worker.start_load_kv(_metadata(*requests[1:]))
+        assert worker._save_executor.counts() == (4, 1)
+        worker.start_load_kv(
+            _metadata(cancellations=[req.save_operation for req in requests[1:]])
+        )
+        assert worker._save_executor.counts() == (0, 1)
+        assert worker.get_finished().finished_saving == {
+            req.save_operation for req in requests[1:]
+        }
+    finally:
+        release.set()
+        worker.close()
+    assert calls == ["1"]
+    assert worker.get_finished().finished_saving == {requests[0].save_operation}
+
+
+def test_non_early_release_connector_keeps_legacy_executor_and_completion(monkeypatch):
+    class LegacyDense(DenseOffloadConnector):
+        _supports_early_block_release = False
+
+    worker = _worker(monkeypatch, cls=LegacyDense)
+    request = _request(1)
+    worker._engine = SimpleNamespace(
+        gpu_connector=None, store=lambda *_args, **_kwargs: None
+    )
+    try:
+        assert isinstance(worker._save_executor, ThreadPoolExecutor)
+        assert isinstance(worker._load_executor, ThreadPoolExecutor)
+        worker.start_load_kv(_metadata(request))
+        worker.close()
+        output = worker.get_finished()
+        assert output.finished_saving == {request.save_operation}
+        assert output.connector_completions == set()
+    finally:
+        worker.close()

--- a/tests/test_offload_early_block_release.py
+++ b/tests/test_offload_early_block_release.py
@@ -24,6 +24,7 @@ from atom.kv_transfer.offload._block_gpu_connector import (
     _TransferGroup,
 )
 from atom.kv_transfer.offload.dense.connector import (
+    DENSE_PAGE_RETIRED_CHANNEL,
     DENSE_PAGE_SOURCE_SAFE_CHANNEL,
     DENSE_PAGE_STORE_CHANNEL,
     DenseOffloadConnector,
@@ -75,6 +76,10 @@ def _store_terminal(operation, succeeded=True):
     return ConnectorCompletion(DENSE_PAGE_STORE_CHANNEL, operation, succeeded)
 
 
+def _retired(operation):
+    return ConnectorCompletion(DENSE_PAGE_RETIRED_CHANNEL, operation, True)
+
+
 def _finish_and_lease(scheduler, seq):
     scheduler.request_finished(seq)
     protected = scheduler.protected_block_ids(seq)
@@ -103,6 +108,70 @@ class TestBlockPoolLeaseOwnership:
         bm.free_leased_blocks(protected)
         assert bm.kv.num_used == 0
 
+    @pytest.mark.parametrize("first_owner", [0, 1])
+    def test_shared_prefix_lease_refs_retire_per_owner(
+        self, monkeypatch, seq_factory, first_owner
+    ):
+        scheduler = _early_release_scheduler(monkeypatch)
+        bm = BlockManager(
+            MockConfig(
+                num_kvcache_blocks=32,
+                kv_cache_block_size=4,
+                enable_prefix_caching=True,
+            )
+        )
+        tokens = list(range(20))
+        first = seq_factory(tokens)
+        bm.allocate(first)
+        bm.hash_blocks(first, len(tokens))
+        second = seq_factory(tokens)
+        second.offload_joint.claim_tokens = 16
+        bm.allocate(second, 2)
+        shared = frozenset(first.block_table[:4])
+        assert frozenset(second.block_table[:4]) == shared
+        assert all(bm.kv.block(block).ref_count == 2 for block in shared)
+
+        owners = [first, second]
+        for owner in owners:
+            scheduler.update_state_after_alloc(owner)
+            owner.num_cached_tokens = 16
+        operations = {
+            request.req_id: request.save_operation
+            for request in scheduler.build_connector_meta().requests
+        }
+        assert scheduler._save_budget.source_blocks == 8
+        for owner in owners:
+            scheduler.request_finished(owner)
+            protected = scheduler.protected_block_ids(owner)
+            assert protected == shared
+            bm.deallocate_partial(owner, protected)
+            scheduler.activate_block_leases(owner, protected)
+        assert all(bm.kv.block(block).ref_count == 2 for block in shared)
+
+        operation = operations[owners[first_owner].id]
+        scheduler.connector_completion(_source_safe(operation, (0, 16)))
+        released = scheduler.take_source_safe_releases()
+        assert released == [shared]
+        bm.free_leased_blocks(released[0])
+        scheduler.connector_completion(_store_terminal(operation))
+        scheduler.connector_completion(_retired(operation))
+        assert scheduler.take_source_safe_releases() == []
+        assert scheduler._save_budget.source_blocks == 4
+        assert all(bm.kv.block(block).ref_count == 1 for block in shared)
+
+        other = operations[owners[1 - first_owner].id]
+        scheduler.connector_completion(_store_terminal(other, succeeded=False))
+        assert scheduler.take_source_safe_releases() == []
+        scheduler.connector_completion(_retired(other))
+        released = scheduler.take_source_safe_releases()
+        assert released == [shared]
+        bm.free_leased_blocks(released[0])
+        assert all(bm.kv.block(block).ref_count == 0 for block in shared)
+        assert scheduler._save_budget.source_blocks == 0
+        scheduler.connector_completion(_source_safe(operation, (0, 16)))
+        scheduler.connector_completion(_retired(other))
+        assert scheduler.take_source_safe_releases() == []
+
 
 class TestSourceSafeBoundary:
     def test_worker_reports_source_safe_and_store_failure_separately(self):
@@ -122,11 +191,15 @@ class TestSourceSafeBoundary:
         )
         output = worker.get_finished()
 
-        assert output.finished_saving == {operation}
+        assert output.finished_saving == set()
         assert output.connector_completions == {
             ConnectorCompletion(DENSE_PAGE_SOURCE_SAFE_CHANNEL, identity, True),
             ConnectorCompletion(DENSE_PAGE_STORE_CHANNEL, operation, False),
         }
+        worker._record_save_retired(operation)
+        output = worker.get_finished()
+        assert output.finished_saving == {operation}
+        assert output.connector_completions == {_retired(operation)}
 
     def test_gpu_connector_reports_only_after_staging_group_fence(self):
         codec = SimpleNamespace(device=torch.device("cpu"), bytes_per_block=4)
@@ -298,9 +371,10 @@ class TestIncrementalLeaseRelease:
         seq = _seq(100, num_prompt_tokens=48, num_blocks=12)
         scheduler.update_state_after_alloc(seq)
 
-        seq.num_cached_tokens = 8
-        op1 = scheduler.build_connector_meta().requests[0].save_operation
+        # Only admitted ranges are protected: admit all eight source blocks
+        # before testing their incremental release, not an unsubmitted tail.
         seq.num_cached_tokens = 32
+        op1 = scheduler.build_connector_meta().requests[0].save_operation
         protected = _finish_and_lease(scheduler, seq)
         assert protected == frozenset(range(8))
 
@@ -308,11 +382,13 @@ class TestIncrementalLeaseRelease:
         assert scheduler.take_source_safe_releases() == [frozenset({0, 1})]
         assert scheduler.protected_block_ids(seq) == frozenset(range(2, 8))
 
-        assert scheduler.connector_completion(_store_terminal(op1)) is True
-        op2 = scheduler.build_connector_meta().requests[0].save_operation
-        assert scheduler.connector_completion(_source_safe(op2, (8, 32))) is None
+        assert scheduler.connector_completion(_source_safe(op1, (8, 32))) is None
         assert scheduler.take_source_safe_releases() == [frozenset(range(2, 8))]
-        scheduler.connector_completion(_store_terminal(op2))
+        assert op1 in scheduler._save_budget.operations
+        assert scheduler.connector_completion(_store_terminal(op1)) is True
+        assert op1 in scheduler._save_budget.operations
+        scheduler.connector_completion(_retired(op1))
+        assert op1 not in scheduler._save_budget.operations
         assert scheduler.protected_block_ids(seq) == frozenset()
 
     def test_final_pending_save_survives_request_block_table_clear(self, monkeypatch):
@@ -373,6 +449,10 @@ class TestStoreOutcomeSeparation:
         assert scheduler.total_save_requests == 0
         assert scheduler.total_saved_tokens == 0
         assert scheduler.blocks_waiting_for_store() == 0
+        assert operation in scheduler._save_budget.operations
+        scheduler.connector_completion(_retired(operation))
+        assert operation not in scheduler._save_budget.operations
+        assert scheduler.total_save_requests == 0
 
     def test_source_safe_blocks_are_observable_while_store_is_pending(
         self, monkeypatch
@@ -388,12 +468,15 @@ class TestStoreOutcomeSeparation:
         assert scheduler.get_statistics()["blocks_waiting_for_store"] == 2
         scheduler.connector_completion(_store_terminal(operation))
         assert scheduler.get_statistics()["blocks_waiting_for_store"] == 0
+        assert scheduler.total_save_requests == 0
+        assert operation in scheduler._save_budget.operations
+        scheduler.connector_completion(_retired(operation))
         assert scheduler.total_save_requests == 1
         assert scheduler.total_saved_tokens == 8
 
 
 class TestNoDoubleFree:
-    def test_timeout_drops_an_unemitted_finished_save_before_freeing(self, monkeypatch):
+    def test_timeout_cancels_a_prepared_final_save_before_freeing(self, monkeypatch):
         scheduler = _early_release_scheduler(monkeypatch, chunk_size=8)
         seq = _seq(399, num_prompt_tokens=16, num_blocks=4)
         scheduler.update_state_after_alloc(seq)
@@ -401,11 +484,19 @@ class TestNoDoubleFree:
         _finish_and_lease(scheduler, seq)
         scheduler._save_lease_at[id(seq)] = time.monotonic() - 10
 
-        assert scheduler.reclaim_stale_leases(1) == [frozenset({0, 1})]
+        assert scheduler.reclaim_stale_leases(1) == []
+        assert scheduler.protected_block_ids(seq) == frozenset({0, 1})
+        metadata = scheduler.build_connector_meta()
+        operation = metadata.requests[0].save_operation
+        assert metadata.cancel_save_operations == [operation]
+        scheduler.connector_completion(_store_terminal(operation, succeeded=False))
+        assert scheduler.take_source_safe_releases() == []
+        scheduler.connector_completion(_retired(operation))
+        assert scheduler.take_source_safe_releases() == [frozenset({0, 1})]
         assert str(seq.id) not in scheduler._save_tracker
         assert scheduler.has_pending_work() is False
 
-    def test_late_completions_after_timeout_reclaim_are_noops(self, monkeypatch):
+    def test_late_completions_after_confirmed_cancellation_are_noops(self, monkeypatch):
         scheduler = _early_release_scheduler(monkeypatch, chunk_size=8)
         seq = _seq(400, num_prompt_tokens=16, num_blocks=4)
         scheduler.update_state_after_alloc(seq)
@@ -414,11 +505,18 @@ class TestNoDoubleFree:
         _finish_and_lease(scheduler, seq)
         scheduler._save_lease_at[id(seq)] = time.monotonic() - 10
 
-        assert scheduler.reclaim_stale_leases(1) == [frozenset({0, 1})]
+        assert scheduler.reclaim_stale_leases(1) == []
+        assert scheduler.build_connector_meta().cancel_save_operations == [operation]
+        assert scheduler.take_source_safe_releases() == []
+        scheduler.connector_completion(_store_terminal(operation, succeeded=False))
+        assert scheduler.take_source_safe_releases() == []
+        scheduler.connector_completion(_retired(operation))
+        assert scheduler.take_source_safe_releases() == [frozenset({0, 1})]
         scheduler.connector_completion(_source_safe(operation, (0, 8)))
         scheduler.connector_completion(_store_terminal(operation))
+        scheduler.connector_completion(_retired(operation))
         assert scheduler.take_source_safe_releases() == []
-        assert scheduler.total_abnormal_lease_reclaims == 2
+        assert scheduler.total_abnormal_lease_reclaims == 0
         assert scheduler.total_save_requests == 0
 
     def test_duplicate_and_stale_source_completions_do_not_double_release(
@@ -440,7 +538,7 @@ class TestNoDoubleFree:
         assert scheduler.take_source_safe_releases() == [frozenset({0, 1})]
         assert scheduler.take_source_safe_releases() == []
 
-    def test_abandon_then_late_store_completion_does_not_release_twice(
+    def test_abandon_waits_for_safe_retirement_and_does_not_release_twice(
         self, monkeypatch
     ):
         scheduler = _early_release_scheduler(monkeypatch, chunk_size=8)
@@ -451,10 +549,15 @@ class TestNoDoubleFree:
         _finish_and_lease(scheduler, seq)
 
         scheduler.abandon_save(str(seq.id))
-        released = scheduler.take_source_safe_releases()
+        assert scheduler.take_source_safe_releases() == []
+        assert scheduler.build_connector_meta().cancel_save_operations == [operation]
         scheduler.connector_completion(_store_terminal(operation))
         assert scheduler.take_source_safe_releases() == []
-        assert released == [frozenset({0, 1})]
+        scheduler.connector_completion(_retired(operation))
+        assert scheduler.take_source_safe_releases() == [frozenset({0, 1})]
+        scheduler.connector_completion(_store_terminal(operation))
+        scheduler.connector_completion(_retired(operation))
+        assert scheduler.take_source_safe_releases() == []
 
     def test_request_id_reuse_cannot_attach_an_old_lease_to_new_blocks(
         self, monkeypatch

--- a/tests/test_pp_kv_status.py
+++ b/tests/test_pp_kv_status.py
@@ -7,8 +7,10 @@ from aiter_stub import stubbed_aiter
 with stubbed_aiter():
     from atom.kv_transfer.disaggregation.pp_kv_aggregator import PPKVAggregator
     from atom.kv_transfer.disaggregation.types import (
+        ConnectorCompletion,
         KVConnectorOutput,
         SaveOperationId,
+        SaveSourceGroupId,
     )
     from atom.model_engine.pp_engine_core import PPEngineCoreProc
 
@@ -242,3 +244,147 @@ def test_load_failure_does_not_block_another_request():
 def test_aggregator_rejects_bad_pp_size():
     with pytest.raises(ValueError):
         PPKVAggregator(0)
+
+
+def _output(*completions):
+    return KVConnectorOutput(connector_completions=set(completions))
+
+
+def _source(operation, start=0, succeeded=True):
+    return ConnectorCompletion(
+        "dense.page.source_safe",
+        SaveSourceGroupId(operation, ((start, start + 8),)),
+        succeeded,
+    )
+
+
+def _retired(operation, succeeded=True):
+    return ConnectorCompletion("dense.page.retired", operation, succeeded)
+
+
+@pytest.mark.parametrize("group_succeeded", [True, False])
+def test_never_started_stage_groups_wait_for_all_stage_safe_retirement(group_succeeded):
+    agg = PPKVAggregator(3)
+    operation = SaveOperationId("request", 1)
+    first = _source(operation)
+    second = _source(operation, 8, succeeded=group_succeeded)
+    rejected = ConnectorCompletion("dense.page.store", operation, False)
+
+    assert agg.ingest(0, _output(first, second)).is_empty()
+    assert agg.ingest(1, _output(first)).is_empty()
+    assert agg.ingest(2, _output(rejected, _retired(operation))).is_empty()
+    assert agg.ingest(0, _output(_retired(operation))).is_empty()
+    # Repeated reports from one stage cannot stand in for the missing stage.
+    assert agg.ingest(0, _output(_retired(operation))).is_empty()
+    assert first.key in agg._connector
+    assert second.key in agg._connector
+
+    result = agg.ingest(1, _output(_retired(operation)))
+    assert result.connector_completions == {_retired(operation)}
+    assert agg._connector == {rejected.key: {2}}
+    assert agg._connector_failed == {rejected.key}
+    assert agg.has_pending() is True
+
+    stored = ConnectorCompletion("dense.page.store", operation, True)
+    assert agg.ingest(0, _output(stored)).is_empty()
+    result = agg.ingest(1, _output(stored))
+    assert result.connector_completions == {rejected}
+    assert agg.has_pending() is False
+    assert agg._connector_failed == set()
+
+    for stage in range(3):
+        assert agg.ingest(stage, _output(first, second, _retired(operation))).is_empty()
+        assert agg.has_pending() is False
+
+
+def test_failed_retirement_preserves_source_groups_and_late_reports():
+    agg = PPKVAggregator(2)
+    operation = SaveOperationId("request", 1)
+    group = _source(operation)
+    assert agg.ingest(0, _output(group, _retired(operation, False))).is_empty()
+    # A later success from that stage must not erase its failure verdict.
+    assert agg.ingest(0, _output(_retired(operation))).is_empty()
+    result = agg.ingest(1, _output(_retired(operation)))
+    assert result.connector_completions == {_retired(operation, False)}
+    assert agg.has_pending() is True
+
+    result = agg.ingest(1, _output(group))
+    assert result.connector_completions == {group}
+    assert agg.has_pending() is False
+
+    later_group = _source(operation, 8)
+    assert agg.ingest(0, _output(later_group)).is_empty()
+    result = agg.ingest(1, _output(later_group))
+    assert result.connector_completions == {later_group}
+    assert agg.has_pending() is False
+
+
+def test_newer_retirement_preserves_an_older_running_generation():
+    agg = PPKVAggregator(2)
+    older, newer = SaveOperationId("old", 1), SaveOperationId("new", 2)
+    older_group, newer_group = _source(older), _source(newer)
+    assert agg.ingest(0, _output(older_group, newer_group)).is_empty()
+    assert agg.ingest(0, _output(_retired(newer))).is_empty()
+    result = agg.ingest(1, _output(_retired(newer)))
+    assert result.connector_completions == {_retired(newer)}
+    assert agg.has_pending() is True
+
+    result = agg.ingest(1, _output(older_group))
+    assert result.connector_completions == {older_group}
+    assert agg.has_pending() is False
+    assert agg.ingest(0, _output(_retired(older))).is_empty()
+    result = agg.ingest(1, _output(_retired(older)))
+    assert result.connector_completions == {_retired(older)}
+    assert agg._retired_dense_generations._intervals == [(1, 2)]
+
+
+def test_old_retired_generation_cannot_recreate_pending_groups():
+    agg = PPKVAggregator(2)
+    for generation in range(1, 101):
+        operation = SaveOperationId(str(generation), generation)
+        assert agg.ingest(
+            0, _output(_source(operation), _retired(operation))
+        ).is_empty()
+        result = agg.ingest(1, _output(_retired(operation)))
+        assert result.connector_completions == {_retired(operation)}
+        assert agg.has_pending() is False
+    assert agg._retired_dense_generations._intervals == [(1, 100)]
+
+    oldest = SaveOperationId("1", 1)
+    for stage in range(2):
+        assert agg.ingest(stage, _output(_source(oldest), _retired(oldest))).is_empty()
+        assert agg.has_pending() is False
+
+
+def test_retirement_preserves_store_outcomes_and_other_channels():
+    agg = PPKVAggregator(2)
+    operation = SaveOperationId("request", 1)
+    unrelated = ConnectorCompletion(
+        "other.page.source_safe", _source(operation).operation_id, True
+    )
+    assert agg.ingest(0, _output(unrelated, _retired(operation))).is_empty()
+    result = agg.ingest(1, _output(_retired(operation)))
+    assert result.connector_completions == {_retired(operation)}
+    assert agg.has_pending() is True
+
+    # No store report arrived before retirement; its entire quorum is late.
+    stored = ConnectorCompletion("dense.page.store", operation, True)
+    failed = ConnectorCompletion("dense.page.store", operation, False)
+    assert agg.ingest(0, _output(stored)).is_empty()
+    result = agg.ingest(1, _output(unrelated, failed))
+    assert result.connector_completions == {unrelated, failed}
+    assert agg.has_pending() is False
+
+
+def test_reset_allows_generation_reuse_in_a_new_scheduler_lifetime():
+    agg = PPKVAggregator(2)
+    operation = SaveOperationId("request", 1)
+    assert agg.ingest(0, _output(_retired(operation))).is_empty()
+    agg.ingest(1, _output(_retired(operation)))
+    agg.reset()
+
+    group = _source(operation)
+    assert agg.ingest(0, _output(group)).is_empty()
+    result = agg.ingest(1, _output(group))
+    assert result.connector_completions == {group}
+    assert agg.has_pending() is False


### PR DESCRIPTION
Dense/M3 PAGE saves could accumulate behind a slow offload backend while retaining source blocks needed by foreground requests. At concurrency 96, the historical run reached 141 pending saves. This change admits saves before dispatch and retains each source reference until workers prove that no further source reads can occur.

- Reserve operation, candidate-byte, and unsafe-source-block budgets in the scheduler, including sources of active requests. Defaults are `max(2, 2 * OFFLOAD_COPY_WORKERS)` operations and 10% of the PAGE pool, with bytes derived from the largest measured per-rank PAGE entry.
- Physically remove cancelled tasks from a bounded worker queue. Budget rejection disables subsequent save ranges for that request lifecycle; request teardown admits the final range before deallocation and drops the tail when an earlier save is still outstanding.
- Separate store outcome from safe retirement. Source-group reports release source references incrementally; operation/byte credits wait for both outcome and retirement. Exceptions fence staging streams, and timeouts only request cancellation. TP/PP retirement also clears incomplete source-group quorums and suppresses late reports.
- Export admission, drop, cancellation, queue, byte, source, and age observations. Document the controls and clarify that `saved_tokens` counts candidates in normally returned store calls, not confirmed persisted tokens. The legacy K3 path is retained.

Validation on the PR branch, based on main `13a2fc427d02cf8778d9f0542e7988ee52669eff`:

- Native CPU CI script, `.github/scripts/run_unit_tests.sh`: **5,232 passed, 380 skipped, 3 xfailed** in 50.33 seconds, using an isolated Python 3.12 environment with CPU PyTorch and the CI dependencies. Existing GPU/integration guards are retained.
- The pinned-base implementation also passed 614 focused regressions covering admission, physical cancellation, stream fences, mixed TP/PP outcomes, duplicate/late generations, request-ID reuse, shared prefix references, timeout safety, metrics, and legacy compatibility.
- Whole-repository Black: 758 files unchanged. Ruff: zero findings in the PR diff context, matching the CI reviewdog filter; existing repository diagnostics remain outside that context. Accuracy catalog schema validation and `git diff --check` pass.

MiniMax M3 MXFP8 benchmark on eight MI355X GPUs: TP8 / DP1 / PP1, concurrency 96, AIPerf's `inferencex-agentx-mvp` scenario with `semianalysis_cc_traces_weka_062126` at the same dataset revision and seed 42, mandatory snapshot primers, 900 seconds sending, 30 seconds grace, and a 300-second cancellation-drain limit. Offload runs used 192 GiB CPU cache per rank, chunk size 256, one copy worker, and two staging chunks. The fresh A run had offload disabled.

| Metric | Historical offload | Fresh no-offload A | Patched offload |
|---|---:|---:|---:|
| Sent / successful / cancelled / errors | 333 / 221 / 112 / 0 | 374 / 269 / 105 / 0 | 385 / 279 / 106 / 0 |
| Successful within 900 seconds | 214 | 262 | 272 |
| Success/s within 900 seconds | 0.2378 | 0.2911 | 0.3022 |
| TTFT p50, seconds | 98.29 | 12.27 | 10.86 |
| TTFT p99, seconds | 585.32 | 453.58 | 459.09 |
| TPOT p50, milliseconds | 34.22 | 116.21 | 106.52 |
| Prompt cache read | 53.57% | 38.10% | 42.02% |
| Pending saves, time-weighted mean / max in first 900 seconds | 72.69 / 141 | 0 / 0 | 1.26 / 2 |
| Running requests, time-weighted mean in first 900 seconds | 15.13 | 38.75 | 38.58 |

The patched run improved 900-second throughput by 27.1% versus historical offload and 3.8% versus fresh A. Successful-request TTFT p50 fell 88.9% versus historical offload. Across the 266 requests completed by both fresh runs, median patched/A TTFT ratio was 1.0165, TPOT ratio was 0.9688, and median end-to-end change was -3.23 seconds.

Observed unretired operations and per-rank queued-plus-running saves stayed at or below two. Maximum reserved source blocks were 5,354 against a cap of 5,739; maximum candidate bytes per rank were 16,980,713,472 against a cap of 16,995,520,512. All 258 observed operations, including warmup and ten operations with mixed started/never-started ranks, retired across all eight ranks; final admission and lease balances were zero.

These are single-run observations. Latencies cover successful requests, and paired results cover only jointly successful requests. All runs reached the cancellation-drain timeout, making the full phase 1,230 seconds. TTFT tails remain near fresh A, and TPOT increased relative to historical offload as foreground concurrency recovered. The capacity-disabled B-safe control never reached serving because AITER hardware detection blocked, so these results establish the combined change rather than the isolated contribution of admission limits. No repeated ABBA run or broad accuracy validation is claimed.

GPU measurements used the patch on base `23a99bc5bbc72afa838947a88c5985e4dcce4fc4`, with base image `rocm/atom-dev@sha256:94d81064f48324e4a1d53ad4450ad40a28a32e28f794f7d5f839ee382aa5e668`. The measured v1 image ID was `sha256:a99fbf4c89c406d65f8a37ce81eed503063ffe57085ff7dcb00a3162341125b2`. The final implementation adds PP aggregation cleanup; AST comparison confirmed that this is the only runtime difference from v1, and PP1 does not execute that aggregator. PP>1 has CPU protocol coverage, without GPU performance validation. The PR is based on current main; its final checks are separate from the pinned-base GPU measurements.
