### PR TITLE
[KV-events] match vLLM/SGLang ZMQ framing and per-DP-rank port offset

### DIFF
--- a/atom/distributed/kv_events.py
+++ b/atom/distributed/kv_events.py
@@ -6,6 +6,7 @@ plus ATOM extensions (`BlockTransferred`, CPU/DISK/REMOTE medium constants)."""
 
 from __future__ import annotations
 
+import itertools
 import logging
 import queue
 import threading
@@ -134,10 +135,18 @@ class ZmqEventPublisher(EventPublisher):
     batch is dropped — KV events are advisory and a missed eviction is
     cheaper than stalling inference.
 
-    With `topic=""` (default) each message is a single msgpack frame; with a
-    non-empty `topic` the publisher sends two-frame multipart messages
-    (`[topic, payload]`), so consumers must use `recv_multipart()` to read
-    the payload.
+    Every message is a three-frame multipart `[topic, seq, payload]`, the
+    layout vLLM's `ZmqEventPublisher` emits: `topic` is the (possibly empty)
+    subscription key, `seq` is a monotonic uint64 big-endian batch counter,
+    and `payload` is the msgpack-encoded `EventBatch`. Consumers must use
+    `recv_multipart()`. `seq` is assigned at enqueue, so a batch dropped on
+    queue overflow shows up as a gap in the stream instead of vanishing
+    silently. The all-0xFF value is never used as a data seq; vLLM reserves
+    it as the replay terminator.
+
+    With `data_parallel_rank` set, the bound endpoint is moved to that rank
+    (see `offset_endpoint_port`) so co-located DP ranks do not collide on one
+    socket, and subscribers reach rank N at base port + N.
     """
 
     def __init__(
@@ -162,12 +171,16 @@ class ZmqEventPublisher(EventPublisher):
         self._dp_rank = data_parallel_rank
         self._topic_bytes = topic.encode("utf-8")
         self._encoder = encoder or msgspec.msgpack.Encoder()
-        self._queue: queue.Queue[bytes | None] = queue.Queue(maxsize=buffer_steps)
+        # Queue items are (seq, payload); None is the shutdown sentinel.
+        self._queue: queue.Queue[tuple[int, bytes] | None] = queue.Queue(
+            maxsize=buffer_steps
+        )
+        self._seq_gen = itertools.count()
 
         ctx = zmq.Context.instance()
         self._socket = ctx.socket(zmq.PUB)
         self._socket.set_hwm(hwm)
-        self._socket.bind(endpoint)
+        self._socket.bind(offset_endpoint_port(endpoint, data_parallel_rank or 0))
         self._zmq_error_cls = zmq.ZMQError  # captured so _run doesn't re-import
 
         self._drops = 0
@@ -207,10 +220,16 @@ class ZmqEventPublisher(EventPublisher):
                 )
             return
 
+        # Assigned at enqueue rather than at send: a batch dropped on overflow
+        # below still consumes a seq, so subscribers see the loss as a gap.
+        # Modulo keeps the counter in [0, 2**64-2], clear of vLLM's all-0xFF
+        # replay terminator.
+        seq = next(self._seq_gen) % 0xFFFFFFFFFFFFFFFF
+
         # Non-blocking enqueue; drop oldest on overflow.
         while True:
             try:
-                self._queue.put_nowait(payload)
+                self._queue.put_nowait((seq, payload))
                 return
             except queue.Full:
                 try:
@@ -246,11 +265,11 @@ class ZmqEventPublisher(EventPublisher):
             item = self._queue.get()
             if item is None:
                 return
+            seq, payload = item
             try:
-                if self._topic_bytes:
-                    self._socket.send_multipart([self._topic_bytes, item])
-                else:
-                    self._socket.send(item)
+                self._socket.send_multipart(
+                    [self._topic_bytes, seq.to_bytes(8, "big"), payload]
+                )
                 with self._lock:
                     self._sent += 1
             except self._zmq_error_cls:  # pragma: no cover - socket closed
