### PR TITLE
setting HSA_ENABLE_IPC_MODE_LEGACY=1 to avoid GPU memory pin after hi…

### DIFF
--- a/docker/vllm_release.dockerfile
+++ b/docker/vllm_release.dockerfile
@@ -17,6 +17,10 @@ ENV MAX_JOBS=${MAX_JOBS}
 ENV VLLM_TARGET_DEVICE=rocm
 ENV CMAKE_MAKE_PROGRAM=/usr/local/bin/ninja
 
+# Use legacy IPC mode for HSA to avoid GPU memory pinning issues
+# See: https://github.com/ROCm/rocm-libraries/issues/6266
+ENV HSA_ENABLE_IPC_MODE_LEGACY=1
+
 # Preserve the base image's custom RCCL before any OOT apt runs.
 # The native base builds RCCL from the pinned RCCL_BRANCH (build_rccl stage) and
 # installs it to /usr/local/lib with an /etc/ld.so.conf.d/rccl.conf entry, so


### PR DESCRIPTION
With atom+lmcache sidecar implementation, whenever vllm crashes, it will enter a crashloop with not enough free GPU memory and prevent vllm from self-recovering.

We've confirmed that on vllm image lmcache reaps the dead worker from registry and de-registers the vram it held, and memory is reclaimed correctly.

This is later confirmed to be caused by [issues/6266](https://github.com/ROCm/rocm-libraries/issues/6266), thus setting HSA_ENABLE_IPC_MODE_LEGACY=1 to avoid GPU memory pin after hipFree. Same env is set on [vllm dockerfile](https://github.com/vllm-project/vllm/blob/485421b1c3572597a4cfaece04836a843537435a/docker/Dockerfile.rocm#L856) 