### PR TITLE
perf(minimax-m3): route the sparse selection to the kernel its row count wins on

### DIFF
--- a/atom/model_ops/minimax_m3/sparse_attn.py
+++ b/atom/model_ops/minimax_m3/sparse_attn.py
@@ -10,6 +10,7 @@ Only the MiniMax M3 paths are implemented: base-2 softmax, no attention sink,
 and split-K decode with a separate merge step.
 """
 
+import functools
 from dataclasses import dataclass
 
 import aiter
@@ -122,6 +123,68 @@ def _is_fp8_kv_cache_tensor(kv_cache: torch.Tensor) -> bool:
         getattr(torch, "float8_e5m2", None),
     )
     return kv_cache.dtype in {dtype for dtype in fp8_dtypes if dtype is not None}
+
+
+@functools.cache
+def _gluon_one_pass_max_rows(device_index: int | None) -> int:
+    """Rows up to which split-KV still covers the GPU one workgroup per CU.
+
+    Under it gluon wins (ASM is launch-bound), over it loses (its workgroups
+    stop fitting). Measured on MI355X, 256 CU: gluon 9.4 / 10.4 / 15.0us at
+    1 / 32 / 40 rows against ASM 12.7 / 14.2 / 14.3 -- re-measure before moving
+    it. Splits is non-increasing in rows, so rows=1 asks aiter for its own cap
+    rather than restating it here, where the two could drift apart.
+    """
+    from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
+
+    cus = torch.cuda.get_device_properties(device_index).multi_processor_count
+    return max(1, cus // get_recommended_splits(1, 1))
+
+
+def _sparse_pa_ran_on_asm(
+    q: torch.Tensor,  # [rows, query_group_size, head_dim]
+    k_cache: torch.Tensor,  # page-16 SHUFFLE, kv-head already collapsed
+    v_cache: torch.Tensor,
+    sparse_bt: torch.Tensor,
+    sparse_ctx: torch.Tensor,
+    k_scale: torch.Tensor | None,
+    v_scale: torch.Tensor | None,
+    out: torch.Tensor,
+) -> bool:
+    """Run the selection on ASM; False if ASM is unfit or unprofitable here.
+
+    The test sits with the call because past ``PA_ASM_MAX_QUERY_GROUP_SIZE``
+    the heuristic substitutes an mtp=1 kernel and answers wrongly rather than
+    refusing -- a test that can be skipped is one that will be. bf16 KV is in
+    the table but unmeasured, so it is not claimed; too few rows and ASM fits
+    but loses, see ``_gluon_one_pass_max_rows``.
+    """
+    from atom.model_ops.base_attention import (
+        PA_ASM_MAX_QUERY_GROUP_SIZE,
+        run_pa_fwd_asm,
+    )
+
+    if (
+        k_scale is None
+        or not _is_fp8_kv_cache_tensor(k_cache)
+        or q.shape[1] > PA_ASM_MAX_QUERY_GROUP_SIZE
+        or q.shape[0] <= _gluon_one_pass_max_rows(q.device.index)
+    ):
+        return False
+
+    pages, pbs = k_cache.shape[0], k_scale.shape[-1]
+    run_pa_fwd_asm(
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        block_tables=sparse_bt,
+        context_lens=sparse_ctx,
+        k_scale=k_scale.view(pages, 1, pbs),
+        v_scale=v_scale.view(pages, 1, pbs),
+        out=out,
+        max_qlen=1,
+    )
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1146,28 +1209,17 @@ def minimax_m3_sparse_attn_decode_asm(
     sparse_bt: torch.Tensor | None = None,  # prebuilt (fused topk) -> skip build
     sparse_ctx: torch.Tensor | None = None,
 ) -> None:
-    """Block-sparse decode attention via the AITER Gluon paged-attention kernel.
+    """Block-sparse decode attention over the page-16 SHUFFLE KV cache.
 
     The lightning-indexer's selected logical 128-blocks are compacted into a
     dense PHYSICAL 16-page block_table (each 128-block -> 8 pages, tail packed
-    last) + exact context_lens, then fed to the Gluon split-KV paged-attention
-    decode kernel (``pa_decode_gluon``) over the page-16 SHUFFLE KV cache. The
-    split-KV (flash-decoding) implementation is more efficient than the monolithic
-    ASM kernel at low concurrency (few decode sequences), where it parallelizes
-    over KV partitions to keep the GPU busy.
-
-    If ``sparse_bt`` / ``sparse_ctx`` are provided (built fused inside the topk
-    merge kernel), the standalone compaction launch is skipped.
+    last) + exact context_lens, then run one row per sequence. A ``sparse_bt`` /
+    ``sparse_ctx`` built fused inside the topk merge kernel skips the standalone
+    compaction launch.
 
     Requires per-rank num_kv_heads == 1 (the indexer top-k is per-kv-head; one
     shared block_table cannot express per-kv-head selection) and head_dim == 128.
     """
