### PR TITLE
offload/dsv4: give PAGE saves a failure channel and roll the watermark back

### DIFF
--- a/atom/kv_transfer/offload/hybrid/dsv4/connector.py
+++ b/atom/kv_transfer/offload/hybrid/dsv4/connector.py
@@ -90,6 +90,13 @@ from atom.kv_transfer.offload.metadata import (
 logger = logging.getLogger("atom")
 
 DSV4_CHECKPOINT_SAVE_CHANNEL = "atom.dsv4.checkpoint.save"
+# PAGE saves need a terminal channel of their own because ``finished_saving``
+# cannot express failure: it is one undifferentiated set, so a save rejected on
+# admission or killed inside the executor reaches the scheduler looking exactly
+# like one that landed. The scheduler advances its saved watermark when a save
+# is *emitted*, so with no failure signal it can never learn to take that
+# advance back, and the skipped range becomes a permanent hole in the prefix.
+DSV4_PAGE_SAVE_CHANNEL = "atom.dsv4.page.save"
 
 
 def _wait_for_publication(
@@ -223,6 +230,12 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
         n_save_workers = int(os.environ.get("OFFLOAD_COPY_WORKERS", "1"))
         self._max_pending_saves = max_pending_saves(kvc, n_save_workers)
         self._save_admission = threading.BoundedSemaphore(self._max_pending_saves)
+        # Terminal PAGE-save outcomes, drained by ``get_finished`` onto
+        # ``DSV4_PAGE_SAVE_CHANNEL``. Every request carrying a ``save_spec``
+        # lands in exactly one of these, on every path out of the save, so the
+        # TP aggregator always reaches a verdict instead of stranding the key.
+        self._done_page_save: set = set()
+        self._failed_page_save: set = set()
         self._init_worker_common(
             config,
             save_workers=n_save_workers,
@@ -751,6 +764,31 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
                         slot_snapshot,
                     )
 
+    def _report_page_save_locked(self, req: LMCacheReqMeta, *, succeeded: bool) -> None:
+        """Record one request's terminal PAGE outcome. Caller holds ``_lock``.
+
+        Only a request that carries a ``save_spec`` moved the scheduler's
+        watermark, so only that one needs a verdict -- a SLOT-only save has
+        nothing to roll back.
+        """
+        if getattr(req, "save_spec", None) is None:
+            return
+        completion_id = self._save_completion_id(req)
+        if succeeded:
+            self._done_page_save.add(completion_id)
+        else:
+            self._failed_page_save.add(completion_id)
+
+    def _report_page_save(self, req: LMCacheReqMeta, *, succeeded: bool) -> None:
+        """Lock-taking form of :meth:`_report_page_save_locked`.
+
+        ``_lock`` is a plain ``Lock``, so this must never be called while it is
+        already held; the in-executor path reports through the ``_locked`` form
+        inside the section it already owns.
+        """
+        with self._lock:
+            self._report_page_save_locked(req, succeeded=succeeded)
+
     def _finish_unadmitted_save(
         self,
         req: LMCacheReqMeta,
@@ -759,6 +797,7 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
     ) -> None:
         """Terminally reject a save before retaining any operation state."""
 
+        self._report_page_save(req, succeeded=False)
         completion_id = self._save_completion_id(req)
         with self._lock:
             save_operation = getattr(req, "save_operation", None)
@@ -882,6 +921,7 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
         slot_snapshot: _SlotSaveSnapshot | None,
     ) -> None:
         """Safely retire an RPC snapshot when executor submission fails."""
+        self._report_page_save(req, succeeded=False)
         try:
             gpu_complete = True
             try:
@@ -1031,6 +1071,14 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
                     self._complete_load_locked(req, succeeded=False)
                 elif getattr(req, "slot_save_spec", None) is not None:
                     self._failed_sidecar_save.add(self._save_completion_id(req))
+                if kind == "save":
+                    # Backstop. ``_do_save_req`` normally reports its own PAGE
+                    # verdict and swallows its errors, so this only fires if it
+                    # died outside that handling -- but a save that reports
+                    # nothing would sit in the TP aggregator forever, so the
+                    # failure has to be recorded here too. A duplicate report is
+                    # harmless: the aggregator is failure-dominant per worker.
+                    self._report_page_save_locked(req, succeeded=False)
 
     def _complete_load_locked(self, req: LMCacheReqMeta, *, succeeded: bool) -> None:
         completion_id = self._load_completion_id(req)
@@ -1447,6 +1495,7 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
         slot_blob = None
         slot_preparation_error: Exception | None = None
         page_plan = None
+        page_stored = False
         t_total0 = time.perf_counter()
         store_ms = 0.0
         transfer_stats: dict[str, int | float] = {}
@@ -1543,12 +1592,21 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
                 )
                 store_ms = (time.perf_counter() - t_store0) * 1000
                 transfer_stats = self._last_gpu_connector_transfer_stats()