@@ -265,6 +284,22 @@ class ZmqEventPublisher(EventPublisher):
                 "dropped": self._drops,
                 "encode_errors": self._encode_errors,
             }
+
+
+def offset_endpoint_port(endpoint: str, data_parallel_rank: int) -> str:
+    """Return `endpoint` moved to the given data-parallel rank: tcp ports are
+    offset by the rank, other transports (inproc, ipc) get a `_dp<rank>`
+    suffix. Rank 0 returns the endpoint unchanged. Mirrors vLLM's
+    `ZmqEventPublisher.offset_endpoint_port`, so a subscriber that dials
+    base port + rank works against either engine."""
+    if data_parallel_rank <= 0:
+        return endpoint
+    if endpoint.startswith("tcp://"):
+        base, sep, port = endpoint.rpartition(":")
+        if not sep or not port.isdigit():
+            raise ValueError(f"tcp endpoint without a numeric port: {endpoint!r}")
+        return f"{base}:{int(port) + data_parallel_rank}"
+    return f"{endpoint}_dp{data_parallel_rank}"
 
 
 def make_publisher(

--- a/tests/test_kv_events.py
+++ b/tests/test_kv_events.py
@@ -10,7 +10,8 @@ Covers:
   * `take_events()` drain semantics
   * `clear_cache()` emits AllBlocksCleared
   * `record_remote_store()` emits BlockStored(medium=REMOTE)
-  * ZmqEventPublisher PUB→SUB round-trip
+  * ZmqEventPublisher PUB→SUB round-trip, `[topic, seq, payload]` framing,
+    per-DP-rank endpoint offset
   * NullEventPublisher is a no-op
 """
 
@@ -33,6 +34,7 @@ from atom.distributed.kv_events import (
     NullEventPublisher,
     ZmqEventPublisher,
     make_publisher,
+    offset_endpoint_port,
 )
 from atom.model_engine.block_manager import BlockManager
 
@@ -339,20 +341,67 @@ class TestPublisher:
         try:
             sub.setsockopt(zmq.SUBSCRIBE, b"")
             sub.connect(endpoint)
-            decoder = msgspec.msgpack.Decoder(EventBatch)
-            payload: bytes | None = None
-            for _ in range(10):
-                pub.publish([BlockRemoved(block_hashes=[7])])
-                if sub.poll(timeout=200):
-                    payload = sub.recv()
-                    break
-            assert payload is not None, "SUB did not receive any batch"
-            batch = decoder.decode(payload)
+            topic, seq_bytes, payload = _first_frames(
+                pub, sub, BlockRemoved(block_hashes=[7])
+            )
+            assert topic == b""
+            assert len(seq_bytes) == 8
+            batch = msgspec.msgpack.Decoder(EventBatch).decode(payload)
             assert len(batch.events) == 1
             assert isinstance(batch.events[0], BlockRemoved)
         finally:
             sub.close(linger=0)
             pub.shutdown()
+
+    def test_wire_frames_are_topic_seq_payload(self):
+        # vLLM layout: [topic, uint64 big-endian seq, msgpack EventBatch], with
+        # seq advancing by one per published batch.
+        zmq = pytest.importorskip("zmq")
+        endpoint = "inproc://test-kv-events-frames"
+        topic = b"kv@10.0.0.1@model"
+        pub = ZmqEventPublisher(
+            endpoint=endpoint, topic=topic.decode(), buffer_steps=16
+        )
+        ctx = zmq.Context.instance()
+        sub = ctx.socket(zmq.SUB)
+        try:
+            sub.setsockopt(zmq.SUBSCRIBE, b"kv@")
+            sub.connect(endpoint)
+            decoder = msgspec.msgpack.Decoder(EventBatch)
+            first = _first_frames(pub, sub, BlockRemoved(block_hashes=[0]))
+            assert first[0] == topic
+            first_seq = int.from_bytes(first[1], "big")
+            for expected in range(first_seq + 1, first_seq + 4):
+                pub.publish([BlockRemoved(block_hashes=[expected])])
+                assert sub.poll(timeout=2000), f"batch {expected} not received"
+                frames = sub.recv_multipart()
+                assert len(frames) == 3
+                assert frames[0] == topic
+                assert len(frames[1]) == 8
+                assert int.from_bytes(frames[1], "big") == expected
+                batch = decoder.decode(frames[2])
+                assert batch.events[0].block_hashes == [expected]
+        finally:
+            sub.close(linger=0)
+            pub.shutdown()
+
+    def test_dropped_batches_consume_seq(self):
+        # Stopped sender + buffer_steps=1: publishes 0 and 1 are dropped on
+        # overflow, and the surviving queued batch carries seq 2.
+        pytest.importorskip("zmq")
+        pub = ZmqEventPublisher(
+            endpoint="inproc://test-kv-events-seq-gap", buffer_steps=1
+        )
+        pub._queue.put_nowait(None)
+        pub._sender.join(timeout=2.0)
+        try:
+            for i in range(3):
+                pub.publish([BlockRemoved(block_hashes=[i])])
+            seq, _ = pub._queue.get_nowait()
+            assert seq == 2
+            assert pub.stats["dropped"] == 2
+        finally:
+            pub._socket.close(linger=0)
 
     def test_publish_drops_oldest_on_overflow(self):
         # buffer_steps=1 + stopped sender => every publish past the first must
@@ -390,3 +439,56 @@ class TestPublisher:
             assert pub.stats["sent"] == 0
         finally:
             pub.shutdown()
+
+
+# ── Endpoint offset ────────────────────────────────────────────────────────
+
+
+class TestOffsetEndpointPort:
+    @pytest.mark.parametrize(
+        ("endpoint", "rank", "expected"),
+        [
+            ("tcp://*:5557", 0, "tcp://*:5557"),
+            ("tcp://*:5557", 3, "tcp://*:5560"),
+            ("tcp://0.0.0.0:5557", 1, "tcp://0.0.0.0:5558"),
+            ("tcp://[::1]:5557", 2, "tcp://[::1]:5559"),
+            ("inproc://kv", 2, "inproc://kv_dp2"),
+            ("ipc:///tmp/kv.sock", 1, "ipc:///tmp/kv.sock_dp1"),
+        ],
+    )
+    def test_offsets(self, endpoint, rank, expected):
+        assert offset_endpoint_port(endpoint, rank) == expected
+
+    def test_tcp_without_numeric_port_rejected(self):
+        with pytest.raises(ValueError):
+            offset_endpoint_port("tcp://host", 1)
+
+    def test_publisher_binds_rank_offset_endpoint(self):
+        # Two ranks on one base endpoint bind distinct sockets, and the rank-1
+        # stream is reachable at the offset address.
+        zmq = pytest.importorskip("zmq")
+        base = "inproc://test-kv-events-dp"
+        rank0 = ZmqEventPublisher(endpoint=base, buffer_steps=4, data_parallel_rank=0)
+        rank1 = ZmqEventPublisher(endpoint=base, buffer_steps=4, data_parallel_rank=1)
+        ctx = zmq.Context.instance()
+        sub = ctx.socket(zmq.SUB)
+        try:
+            sub.setsockopt(zmq.SUBSCRIBE, b"")
+            sub.connect(offset_endpoint_port(base, 1))
+            _, _, payload = _first_frames(rank1, sub, BlockRemoved(block_hashes=[1]))
+            batch = msgspec.msgpack.Decoder(EventBatch).decode(payload)
+            assert batch.data_parallel_rank == 1
+        finally:
+            sub.close(linger=0)
+            rank0.shutdown()
+            rank1.shutdown()
+
+
+def _first_frames(pub: ZmqEventPublisher, sub, event) -> list[bytes]:
+    """Publish `event` until the SUB (a slow joiner) sees a batch; return its
+    frames."""
+    for _ in range(20):
+        pub.publish([event])
+        if sub.poll(timeout=200):
+            return sub.recv_multipart()
+    raise AssertionError("SUB did not receive any batch")


### PR DESCRIPTION
## Motivation

`ZmqEventPublisher` (#869) sends one frame with the default empty topic, or `[topic, payload]` with a topic set. vLLM's publisher sends `[topic, seq, payload]` with an 8-byte big-endian sequence number, and vLLM-compatible subscribers reject anything else: llm-d-router's KV-events pool (`pkg/kvevents/zmq_subscriber.go`, `parseEventFrame`) requires exactly three frames, so with `ATOM_KV_EVENTS_ENABLE=1` every ATOM batch is logged as malformed and dropped, and precise prefix-cache routing never sees ATOM blocks. The msgpack payload was already slot-for-slot compatible; only the framing was not.

Every DP rank builds its own `Scheduler` and therefore its own publisher, and all of them bound the same `ATOM_KV_EVENTS_ENDPOINT`. vLLM offsets the bound port by `data_parallel_rank`, and llm-d-router's per-pod discovery dials `socketPort + rank` on the same assumption.

Subset of #1316, which also adds `token_offset` and replay and has been conflicting with `main` since July. This PR is the framing and port pieces only, so #1316 stays additive on top.

## Technical Details

- `atom/distributed/kv_events.py`
  - Every message is `[topic, seq, payload]`. `seq` is a monotonic uint64 assigned at enqueue, so a batch dropped on queue overflow shows up as a gap; the all-0xFF value is kept out of the data range because vLLM reserves it as the replay terminator.
  - `offset_endpoint_port(endpoint, data_parallel_rank)` mirrors vLLM's helper: tcp ports are offset by the rank, other transports get a `_dp<rank>` suffix, rank 0 is unchanged. `ZmqEventPublisher.__init__` binds the offset endpoint.
- `tests/test_kv_events.py`: round-trip test reads `recv_multipart()`; new tests cover the frame layout and monotonic `seq`, `seq` consumption on drop, `offset_endpoint_port` cases, and two ranks binding one base endpoint.

Wire change for existing consumers: single-frame `recv()` readers must switch to `recv_multipart()`. Nothing in-tree consumes the stream.

For llm-d, the engine side then needs `ATOM_KV_EVENTS_ENABLE=1`, `ATOM_KV_EVENTS_ENDPOINT=tcp://0.0.0.0:5557`, and `ATOM_KV_EVENTS_TOPIC=kv@<pod-ip>@<served-model-name>`; the router derives the model name from the topic and folds it into the block hash, so it has to match the request's model.

## Test Plan

- [x] `python -m pytest tests/test_kv_events.py` (35 passed)
- [x] `black --check` and `ruff check` on both files, findings unchanged from `main`
- [x] Interop against llm-d-router `main`: the patched publisher (Python) bound at base port + 1 for rank 1, llm-d-router's `kvevents` subscriber, pool, and vLLM adapter dialed it; two chained `BlockStored` runs (64 tokens, block size 16) resolved all four request keys to the pod, and a `BlockRemoved` evicted the second run while the first stayed indexed

## Test Result

macOS, Python 3.11, pyzmq 27.2, msgspec 0.21. No GPU run; the change does not touch the engine path.

```
$ python -m pytest tests/test_kv_events.py -q
35 passed in 0.06s
$ python -m pytest tests/test_lmcache_offload_connector.py tests/test_token_ids_storage.py tests/test_scheduler.py tests/test_kv_connector_scheduler.py tests/test_prefill_scheduler.py -q
372 passed, 1 skipped in 1.97s
$ black --check --target-version py310 --target-version py311 atom/distributed/kv_events.py tests/test_kv_events.py
2 files would be left unchanged.
$ ruff check atom/distributed/kv_events.py tests/test_kv_events.py
5 findings, all pre-existing on main (S110/BLE001 in shutdown() and an existing test, C408 in a test helper)
$ go test ./pkg/kvevents/ -run TestATOMPublisherInterop -v      # llm-d-router main + patched ATOM publisher
atom_publish: bound tcp://127.0.0.1:15658 (rank 1)
    all 4 request keys resolved to 10.1.2.3:8000 via chained BlockStored runs
    BlockRemoved evicted the second run; first run still indexed
--- PASS: TestATOMPublisherInterop (16.38s)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