-    from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
-
-    from atom.model_ops.base_attention import run_pa_decode_gluon
-
-    assert q.shape[-1] == 128, "Gluon paged-attention requires head_dim == 128."
-
     if sparse_bt is None or sparse_ctx is None:
         # Standalone (non-fused) build is num_kv_heads==1 only; the fused topk emit
         # is what produces the kv-head-collapsed sparse_bt/ctx for num_kv_heads>1.
@@ -1179,86 +1231,22 @@ def minimax_m3_sparse_attn_decode_asm(
             topk_idx, block_table, seq_lens
         )
 
-    # Collapse (token, kv_head) into the row dim so gluon runs with an effective
-    # num_kv_heads_view == 1. ZERO data copy: q/cache/output/scale are views, and
-    # sparse_bt already encodes the kv-head in its page ids (page = phys16*Hkv+kvh,
-    # matching the collapsed cache view [num_phys16*Hkv, 1, ...]).
-    #   q:    [T, Hq, 128]               -> [T*Hkv, g, 128]   (g = Hq // Hkv)
-    #   kv:   [num_phys16, Hkv, ...]      -> [num_phys16*Hkv, 1, ...]
-    #   out:  [T, Hq, 128]               -> [T*Hkv, g, 128]
-    # Hkv == 1 is the identity (no shape change).
-    assert q.is_contiguous(), "decode_asm requires contiguous q for the kv-head view"
-    T, num_q_heads_total, head_size = q.shape
-    g = num_q_heads_total // num_kv_heads
-    q_view = q.view(T * num_kv_heads, g, head_size)
-    out_view = output.view(T * num_kv_heads, g, head_size)
-    # .view (not .reshape): the SHUFFLE cache slices are contiguous, so collapsing
-    # (num_phys16, Hkv) -> num_phys16*Hkv is guaranteed zero-copy; a copy here would
-    # silently break the page-id encoding alignment.
-    nph16, _hkv = k_cache.shape[0], k_cache.shape[1]
-    k_cache_view = k_cache.view(nph16 * _hkv, 1, *k_cache.shape[2:])
-    v_cache_view = v_cache.view(nph16 * _hkv, 1, *v_cache.shape[2:])
-
-    num_seqs = T * num_kv_heads
-    num_kv_heads_view = 1
-    query_group_size = g
-    max_context_partition_num = get_recommended_splits(num_seqs, num_kv_heads_view)
-    context_partition_size = 256
-    intermediate_shape = (
-        num_seqs,
-        num_kv_heads_view,
-        max_context_partition_num,
-        query_group_size,
+    _sparse_pa_per_row(
+        q,
+        k_cache,
+        v_cache,
+        sparse_bt,
+        sparse_ctx,
+        num_kv_heads,
+        sm_scale,
+        output,
+        k_scale,
+        v_scale,
     )
-    exp_sums = torch.empty(intermediate_shape, dtype=torch.float32, device=q.device)
-    max_logits = torch.empty(intermediate_shape, dtype=torch.float32, device=q.device)
-    temporary_output = torch.empty(
-        *intermediate_shape, head_size, dtype=q.dtype, device=q.device
-    )
-    # fp8 KV cache -> fp8 compute_type + per-token scales; bf16 otherwise. The scale
-    # tensor [num_phys16, Hkv, pbs] collapses the same way as the cache.
-    is_fp8 = _is_fp8_kv_cache_tensor(k_cache)
-    compute_type = aiter.dtypes.fp8 if is_fp8 else torch.bfloat16
-    if is_fp8 and k_scale is not None:
-        # [num_phys16, Hkv, pbs] -> [num_phys16*Hkv, 1, pbs, 1], matching the cache.
-        pbs = k_scale.shape[-1]
-        gluon_k_scale = k_scale.view(nph16 * _hkv, 1, pbs).unsqueeze(-1)
-        gluon_v_scale = v_scale.view(nph16 * _hkv, 1, pbs).unsqueeze(-1)
-    else:
-        gluon_k_scale = gluon_v_scale = None
-    run_pa_decode_gluon(
-        output=out_view,
-        q=q_view,
-        k_cache=k_cache_view,
-        v_cache=v_cache_view,
-        context_lens=sparse_ctx,
-        block_tables=sparse_bt,
-        softmax_scale=sm_scale,
-        max_seqlen_q=1,
-        max_context_partition_num=max_context_partition_num,
-        context_partition_size=context_partition_size,
-        compute_type=compute_type,
-        q_scale=None,
-        k_scale=gluon_k_scale,
-        v_scale=gluon_v_scale,
-        exp_sums=exp_sums,
-        max_logits=max_logits,
-        temporary_output=temporary_output,
-        alibi_slopes=None,
-        sinks=None,
-        sliding_window=-1,
-        ps=True,
-    )
-
-
-# ---------------------------------------------------------------------------
-# ASM paged-attention PREFILL path (per-token-as-decode).
-#
-# In M3 sparse attention each prefill query token attends its OWN per-token top-k
 
 
 @torch.no_grad()
-def _run_prefill_fp8_gluon(
+def _sparse_pa_per_row(
     q: torch.Tensor,  # [total_q, num_heads, head_dim==128]
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
@@ -1270,29 +1258,46 @@ def _run_prefill_fp8_gluon(
     k_scale: torch.Tensor | None,
     v_scale: torch.Tensor | None,
 ) -> None:
-    """fp8 prefill via the Gluon split-KV decode kernel (per-token-as-decode).
+    """Run one sparse selection per row, on ASM where it pays and Gluon else.
 
-    Each of the ``total_q`` query tokens is treated as an independent length-1
-    "sequence" with its own sparse 16-page block_table + causal context_len --
-    identical setup to ``minimax_m3_sparse_attn_decode_asm``, just with
-    ``num_seqs == total_q``. This avoids the pa_fwd_asm maskless-fp8 NaN bug at
-    the 256-token boundary (see caller).
+    A row is a decode sequence or a prefill query token -- both are a length-1
+    "sequence" with its own 16-page block_table + context_len, so both halves
+    are this one function and the shape alone picks the kernel.
+
+    Prefill was Gluon-only until the pa_fwd_asm "maskless-fp8 NaN at the
+    256-token boundary" it was avoiding turned out not to reproduce: 32768 rows
+    over every causal length 1..2048 give zero NaN and cos 0.9993 vs gluon.
     """
     from aiter.ops.triton.gluon.pa_decode_gluon import get_recommended_splits
 
     from atom.model_ops.base_attention import run_pa_decode_gluon
 
-    # Collapse (token, kv_head) -> row so gluon runs num_kv_heads_view == 1, mirroring
-    # minimax_m3_sparse_attn_decode_asm. sparse_bt/ctx are already [T*Hkv, ...] with
-    # kv-head-encoded page ids. Zero-copy views; Hkv == 1 is the identity.
-    assert q.is_contiguous(), "prefill gluon requires contiguous q for the kv-head view"
+    assert q.shape[-1] == 128, "Paged attention here requires head_dim == 128."
+    # Collapse (token, kv_head) -> row so gluon runs num_kv_heads_view == 1.
+    # sparse_bt/ctx already carry kv-head-encoded page ids (page = phys16*Hkv +
+    # kvh), matching the collapsed cache view. Zero-copy; Hkv == 1 is identity.
+    assert q.is_contiguous(), "contiguous q required for the kv-head view"
     T, num_q_heads_total, head_size = q.shape
     g = num_q_heads_total // num_kv_heads
     q_view = q.view(T * num_kv_heads, g, head_size)
     out_view = output.view(T * num_kv_heads, g, head_size)
+    # .view, not .reshape: the SHUFFLE slices are contiguous so this is always
+    # zero-copy, and a copy would silently break the page-id encoding alignment.
     nph16, _hkv = k_cache.shape[0], k_cache.shape[1]
     k_cache_view = k_cache.view(nph16 * _hkv, 1, *k_cache.shape[2:])
     v_cache_view = v_cache.view(nph16 * _hkv, 1, *v_cache.shape[2:])
+
+    if _sparse_pa_ran_on_asm(
+        q_view,
+        k_cache_view,
+        v_cache_view,
+        sparse_bt,
+        sparse_ctx,
+        k_scale,
+        v_scale,
+        out_view,
+    ):
+        return
 
     num_seqs = T * num_kv_heads
     num_kv_heads_view = 1
@@ -1381,8 +1386,6 @@ def minimax_m3_sparse_attn_prefill_asm(
     that don't populate it), derive it on-device, SYNC-FREE, via searchsorted /
     arange (no .item(), no GPU repeat_interleave).
     """
-    assert q.shape[-1] == 128, "ASM paged-attention requires head_dim == 128."
-
     total_q = q.shape[0]
     device = q.device
     if qo_indptr is None:
@@ -1410,7 +1413,7 @@ def minimax_m3_sparse_attn_prefill_asm(
             topk_idx, block_table, query_req_id, query_abs_pos
         )
 
-    _run_prefill_fp8_gluon(
+    _sparse_pa_per_row(
         q,
         k_cache,
         v_cache,

--- a/atom/model_ops/triton_fused_qkv_norm_rope_cache.py
+++ b/atom/model_ops/triton_fused_qkv_norm_rope_cache.py
@@ -13,9 +13,9 @@ Returns freshly allocated contiguous (q_out, k_out).
 """
 
 import torch
-from torch import Tensor
 import triton
 import triton.language as tl
+from torch import Tensor
 
 
 @triton.jit
@@ -76,6 +76,7 @@ def _fused_qkv_norm_rope_cache_kernel(
     ROTARY_DIM: tl.constexpr,
     ROTARY_DIM_HALF: tl.constexpr,
     IS_FP8: tl.constexpr,
+    FP8_AMAX: tl.constexpr,
     # M-RoPE section boundaries (cumulative)
     MROPE_S0: tl.constexpr = 0,
     MROPE_S1: tl.constexpr = 0,
@@ -244,7 +245,7 @@ def _fused_qkv_norm_rope_cache_kernel(
             if IS_FP8:
                 # FP8 per-token quantization for k
                 k_abs_max = tl.max(tl.abs(k_roped), axis=0)
-                k_scale = k_abs_max / 240.0
+                k_scale = k_abs_max / FP8_AMAX
                 k_scale = tl.where(k_scale == 0.0, 1.0, k_scale)
                 k_quant = (k_roped / k_scale).to(k_cache_ptr.dtype.element_ty)
 
@@ -276,7 +277,7 @@ def _fused_qkv_norm_rope_cache_kernel(
                 # FP8 per-token quantization for v
                 v_f32 = v.to(tl.float32)
                 v_abs_max = tl.max(tl.abs(v_f32), axis=0)
-                v_scale = v_abs_max / 240.0
+                v_scale = v_abs_max / FP8_AMAX
                 v_scale = tl.where(v_scale == 0.0, 1.0, v_scale)
                 v_quant = (v_f32 / v_scale).to(v_cache_ptr.dtype.element_ty)
 
@@ -342,6 +343,10 @@ def triton_fused_norm_rope_cache(
     sin_cache = rotary_emb.sin_cache.squeeze(-2).squeeze(-2)
 
     is_fp8 = kv_cache_dtype == "fp8"
+    # From the destination tensor, not the FP8 type this build prefers: a scale
+    # is only right if it is the range of what receives it. K and V are two
+    # views of one pool, so one answer covers both.
+    fp8_amax = float(torch.finfo(k_cache.dtype).max)
 
     block_size = k_cache.shape[3]  # k_cache: [B, H, D//X, block_size, X]
     x_size = k_cache.shape[4]
@@ -410,6 +415,7 @@ def triton_fused_norm_rope_cache(
         ROTARY_DIM=rotary_dim,
         ROTARY_DIM_HALF=rotary_dim // 2,
         IS_FP8=is_fp8,
+        FP8_AMAX=fp8_amax,
         MROPE_S0=s0,
         MROPE_S1=s1,
         IS_MROPE=is_mrope,


### PR DESCRIPTION
## What

MiniMax-M3 sparse attention ran every selection through the Gluon split-KV decode kernel. Both halves — a decode's sequences and a prefill's per-token "sequences" — feed the same compacted 16-page block table, so which kernel is right is a property of the **row count**, not of the caller. This routes each shape to the kernel that wins on it, and collapses the two parallel implementations into one.

A second, independent commit fixes an fp8 scale that used a literal `240.0`.

## Why

**Above ~32 rows the ASM kernel wins**, which is where every prefill chunk lives:

| workload | before | after | |
|---|---|---|---|
| 8192/1024 conc 64, mult 4 | 26,514 tok/s | 35,440 | **+33.7%** |
| 100k/10 conc 50, tp4 | 39,862 tok/s | 50,561 | **+26.8%** |
| attention, traced | 24.11 s | 7.56 s | **−68.6%** |

**Below ~32 rows it loses**, because ASM is launch-bound at those sizes while split-KV still covers the GPU. Per-call device time (aiter `run_perftest`, rotating args, fp8 KV, g=16, ctx 2048, MI355X):

| rows | ASM µs | Gluon µs |
|---:|---:|---:|
| 1 | 12.7 | **9.4** |
| 32 | 14.2 | **10.4** |
| 40 | **14.3** | 15.0 |
| 128 | **15.3** | 26.0 |

So those shapes keep the kernel they had. `_gluon_one_pass_max_rows` derives the floor from the CU count and aiter's own split cap rather than restating a constant that could drift away from it; it evaluates to 32 on MI355X, matching the measurement.

The prefill half had been avoiding a `pa_fwd_asm` "maskless-fp8 NaN at the 256-token boundary". 32768 rows over every causal length 1..2048 give zero NaN and cos 0.9993 against gluon, so that avoidance is dropped.

## fp8 scale

The fused qk-norm/RoPE/cache kernel divided by `240.0` — the max of `e4m3fnuz` — while `aiter.dtypes.fp8` on this build is `e4m3fn`, max 448. The range now comes from the tensor the kernel stores into, so the scale and the store that spends it cannot be set independently and disagree. Quality-neutral over a 6-run alternating GSM8K comparison (the arms' intervals overlap completely).

## Test plan

- [x] Unit tests: 9 failed / 6078 passed, failure set identical to `main` (`test_deepseek_v4_wo_a_dequant` ×3, `test_heavy_ci_gate` ×6 — neither touches these modules)
- [x] GSM8K flexible/strict **0.9447 / 0.9454**, inside the n=3 alternating baseline 0.9434 [0.9393–0.9454]
- [x] MTP acceptance **72.45%**, inside baseline 72.62% [72.45–72.77]
- [x] Row sweep reproduces the dispatch table at 1/8/32/40/48/128 rows; `cos(production, gluon)` is exactly 1.0000 at or below the floor and 0.9987 above it, so the flip lands on the boundary
- [x] Decode entry is **bitwise equal** to calling the shared implementation directly, on both sides of the floor (it forwards ten positional arguments; a swap there is invisible to a timing sweep)
- [x] `black` + `ruff` clean

No new unit test: the floor needs aiter and a live CUDA device, neither of which CI has, so a test for it would never execute there. The evidence is the benchmark, which is reproducible.

## Risk

Dispatch-only. Below the floor the code routes to the Gluon path that shipped before this work, not to anything new. `.view` (not `.reshape`) discipline on the SHUFFLE cache collapse is preserved, with the reason kept next to it.