+            if slot_spec is None:
+                # PAGE-only save. `store` returning is the only durability
+                # signal that exists here, so it is the verdict; a raise above
+                # leaves this False and the advance gets taken back.
+                page_stored = True
 
             if slot_spec is not None:
-                if slot_preparation_error is not None:
-                    raise slot_preparation_error
-                _, slot_store, _ = self._require_slot_components()
-                checkpoint_codec = self._require_checkpoint_codec()
+                # A stateful save can check its own work, and this probe is the
+                # only confirmation that the PAGEs behind the advance are
+                # actually queryable. Run it before anything SLOT-related, so
+                # the PAGE verdict never depends on staging, and claim the
+                # advance only once it passes -- reporting success on a
+                # visibility timeout would commit a watermark over a prefix
+                # nobody can read, which is the hole this channel exists to
+                # prevent.
                 boundary_tokens = int(slot_spec.boundary_tokens)
 
                 def _page_boundary_visible() -> bool:
@@ -1563,6 +1621,16 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
                     raise RuntimeError(
                         "PAGE coverage did not become session-visible before timeout"
                     )
+                # Confirmed. Everything below is sidecar-only, and a SLOT
+                # failure from here on must not revoke a PAGE advance that did
+                # land -- that is why the verdict is taken at this exact point
+                # and not at the end of the block.
+                page_stored = True
+
+                if slot_preparation_error is not None:
+                    raise slot_preparation_error
+                _, slot_store, _ = self._require_slot_components()
+                checkpoint_codec = self._require_checkpoint_codec()
                 if slot_blob is None:
                     raise RuntimeError("SLOT CPU frame is unavailable after D2H")
                 checkpoint_codec.finalize_tensor_(
@@ -1636,11 +1704,22 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
                     save_failure_reason = "staging_cleanup"
 
             with self._lock:
+                self._report_page_save_locked(req, succeeded=page_stored)
                 if slot_spec is not None:
                     if sidecar_published:
                         self._done_sidecar_save.add(self._save_completion_id(req))
                     else:
                         self._failed_sidecar_save.add(self._save_completion_id(req))
+            if not page_stored and getattr(req, "save_spec", None) is not None:
+                logger.warning(
+                    "LMCache offload: PAGE save did not land rank=%s req=%s "
+                    "skip=%d reason=%s error_type=%s",
+                    getattr(self, "_rank", "?"),
+                    req.req_id,
+                    skip,
+                    save_failure_reason,
+                    save_error_type,
+                )
             if slot_spec is not None:
                 if sidecar_published:
                     logger.info(
@@ -1704,6 +1783,10 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
             fss = set(self._failed_sidecar_save)
             self._done_sidecar_save.clear()
             self._failed_sidecar_save.clear()
+            dps = set(self._done_page_save)
+            fps = set(self._failed_page_save)
+            self._done_page_save.clear()
+            self._failed_page_save.clear()
         connector_completions = {
             ConnectorCompletion(
                 channel=DSV4_CHECKPOINT_SAVE_CHANNEL,
@@ -1719,6 +1802,22 @@ class DSV4OffloadConnector(OffloadWorkerMixin, KVConnectorBase):
                 succeeded=False,
             )
             for completion_id in fss
+        )
+        connector_completions.update(
+            ConnectorCompletion(
+                channel=DSV4_PAGE_SAVE_CHANNEL,
+                operation_id=completion_id,
+                succeeded=True,
+            )
+            for completion_id in dps
+        )
+        connector_completions.update(
+            ConnectorCompletion(
+                channel=DSV4_PAGE_SAVE_CHANNEL,
+                operation_id=completion_id,
+                succeeded=False,
+            )
+            for completion_id in fps
         )
         return KVConnectorOutput(
             finished_sending=set(),
@@ -1791,6 +1890,11 @@ class DSV4OffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         self._load_lifecycles: dict[str, object] = {}
         self._active_load_operations: dict[str, tuple[object, LoadOperationId]] = {}
         self._save_inflight: dict[str, set[SaveOperationId]] = {}
+        # sid -> {save operation: the watermark before that operation's advance}.
+        # ``build_connector_meta`` advances the saved watermark where it *emits*
+        # a save, so the advance is a prediction, not a fact. Keep what each one
+        # was contingent on so a save that never lands can take its advance back.
+        self._save_watermark_rollback: dict[str, dict[SaveOperationId, int]] = {}
         # Stateful PAGE/SLOT protocol. Sidecar commits are session-local because
         # worker-side sidecar storage is not queried by the scheduler.
         self._committed_sidecar_hashes = _BoundedLRUSet(
@@ -2325,6 +2429,9 @@ class DSV4OffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
                 )
             )
             if page_save_due:
+                self._save_watermark_rollback.setdefault(sid, {})[save_operation] = int(
+                    entry[1]
+                )
                 entry[1] = aligned
                 self._save_inflight.setdefault(sid, set()).add(save_operation)
             if sidecar_candidate is not None:
@@ -2377,6 +2484,58 @@ class DSV4OffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
             self._reqs_need_recv or self._save_inflight or self._sidecar_save_inflight
         )
 
+    @staticmethod
+    def _watermark_sid(operation) -> str:
+        return str(getattr(operation, "req_id", operation))
+
+    def _forget_save_watermark(self, operation) -> int | None:
+        """Drop one operation's contingency record, returning what it held."""
+        sid = self._watermark_sid(operation)
+        pending = self._save_watermark_rollback.get(sid)
+        if pending is None:
+            return None
+        previous = pending.pop(operation, None)
+        if not pending:
+            self._save_watermark_rollback.pop(sid, None)
+        return previous
+
+    def _release_save_watermark(self, operation) -> None:
+        """Retire the record of a save that landed; its advance was correct."""
+        self._forget_save_watermark(operation)
+
+    def _rollback_save_watermark(self, operation) -> None:
+        """Take back the watermark advance of a save that never landed.
+
+        The advance told every later incremental save to skip that range. With
+        nothing persisting it the range is a permanent hole in the prefix:
+        ``_page_boundary_visible`` can never see a PAGE hit reach
+        ``boundary_tokens``, so SLOT publication times out forever and no prefix
+        is ever complete -- which is why raising CPU capacity cannot help, one
+        saturation poisons the sequence. Lowering the watermark makes the next
+        step re-emit the range. Lowering past a *later* save that did land costs
+        one redundant write and nothing else: stores are idempotent, and the
+        prefix has to be contiguous anyway, so everything beyond the hole was
+        unusable regardless.
+        """
+        previous = self._forget_save_watermark(operation)
+        if previous is None:
+            return
+        sid = self._watermark_sid(operation)
+        entry = self._save_tracker.get(sid)
+        if entry is None:
+            return
+        current = int(entry[1])
+        if current <= previous:
+            return
+        entry[1] = previous
+        logger.warning(
+            "LMCache offload: save watermark rolled back req=%s %d -> %d "
+            "(save did not land); those PAGEs will be saved again",
+            sid,
+            current,
+            previous,
+        )
+
     def save_finished(self, req_id) -> None:
         if isinstance(req_id, SaveOperationId):
             sid = str(req_id.req_id)
@@ -2423,6 +2582,9 @@ class DSV4OffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         if sidecar is not None:
             self._cancel_save_statistics(sidecar[0])
         self._save_tracker.pop(sid, None)
+        # The tracker entry is gone, so there is no longer a watermark to take
+        # back; keeping the records would only leak.
+        self._save_watermark_rollback.pop(sid, None)
 
     def release_stalled_save(self, seq) -> None:
         """Drop bookkeeping for a stall-escaped save the scheduler is freeing.
@@ -2436,6 +2598,20 @@ class DSV4OffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
     def connector_completion(self, completion: ConnectorCompletion) -> bool:
         """Apply one TP-aggregated completion owned by the DSV4 scheduler."""
 
+        if completion.channel == DSV4_PAGE_SAVE_CHANNEL:
+            # `process_completions` runs this before `save_finished`, so the
+            # watermark is corrected while the operation is still in
+            # `_save_inflight`; clearing it there then lets the very next
+            # `build_connector_meta` re-emit the range.
+            if completion.succeeded:
+                self._release_save_watermark(completion.operation_id)
+            else:
+                self._rollback_save_watermark(completion.operation_id)
+                # Nothing was persisted, so these bytes must not land in
+                # `total_saved_tokens`; cancelling first makes the
+                # `_finish_save_statistics` in `save_finished` a no-op.
+                self._cancel_save_statistics(completion.operation_id)
+            return True
         if completion.channel != DSV4_CHECKPOINT_SAVE_CHANNEL:
             return False
         if completion.succeeded:
@@ -2533,6 +2709,7 @@ class DSV4OffloadScheduler(OffloadSchedulerMixin, KVConnectorSchedulerBase):
         if entry is not None and entry[0] is seq and not self.should_defer_free(seq):
             self._save_tracker.pop(sid, None)
             self._failed_sidecar_saves.pop(sid, None)
+            self._save_watermark_rollback.pop(sid, None)
         if hasattr(seq, "_load_operation"):
             delattr(seq, "_load_operation")
 

--- a/tests/test_lmcache_offload_connector.py
+++ b/tests/test_lmcache_offload_connector.py
@@ -60,6 +60,7 @@ from atom.kv_transfer.offload.hybrid.dsv4 import policy as connector_module
 from atom.kv_transfer.offload.hybrid.dsv4.codec import DSV4PageSlotCodec
 from atom.kv_transfer.offload.hybrid.dsv4.connector import (
     DSV4_CHECKPOINT_SAVE_CHANNEL,
+    DSV4_PAGE_SAVE_CHANNEL,
 )
 from atom.kv_transfer.offload.hybrid.dsv4.connector import (
     DSV4OffloadConnector as LMCacheOffloadConnector,
@@ -159,6 +160,7 @@ def _scheduler() -> LMCacheOffloadConnectorScheduler:
     sched._load_lifecycles = {}
     sched._active_load_operations = {}
     sched._save_inflight = {}
+    sched._save_watermark_rollback = {}
     sched._lookup_in_step = []
     sched._handoff_loads = set()
     sched.hash_block_size = 4
@@ -2555,6 +2557,149 @@ def test_save_callbacks_clear_only_matching_operation_generation():
     assert sched.should_defer_free(seq) is False
 
 
+def _page_completion(operation, *, succeeded: bool) -> ConnectorCompletion:
+    return ConnectorCompletion(DSV4_PAGE_SAVE_CHANNEL, operation, succeeded)
+
+
+def test_failed_page_save_rolls_the_watermark_back_and_re_emits():
+    """A PAGE save that never lands must not leave its range skipped forever.
+
+    The watermark is advanced where the save is *emitted*, so a save dropped on
+    admission takes a range of the prefix with it: every later incremental save
+    skips it, the PAGE boundary can never become visible, and SLOT publication
+    times out for the rest of the sequence's life. The scheduler only learns
+    this from the PAGE channel -- `finished_saving` reports the drop and the
+    success identically.
+    """
+    sched = _scheduler()
+    seq = SimpleNamespace(
+        id=730,
+        token_ids=list(range(16)),
+        block_table=[1, 2, 3, 4],
+        num_prompt_tokens=16,
+        num_cached_tokens=8,
+        has_per_req_cache=False,
+    )
+    sched._save_tracker["730"] = [seq, 0]
+
+    first = sched.build_connector_meta().requests[0]
+    assert first.save_spec.skip_leading_tokens == 0
+    assert sched._save_tracker["730"][1] == 8
+
+    # The worker dropped it (max_pending_saves). Nothing was persisted.
+    assert (
+        sched.connector_completion(
+            _page_completion(first.save_operation, succeeded=False)
+        )
+        is True
+    )
+    assert sched._save_tracker["730"][1] == 0
+    # Failure must not be counted as saved bytes.
+    assert sched.total_saved_tokens == 0
+
+    # `save_finished` still arrives, and clears the operation so the next step
+    # is free to re-emit the range the drop left behind.
+    sched.save_finished(first.save_operation)
+    assert sched._save_inflight == {}
+    assert sched.total_saved_tokens == 0
+
+    retry = sched.build_connector_meta().requests[0]
+    assert retry.save_operation != first.save_operation
+    assert retry.save_spec.skip_leading_tokens == 0
+    assert retry.token_ids == list(range(8))
+
+    # This one lands: the advance stands and the record is retired.
+    assert (
+        sched.connector_completion(
+            _page_completion(retry.save_operation, succeeded=True)
+        )
+        is True
+    )
+    assert sched._save_tracker["730"][1] == 8
+    assert sched._save_watermark_rollback == {}
+
+    sched.save_finished(retry.save_operation)
+    assert sched.total_saved_tokens == 8
+
+    seq.num_cached_tokens = 16
+    tail = sched.build_connector_meta().requests[0]
+    assert tail.save_spec.skip_leading_tokens == 8
+
+
+def test_page_watermark_records_do_not_outlive_their_request():
+    """Records are keyed by operation, so they must be dropped with the request."""
+    sched = _scheduler()
+    seq = SimpleNamespace(
+        id=731,
+        token_ids=list(range(16)),
+        block_table=[1, 2, 3, 4],
+        num_prompt_tokens=16,
+        num_cached_tokens=8,
+        has_per_req_cache=False,
+    )
+    sched._save_tracker["731"] = [seq, 0]
+    sched.build_connector_meta()
+    assert sched._save_watermark_rollback["731"]
+
+    sched.abandon_save(seq.id)
+    assert sched._save_watermark_rollback == {}
+
+    sched._save_tracker["731"] = [seq, 0]
+    sched.build_connector_meta()
+    assert sched._save_watermark_rollback["731"]
+
+    sched._save_inflight.clear()
+    sched.request_finished(seq)
+    assert sched._save_watermark_rollback == {}
+
+
+def test_worker_reports_a_page_verdict_on_every_terminal_path():
+    """A missing report strands the operation in the TP aggregator forever."""
+    conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
+    conn._lock = threading.Lock()
+    conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
+    conn._done_sidecar_save = set()
+    conn._failed_sidecar_save = set()
+    conn._pending_save_ops = {}
+    conn._pending_legacy_save_ops = {}
+    conn._max_pending_saves = 4
+
+    operation = SaveOperationId(732, 0)
+    req = SimpleNamespace(
+        req_id=732,
+        token_ids=list(range(8)),
+        block_ids=[1, 2],
+        save_spec=SimpleNamespace(skip_leading_tokens=0, can_save=True),
+        slot_save_spec=None,
+        save_operation=operation,
+    )
+
+    conn._finish_unadmitted_save(req)
+
+    assert conn._failed_page_save == {operation}
+    assert conn._done_page_save == set()
+    # It is still reported as terminal on the plain saving path, so the
+    # scheduler's inflight bookkeeping still clears.
+    assert conn._done_save == {operation}
+
+    # A SLOT-only save moved no watermark and must not claim a PAGE verdict.
+    conn._failed_page_save.clear()
+    conn._done_save.clear()
+    slot_only = SimpleNamespace(
+        req_id=733,
+        token_ids=list(range(8)),
+        block_ids=[1, 2],
+        save_spec=None,
+        slot_save_spec=SimpleNamespace(boundary_tokens=8, boundary_block_hash=7),
+        save_operation=SaveOperationId(733, 0),
+    )
+    conn._finish_unadmitted_save(slot_only)
+    assert conn._failed_page_save == set()
+    assert conn._done_page_save == set()
+
+
 def test_raw_callbacks_cannot_retire_exact_active_operations():
     page_sched = _scheduler()
     page_seq = SimpleNamespace(
@@ -3740,6 +3885,8 @@ def test_worker_completes_noop_load_when_hbm_satisfies():
     conn._done_load = set()
     conn._failed_load = set()
     conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
     conn._engine = SimpleNamespace(unpinned=[])
     conn._engine.lookup_unpin = lambda lookup_id: conn._engine.unpinned.append(
         lookup_id
@@ -3765,6 +3912,8 @@ def test_worker_load_terminal_paths_report_exact_operation_once():
     conn._done_load = set()
     conn._failed_load = set()
     conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
     conn._done_sidecar_save = set()
     conn._failed_sidecar_save = set()
     conn._pending_save_ops = {}
@@ -3837,6 +3986,8 @@ def test_worker_reports_unaligned_hbm_load_as_failed_without_exception():
     conn._done_load = set()
     conn._failed_load = set()
     conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
     conn.chunk_size = 4
     conn._engine = SimpleNamespace(unpinned=[])
     conn._engine.lookup_unpin = lambda lookup_id: conn._engine.unpinned.append(
@@ -3873,6 +4024,8 @@ def test_worker_save_uses_lmcache_engine_store():
     conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
     conn._lock = threading.Lock()
     conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
     conn._pending_save_ops = {}
     conn._pending_legacy_save_ops = {}
     conn._save_req_locks = {}
@@ -3918,6 +4071,8 @@ def test_worker_save_waits_for_forward_event_before_store():
     conn = LMCacheOffloadConnector.__new__(LMCacheOffloadConnector)
     conn._lock = threading.Lock()
     conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
     conn._pending_save_ops = {}
     conn._pending_legacy_save_ops = {}
     conn._save_req_locks = {}
@@ -3962,6 +4117,8 @@ def test_worker_load_uses_lmcache_engine_retrieve_and_marks_done():
     conn._done_load = set()
     conn._failed_load = set()
     conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
     conn.chunk_size = 4
     conn._engine = _Engine()
 
@@ -4005,6 +4162,8 @@ def test_worker_load_partial_retrieve_marks_failed():
     conn._done_load = set()
     conn._failed_load = set()
     conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
     conn.chunk_size = 4
     conn._engine = _Engine()
 
@@ -4027,6 +4186,8 @@ def test_load_exception_is_reported_as_failed_recving():
     conn._lock = threading.Lock()
     conn._done_load = set()
     conn._done_save = set()
+    conn._done_page_save = set()
+    conn._failed_page_save = set()
     conn._failed_load = set()
     req = SimpleNamespace(req_id=42)
 

--- a/tests/test_lmcache_offload_v4_page_slot.py
+++ b/tests/test_lmcache_offload_v4_page_slot.py
@@ -31,6 +31,7 @@ from atom.kv_transfer.offload.hybrid.dsv4.codec import (
 )
 from atom.kv_transfer.offload.hybrid.dsv4.connector import (
     DSV4_CHECKPOINT_SAVE_CHANNEL,
+    DSV4_PAGE_SAVE_CHANNEL,
     _env_nonnegative_float,
     _env_positive_float,
     _wait_for_publication,
@@ -482,6 +483,10 @@ def _worker(
     connector._done_save = _OrderedSet(order, "done")
     connector._done_sidecar_save = _OrderedSet(order, "sidecar-done")
     connector._failed_sidecar_save = _OrderedSet(order, "sidecar-failed")
+    # Plain sets: the PAGE channel is not part of the terminal ordering these
+    # tests assert on, so it must not be recorded into `order`.
+    connector._done_page_save = set()
+    connector._failed_page_save = set()
     connector._pending_save_ops = {}
     connector._pending_legacy_save_ops = {}
     connector._save_req_locks = {}
@@ -523,6 +528,103 @@ def _worker(
     connector._create_slot_stream = lambda: _FakeTransferStream(order)
     connector._slot_stream_context = lambda stream: nullcontext()
     return connector
+
+
+def _verdicts(connector) -> dict[str, dict]:
+    """Drain get_finished once and split completions by channel.
+
+    `get_finished` clears the underlying sets, so a test that wants both the
+    PAGE and the SLOT verdict has to read them out of the same drain.
+    """
+    out = connector.get_finished()
+    by_channel: dict[str, dict] = {
+        DSV4_PAGE_SAVE_CHANNEL: {},
+        DSV4_CHECKPOINT_SAVE_CHANNEL: {},
+    }
+    for c in out.connector_completions:
+        by_channel.setdefault(c.channel, {})[c.operation_id] = c.succeeded
+    return by_channel
+
+
+def _page_verdict(connector) -> dict:
+    return _verdicts(connector)[DSV4_PAGE_SAVE_CHANNEL]
+
+
+def test_page_verdict_fails_when_the_store_raises():
+    """The executor path must report the PAGE failure, not just log it."""
+    order: list[str] = []
+    connector = _worker(order)
+    connector._engine.store_error = RuntimeError("store exploded")
+    request = _save_request()
+
+    connector._do_save_req(request, None, None)
+
+    assert _page_verdict(connector) == {request.req_id: False}
+
+
+def test_page_verdict_fails_when_coverage_never_becomes_visible():
+    """A visibility timeout must not be reported as a landed PAGE save.
+
+    `store` returning is not proof the PAGEs are queryable. Committing the
+    watermark here would leave exactly the hole this channel exists to prevent.
+    """
+    order: list[str] = []
+    connector = _worker(order)
+    _inject_fake_publication_clock(connector)
+    connector._engine.lookup_hit = 0  # boundary is 8; never satisfied
+    request = _save_request()
+
+    connector._do_save_req(request, None, None)
+
+    seen = _verdicts(connector)
+    assert seen[DSV4_PAGE_SAVE_CHANNEL] == {request.req_id: False}
+    assert seen[DSV4_CHECKPOINT_SAVE_CHANNEL] == {request.req_id: False}
+
+
+def test_page_verdict_survives_a_sidecar_failure_after_coverage_is_visible():
+    """PAGE landed and was confirmed; a later SLOT failure must not revoke it."""
+    order: list[str] = []
+    connector = _worker(order)
+    connector._engine.lookup_hit = 8  # boundary satisfied
+    connector._slot_store.put_result = False  # sidecar put is rejected
+    request = _save_request()
+
+    connector._do_save_req(request, None, None)
+
+    seen = _verdicts(connector)
+    assert seen[DSV4_PAGE_SAVE_CHANNEL] == {request.req_id: True}
+    assert seen[DSV4_CHECKPOINT_SAVE_CHANNEL] == {request.req_id: False}
+
+
+def test_page_verdict_succeeds_for_a_page_only_save():
+    """With no SLOT spec there is no probe, so a clean store is the verdict."""
+    order: list[str] = []
+    connector = _worker(order)
+    request = LMCacheReqMeta(
+        req_id=71,
+        token_ids=list(range(8)),
+        block_ids=[10, 11],
+        save_spec=SaveSpec(skip_leading_tokens=0),
+        slot_save_spec=None,
+    )
+
+    connector._do_save_req(request, None, None)
+
+    assert _page_verdict(connector) == {request.req_id: True}
+
+
+def test_page_verdict_reported_when_executor_submission_is_rejected():
+    """`_finish_rejected_save` is a terminal path and owes a verdict too."""
+    order: list[str] = []
+    connector = _worker(order)
+    request = _save_request()
+
+    connector._save_admission.acquire()
+    connector._begin_save_operation(request.req_id, None)
+
+    connector._finish_rejected_save(request, None, None)
+
+    assert _page_verdict(connector) == {request.req_id: False}
 
 
 def _inject_fake_publication_clock(


### PR DESCRIPTION
## Problem

`DSV4OffloadScheduler` advances a sequence's saved watermark where the save is
**emitted** — before admission, before execution — and reads it one step later as
`SaveSpec.skip_leading_tokens`. The advance is a prediction, and nothing checked it.

Save admission is a non-blocking `BoundedSemaphore`, so a save rejected on
`max_pending_saves` is dropped and never retried while the watermark has already
moved past it. A save that dies inside the executor is worse: `_do_save_req`
catches its own exceptions and does not re-raise, so the operation is reported as
**success**. Either way every later incremental save skips that range, leaving a
permanent hole in the persisted prefix. Nothing on the save side ever lowers
`entry[1]` — the only lowering lives in `load_failed`.

One hole is enough to disable the sequence. `_page_boundary_visible` requires
`lookup(tokens[:boundary]) >= boundary`, and `lookup` returns a **contiguous**
prefix length, so a gap anywhere at or before the boundary truncates the hit
there and SLOT publication times out for the rest of that sequence's life.

This is why raising CPU capacity cannot help: capacity only changes how often the
queue saturates, and one saturation poisons that sequence permanently. Higher
concurrency saturates more often, which is why 256-concurrency failed and low
concurrency did not.

## Why the rollback needed new plumbing first

The scheduler could not tell a save that landed from one that did not.
`get_finished` reports PAGE saves only through `finished_saving` — one
undifferentiated set — and `save_finished` takes no success flag. The
`connector_completions` channel, which does carry `succeeded` and is TP
aggregated, was wired only for the SLOT sidecar. PAGE had no failure channel at
all, so there was nothing a rollback could hang off.

## Change

Give PAGE saves their own completion channel, alongside the sidecar's.

**Worker** — `DSV4_PAGE_SAVE_CHANNEL`, reusing the existing generic completion
mechanism: channel dispatched, TP aggregated, failure dominant (if any rank did
not persist its shard, the range is not durable). No shared structures change. A
verdict is reported on every terminal path — rejection before admission,
rejection at submission, and out of the executor via a `page_stored` flag — plus
a backstop in `_guard`, because an operation that reports nothing would sit in
the TP aggregator forever.

**Scheduler** — record what each advance was contingent on, keyed by save
operation. `connector_completion` releases the record on success and, on failure,
rolls the watermark back and cancels the save statistics so bytes that never
landed do not inflate `total_saved_tokens`.

Ordering works because `process_completions` applies `connector_completions`
before `finished_saving`: the watermark is corrected while the operation is still
in `_save_inflight`, and the next `build_connector_meta` re-emits the range.
Rolling back past a later save that did land costs one redundant write and
nothing else — stores are idempotent, and a prefix has to be contiguous anyway.

## Verification

Measured on DeepSeek-V4-Pro, PD-disaggregated, concurrency 256 with 8 x 128 GiB
`LocalCPUBackend`, against the same configuration on the unfixed code:

| signal | before | after |
|---|---|---|
| `page_visibility_timeout` | 1,874 | **0** |
| SLOT sidecar failure rate | 83.7% | 26.0% |
| SLOT loads restored | 23 | **1,075** |
| bytes read back from CPU | 0.58 GiB | **27.17 GiB** |
| outcome | operator-aborted in warmup | completed |

The failure mode is worth naming precisely, because it is easy to miss: the
unfixed run did **not** error and did **not** crash. Client-side `errors` stayed
at 0 and every request returned normally. What happened is that each SLOT save
waits on `_page_boundary_visible`, a hole makes that wait unsatisfiable, and the
save burns its full timeout before giving up — so the run simply never finished
warmup. It reached 1,293 of 2,845 warmup requests in 2,250 s, work the fixed
build does in 1,800 s, and was stopped by hand. The only outward signal is 1,874
timeout lines in the server log.

(Both builds log a handful of `KV transfer drain during shutdown failed`
tracebacks at teardown; those are unrelated to this change and present either
way.)

In one 3,600 s run the fix rolled back 6,723 advances covering **29,989,120
tokens** across 6,183 sequences — all of which the unfixed code would have
declared saved and never written. 1,148 of those holes sat at offset 0, where the
prefix is worth nothing at all; the rest had a median offset of 79,616 tokens.

Rollback tracks rejection 1:1 and is a load-step transient, not a runaway: the
rate spikes on each concurrency ramp and decays within two minutes.
`PAGE save did not land` stayed at 0, so the executor-internal path is covered
but not yet exercised.

## Tests

556 passed, 1 skipped across the `kv_transfer` suites. The new rollback test is
not vacuous — neutering `_rollback_save_watermark` makes it fail with
`assert 8 == 0`, which is exactly the hole.

- `test_failed_page_save_rolls_the_watermark_back_and_re_emits`
- `test_page_watermark_records_do_not_outlive_their_request`
- `test_worker_reports_a_page_verdict_on_every_terminal_path`

The hand-rolled `__new__` fixtures mirror `__init__` field by field, so they
carry the two new sets.

## Not covered here

SLOT sidecar saves still fail at roughly 15-25% under load, and are deliberately
not retried. That is a separate issue: `OFFLOAD_SLOT_STAGING_SLOTS` defaults to 1,
so each rank has a single staging row contended by saves and by loads that hold it
for a whole batch. Unlike the PAGE hole this costs cache hit rate, not
correctness — a missing sidecar is a miss on a later load, not a corrupt prefix.

