### PR TITLE
perf(moe): use fixed-slot MegaMoE for small decode graphs

### DIFF
--- a/atom/model_ops/fused_moe/flydsl_mega_experts.py
+++ b/atom/model_ops/fused_moe/flydsl_mega_experts.py
@@ -11,9 +11,13 @@ lives inside aiter, so there is no ``ATOM_FLYDSL_KERNELS_PATH`` and no
 MegaMoEV2 auto-selects its execution config from the runtime token count and
 ``max_tok_per_rank`` (MTPR): MTPR<=255 -> low-latency fixed-slot path,
 MTPR>=256 -> compact path (``FIXED_SLOT_MAX_MTPR``). MTPR must be a positive
-power of two. It is passed in as ``max_num_tokens`` (ATOM's
-``max_num_batched_tokens``) so that every rank uses the same value: MTPR also
-selects the p2p wire format, and a rank-dependent MTPR desynchronises it.
+power of two. The configured ``max_num_tokens`` remains the fallback capacity.
+For native ATOM EP8 with 48 experts per rank, DP-unified forwards with at most 128
+padded token rows can use a second, 128-token instance. Target verification
+and draft passes use their own token counts, including MTP and graph padding.
+MTPR also selects the p2p wire format, so the choice must use group-agreed
+metadata, never a rank's local request count. Set ATOM_MEGA_DECODE_FAST_PATH=0
+to retain the configured capacity for all forwards.
 
 Weight prep uses aiter's own shuffles (``aiter.ops.shuffle``):
   w1/w1_scale: ``shuffle_weight_a16w4(., 16, gate_up=True)`` /
@@ -23,8 +27,9 @@ Weight prep uses aiter's own shuffles (``aiter.ops.shuffle``):
 Shuffled tensors stay expert-major + contiguous, so EPLB can migrate their
 expert-major views in place.
 
-Memory: ONE MegaMoEV2 is shared across all MoE layers (process-level cache keyed
-by shape/quant/mtpr); per-layer weights are swapped in before forward
+Memory: MegaMoEV2 instances are shared across all MoE layers (process-level
+cache keyed by shape/quant/mtpr); both capacities are built in the same order
+on all ranks before capture. Per-layer weights are swapped in before forward
 (``_s1_w1`` / ``_s1_w1_scale`` / ``w2`` / ``w2_scale`` are runtime pointer args,
 not baked into the kernel).
 """
@@ -36,15 +41,36 @@ import os
 
 import torch
 
+from atom.plugin import is_plugin_mode
+from atom.utils import envs
+
 logger = logging.getLogger("atom")
 
 _MEGA_CACHE: dict = {}
 _MEGA_ROUTE_ROWS: dict[tuple[torch.device, int], torch.Tensor] = {}
 _MEGA_BUILD_DBG = False
+_MEGA_DECODE_MTPR = 128
+_MEGA_CAPACITY_LOGGED: set[tuple[bool, int, int]] = set()
 
 
 def _os_env(k):
     return os.environ.get(k, "<unset>")
+
+
+def _select_decode_mtpr(mtpr: int, context, *, tbo_active: bool) -> int:
+    """Select from already allocated capacities using the pass's shared shape.
+
+    A decode rank can have a prefilling peer. Only ``running_tokens_are_unified``
+    proves that every DP rank agreed on this shape. Do not gate on is_prefill or
+    is_dummy_run: a draft pass also runs on idle peers whose parent batch flags
+    can differ. TBO contexts keep the existing capacity. ``running_bs`` counts
+    requests and underestimates MTP verification rows.
+    """
+    if context is None or not context.running_tokens_are_unified or tbo_active:
+        return mtpr
+    if 0 < context.running_tokens <= _MEGA_DECODE_MTPR:
+        return _MEGA_DECODE_MTPR
+    return mtpr
 
 
 def build_mega_weights(layer) -> None:
@@ -127,6 +153,11 @@ def get_or_build_mega_moe(
     )
     m = _MEGA_CACHE.get(key)
     if m is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                f"MegaMoE capacity {mtpr} was not warmed before graph capture; "
+                "its symmetric workspace must be allocated on every rank first"
+            )
         from aiter.ops.flydsl.kernels.mega_moe import MegaMoEV2
 
         # MegaMoEV2 auto-selects fixed-slot vs compact and its GEMM tiles from
@@ -148,6 +179,13 @@ def get_or_build_mega_moe(
                 swiglu_limit=swiglu_limit,
             )
         _MEGA_CACHE[key] = m
+        if rank == 0:
+            logger.info(
+                "[MEGA-CAPACITY] built capacity=%d, ep=%d, experts/rank=%d",
+                mtpr,
+                world_size,
+                experts // world_size,
+            )
 
     # Bind this layer's weights on EVERY call, not only on build: the cache key
     # has no weight component, so ONE instance is shared by all MoE layers (they
@@ -202,22 +240,70 @@ def run_mega_moe(
     if not hasattr(layer, "_mega_w1"):
         raise RuntimeError("MegaMoE weights were not prepared")
 
-    # Returns the shared MegaMoEV2 already bound to this layer's weights.
-    mega = get_or_build_mega_moe(
-        rank=rank,
-        world_size=world,
-        model_dim=model_dim,
-        inter_dim=inter_dim,
-        experts=experts,
-        topk=topk,
-        quant=quant,
-        mtpr=mtpr,
-        swiglu_limit=float(swiglu_limit),
-        w1=layer._mega_w1,
-        w1_scale=layer._mega_w1_scale,
-        w2=layer._mega_w2,
-        w2_scale=layer._mega_w2_scale,
+    build_args = {
+        "rank": rank,
+        "world_size": world,
+        "model_dim": model_dim,
+        "inter_dim": inter_dim,
+        "experts": experts,
+        "topk": topk,
+        "quant": quant,
+        "swiglu_limit": float(swiglu_limit),
+        "w1": layer._mega_w1,
+        "w1_scale": layer._mega_w1_scale,
+        "w2": layer._mega_w2,
+        "w2_scale": layer._mega_w2_scale,
+    }
+    # Allocate in a fixed order even when the first pass is prefill/profiling.
+    # Mega construction has symmetric allocations and barriers; lazily building
+    # only the locally selected capacity could leave peers in different calls.
+    mega = get_or_build_mega_moe(mtpr=mtpr, **build_args)
+    use_decode_capacity = (
+        envs.ATOM_MEGA_DECODE_FAST_PATH
+        # Plugin bridges do not all publish native ForwardMode's group-agreed
+        # token rows. Some still report request counts for prefill.
+        and not is_plugin_mode()
+        and mtpr > _MEGA_DECODE_MTPR
+        and world == 8
+        and experts == world * 48
     )
+    if use_decode_capacity:
+        from atom.utils.tbo.ubatching import tbo_active
+
+        # Do not introduce symmetric workspace allocation from a TBO worker.
+        # The first ordinary forward's warmup will allocate the small instance.
+        use_decode_capacity = not tbo_active()
+    if use_decode_capacity:
+        decode_mega = get_or_build_mega_moe(mtpr=_MEGA_DECODE_MTPR, **build_args)
+        from atom.utils.forward_context import get_forward_context
+
+        context = get_forward_context().context
+        selected_mtpr = _select_decode_mtpr(mtpr, context, tbo_active=False)
+        if selected_mtpr != mtpr:
+            # The local tensor is a bound check, not an independent protocol
+            # selector. All peers must choose using the same context metadata.
+            if run_tokens > selected_mtpr:
+                raise ValueError(
+                    f"[mega] run_tokens={run_tokens} exceeds the DP-agreed "
+                    f"decode capacity={selected_mtpr}; "
+                    f"context.running_tokens={context.running_tokens}"
+                )
+            mega = decode_mega
+        if (
+            rank == 0
+            and context is not None
+            and context.running_tokens_are_unified
+            and context.running_tokens > 0
+        ):
+            key = (context.is_draft, context.running_tokens, selected_mtpr)
+            if key not in _MEGA_CAPACITY_LOGGED:
+                _MEGA_CAPACITY_LOGGED.add(key)
+                logger.info(
+                    "[MEGA-CAPACITY] phase=%s tokens=%d capacity=%d",
+                    "draft" if context.is_draft else "target",
+                    context.running_tokens,
+                    selected_mtpr,
+                )
 
     wts = topk_weights.to(torch.float32).contiguous()
     ids = topk_ids.to(torch.int32).contiguous()
@@ -311,7 +397,8 @@ class MegaFusedExperts:
             experts=global_num_experts,
             # Infer top-k from the routing tensors, same as the standard kernels.
             topk=int(topk_ids.shape[1]),
-            # todo decode use running_bs for perf
+            # run_mega_moe selects the small instance using this pass's padded
+            # token count; request count alone is insufficient under MTP.
             mtpr=self._mtpr,
             swiglu_limit=getattr(self._layer, "swiglu_limit", 0.0),
             quant=self._quant,

--- a/atom/utils/envs.py
+++ b/atom/utils/envs.py
@@ -100,6 +100,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # own MEGA_DISPATCH=flydsl|mori), 0 binds mori's v2 op-layer running plain
     # gather, i.e. the untouched upstream baseline.
     "ATOM_MORI_V2_FUSED": lambda: os.getenv("ATOM_MORI_V2_FUSED", "0") == "1",
+    # Reuse a 128-token MegaMoEV2 instance for native DP-unified small decode/
+    # verify/draft forwards on the supported EP8, 48-experts-per-rank layout. Set to 0
+    # to keep the configured max_num_batched_tokens capacity for every graph.
+    "ATOM_MEGA_DECODE_FAST_PATH": lambda: (
+        os.getenv("ATOM_MEGA_DECODE_FAST_PATH", "1") == "1"
+    ),
     "ATOM_MLA_PAGE_SIZE": lambda: int(os.getenv("ATOM_MLA_PAGE_SIZE", "1")),
     # --- Kernel Fusion Toggles ---
     # fused_compress_attn: switch between Triton (default historical) and a

--- a/tests/test_mega_decode_capacity.py
+++ b/tests/test_mega_decode_capacity.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: MIT
+"""Capacity changes must preserve Mega's cross-rank wire protocol.
+
+Exercise the real host dispatch and instance cache with CPU tensors. Only the
+AITER constructor/kernel and per-forward distributed context are replaced;
+these tests do not claim to validate GPU collectives or graph replay numerics.
+"""
+
+import sys
+from itertools import product
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from atom.model_ops.fused_moe import flydsl_mega_experts as mega
+from atom.plugin import prepare as plugin_prepare
+
+LARGE_CAPACITY = 16384
+
+
+def _context(rows, **overrides):
+    values = {
+        "running_bs": 64,
+        "running_tokens": rows,
+        "running_tokens_are_unified": True,
+        "running_tokens_across_dp": None,
+        "is_prefill": False,
+        "is_dummy_run": False,
+        "is_draft": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _layer(value=0):
+    return SimpleNamespace(
+        **{
+            name: torch.full((48, 4), value, dtype=torch.uint8)
+            for name in ("_mega_w1", "_mega_w1_scale", "_mega_w2", "_mega_w2_scale")
+        }
+    )
+
+
+@pytest.fixture
+def runtime(monkeypatch):
+    state = SimpleNamespace(
+        manager=SimpleNamespace(rank=0, world_size=8),
+        forward_context=SimpleNamespace(
+            context=None, ubatch_slices=None, in_hipgraph=False
+        ),
+        tbo=False,
+        capturing=False,
+        heap_initialized=False,
+        events=[],
+        instances={},
+        layer=_layer(),
+    )
+    monkeypatch.setenv("ATOM_MEGA_DECODE_FAST_PATH", "1")
+    monkeypatch.setattr(plugin_prepare, "_CURRENT_FRAMEWORK", "atom")
+    monkeypatch.setattr(mega, "_MEGA_CACHE", {})
+    monkeypatch.setattr(mega, "_MEGA_CAPACITY_LOGGED", set())
+    monkeypatch.setattr(
+        torch.cuda, "is_current_stream_capturing", lambda: state.capturing
+    )
+
+    class Communicator:
+        @property
+        def all2all_manager(self):
+            # The real lazy property initializes MORI's symmetric heap.
+            state.heap_initialized = True
+            return state.manager
+
+    ep_group = SimpleNamespace(device_communicator=Communicator())
+
+    class FakeMegaMoEV2:
+        def __init__(self, **kwargs):
+            assert state.heap_initialized
+            assert not state.capturing, "constructor reached during capture"
+            self.rank = kwargs["rank"]
+            self.capacity = kwargs["max_tok_per_rank"]
+            state.events.append(("build", self.rank, self.capacity))
+            state.instances[self.rank, self.capacity] = self
+
+        def forward(self, x, weights, ids):
+            state.events.append(("forward", self.rank, self.capacity))
+            return torch.full_like(x, self.capacity)
+
+    def stub_module(name, **attrs):
+        module = ModuleType(name)
+        module.__dict__.update(attrs)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    stub_module("aiter.dist.parallel_state", get_ep_group=lambda: ep_group)
+    stub_module("aiter.ops.flydsl.kernels.mega_moe", MegaMoEV2=FakeMegaMoEV2)
+    stub_module(
+        "atom.utils.forward_context", get_forward_context=lambda: state.forward_context
+    )
+    stub_module("atom.utils.tbo.ubatching", tbo_active=lambda: state.tbo)
+
+    def run(
+        context,
+        rows=None,
+        *,
+        rank=0,
+        world=8,
+        experts=384,
+        mtpr=LARGE_CAPACITY,
+        layer=None,
+    ):
+        state.manager.rank = rank
+        state.manager.world_size = world
+        state.forward_context.context = context
+        if rows is None:
+            rows = context.running_tokens
+        return mega.run_mega_moe(
+            state.layer if layer is None else layer,
+            torch.zeros(rows, 8, dtype=torch.bfloat16),
+            torch.ones(rows, 6, dtype=torch.float32),
+            torch.zeros(rows, 6, dtype=torch.int64),
+            model_dim=8,
+            inter_dim=8,
+            experts=experts,
+            topk=6,
+            mtpr=mtpr,
+            swiglu_limit=0.0,
+        )
+
+    state.run = run
+    return state
+
+
+def _built(runtime, rank=0):
+    return [
+        capacity
+        for event, pe, capacity in runtime.events
+        if event == "build" and pe == rank
+    ]
+
+
+def _forwarded(runtime):
+    return [capacity for event, _, capacity in runtime.events if event == "forward"]
+
+
+def test_mtp_verification_and_intermediate_draft_use_different_capacities(runtime):
+    # B=64, K=3: target and draft step 0 process 256 token rows. Only the
+    # intermediate serial draft steps reduce to one row per request.
+    target = _context(256)
+    draft_first = _context(256, is_draft=True, running_tokens_are_unified=False)
+    draft_next = _context(64, is_draft=True)
+
+    for context in (target, draft_first, draft_next, target):
+        runtime.run(context)
+
+    assert _forwarded(runtime) == [LARGE_CAPACITY, LARGE_CAPACITY, 128, LARGE_CAPACITY]
+    assert _built(runtime) == [LARGE_CAPACITY, 128]
+
+
+def test_padded_context_prevents_a_local_tensor_from_switching_protocol(runtime):
+    # A scheduled-token table can be smaller than the graph's padded height;
+    # draft contexts can also retain the target's old table.
+    for rank, local_rows in enumerate((64, 256)):
+        runtime.run(
+            _context(256, running_tokens_across_dp=(64,) * 8),
+            rows=local_rows,
+            rank=rank,
+        )
+
+    assert _forwarded(runtime) == [LARGE_CAPACITY, LARGE_CAPACITY]
+    assert _built(runtime, 0) == _built(runtime, 1) == [LARGE_CAPACITY, 128]
+
+    runtime.run(_context(64, is_draft=True, running_tokens_across_dp=(256,) * 8))
+    assert _forwarded(runtime)[-1] == 128
+
+
+def test_rank_local_parent_flags_cannot_split_a_unified_draft(runtime):
+    for rank, (dummy, prefill) in enumerate(product((False, True), repeat=2)):
+        runtime.run(
+            _context(64, is_draft=True, is_dummy_run=dummy, is_prefill=prefill),
+            rank=rank,
+        )
+
+    assert _forwarded(runtime) == [128] * 4
+
+
+def test_mixed_rank_shapes_keep_one_protocol_and_construction_order(runtime):
+    for rank, rows in enumerate((64, 512)):
+        runtime.run(
+            _context(rows, running_tokens_are_unified=False, is_prefill=rank == 1),
+            rank=rank,
+        )
+
+    assert _forwarded(runtime) == [LARGE_CAPACITY, LARGE_CAPACITY]
+    assert _built(runtime, 0) == _built(runtime, 1) == [LARGE_CAPACITY, 128]
+
+    # The later unified pass must find both instances already allocated,
+    # including on the rank whose first local batch was small.
+    runtime.capturing = True
+    for rank in range(2):
+        runtime.run(_context(64), rank=rank)
+    assert _forwarded(runtime)[-2:] == [128, 128]
+
+
+def test_tbo_child_does_not_allocate_small_workspace(runtime):
+    # Child ForwardContext.ubatch_slices is None and Context.unified defaults
+    # to True. Only the active TBO thread tells dispatch this is a microbatch.
+    runtime.tbo = True
+    runtime.run(_context(64))
+    assert _built(runtime) == [LARGE_CAPACITY]
+    assert _forwarded(runtime) == [LARGE_CAPACITY]
+
+    runtime.tbo = False
+    runtime.run(_context(64))
+    assert _built(runtime) == [LARGE_CAPACITY, 128]
+    assert _forwarded(runtime) == [LARGE_CAPACITY, 128]
+
+
+@pytest.mark.parametrize(
+    ("enabled", "world", "experts", "mtpr"),
+    [
+        ("0", 8, 384, LARGE_CAPACITY),
+        ("1", 4, 192, LARGE_CAPACITY),
+        ("1", 8, 392, LARGE_CAPACITY),
+        ("1", 8, 256, LARGE_CAPACITY),
+        ("1", 8, 384, 128),
+        ("1", 8, 384, 64),
+    ],
+)
+def test_disabled_or_unsupported_cases_keep_the_original_instance(
+    runtime, monkeypatch, enabled, world, experts, mtpr
+):
+    monkeypatch.setenv("ATOM_MEGA_DECODE_FAST_PATH", enabled)
+    runtime.run(_context(32), world=world, experts=experts, mtpr=mtpr)
+
+    assert _built(runtime) == [mtpr]
+    assert _forwarded(runtime) == [mtpr]
+
+
+@pytest.mark.parametrize("framework", ["vllm", "sglang", "sgl", "rtpllm"])
+@pytest.mark.parametrize("prefill", [False, True])
+def test_plugin_context_cannot_enable_native_capacity_selection(
+    runtime, monkeypatch, framework, prefill
+):
+    monkeypatch.setattr(plugin_prepare, "_CURRENT_FRAMEWORK", framework)
+    # Some bridges report requests rather than token rows for prefill while
+    # inheriting unified=True. The native fast path must not trust that shape.
+    runtime.run(
+        _context(1 if prefill else 64, is_prefill=prefill),
+        rows=512 if prefill else 64,
+    )
+
+    assert _built(runtime) == [LARGE_CAPACITY]
+    assert _forwarded(runtime) == [LARGE_CAPACITY]
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected_capacity"),
+    [(0, LARGE_CAPACITY), (1, 128), (128, 128), (129, LARGE_CAPACITY)],
+)
+def test_capacity_boundary_uses_the_published_row_count(
+    runtime, rows, expected_capacity
+):
+    output = runtime.run(_context(rows), rows=max(1, rows))
+
+    assert _forwarded(runtime) == [expected_capacity]
+    assert torch.all(output == expected_capacity)
+
+
+def test_missing_context_retains_original_capacity(runtime):
+    runtime.run(None, rows=64)
+    assert _forwarded(runtime) == [LARGE_CAPACITY]
+
+
+def test_tensor_overflow_raises_without_a_rank_local_fallback(runtime):
+    with pytest.raises(ValueError, match="DP-agreed.*capacity=128"):
+        runtime.run(_context(64), rows=129)
+
+    assert _forwarded(runtime) == []
+
+
+def test_warmup_builds_both_capacities_before_any_forward_or_capture(runtime):
+    # Target capture warmup sets in_hipgraph early; draft capture can leave it
+    # False. Actual stream capture state must govern allocation in both cases.
+    runtime.forward_context.in_hipgraph = True
+    runtime.run(_context(256))
+    assert runtime.events == [
+        ("build", 0, LARGE_CAPACITY),
+        ("build", 0, 128),
+        ("forward", 0, LARGE_CAPACITY),
+    ]
+
+    runtime.forward_context.in_hipgraph = False
+    runtime.capturing = True
+    runtime.run(_context(64, is_draft=True))
+    assert _built(runtime) == [LARGE_CAPACITY, 128]
+    assert _forwarded(runtime) == [LARGE_CAPACITY, 128]
+
+
+@pytest.mark.parametrize("large_already_built", [False, True])
+def test_capture_cache_miss_is_rejected_before_symmetric_allocation(
+    runtime, monkeypatch, large_already_built
+):
+    if large_already_built:
+        monkeypatch.setenv("ATOM_MEGA_DECODE_FAST_PATH", "0")
+        runtime.run(_context(256))
+        monkeypatch.setenv("ATOM_MEGA_DECODE_FAST_PATH", "1")
+
+    before_capture = list(runtime.events)
+    runtime.capturing = True
+    missing_capacity = 128 if large_already_built else LARGE_CAPACITY
+    with pytest.raises(
+        RuntimeError, match=f"capacity {missing_capacity}.*before graph capture"
+    ):
+        runtime.run(_context(64))
+
+    assert runtime.events == before_capture
+
+
+def test_cached_capacities_rebind_layer_weights_without_breaking_eplb_aliases(runtime):
+    runtime.run(_context(256))
+    next_layer = _layer(value=7)
+    runtime.capturing = True
+    runtime.run(_context(64), layer=next_layer)
+
+    assert _built(runtime) == [LARGE_CAPACITY, 128]
+    for instance in runtime.instances.values():
+        assert instance._s1_w1.data_ptr() == next_layer._mega_w1.data_ptr()
+        assert instance._s1_w1_scale.data_ptr() == next_layer._mega_w1_scale.data_ptr()
+        assert instance.w2 is next_layer._mega_w2
+        assert instance.w2_scale is next_layer._mega_w2_scale
+
+    next_layer._mega_w1[0].fill_(9)
+    for instance in runtime.instances.values():
+        assert torch.all(instance._s1_w1[0] == 9)


### PR DESCRIPTION
MegaMoE currently uses `max_num_batched_tokens` as its capacity for every forward. With a typical capacity of 16384, even a 64-token decode graph uses AITER's compact path. This change preallocates a second, 128-token instance so eligible small forwards can use fixed-slot dispatch.

The fast path is enabled by default for native ATOM with EP8 and 48 experts per rank. Selection uses the current target/draft pass's group-agreed, padded token rows. For example, 64 requests with MTP3 require 256 target-verification rows and retain the original capacity, while a subsequent 64-row draft pass can use 128. Both instances are built in the same order across ranks before graph capture; an unwarmed cache miss during capture raises before symmetric allocation. Existing per-layer weight rebinding and EPLB aliases are preserved.

TBO workers, plugin bridges, non-unified shapes, and unsupported layouts retain the configured capacity. Set `ATOM_MEGA_DECODE_FAST_PATH=0` before startup to disable the optimization.

Validation:

- 133 passed, 3 skipped in the focused CPU regression suite on the rebased PR branch. Skips require AITER/CUDA. Coverage includes target/draft row counts, graph padding, mixed-rank metadata, plugin contexts, TBO, allocation order, capture cache misses, and weight rebinding.
- Black, Ruff, and `git diff --check` pass.
- Full-model serving on 8×MI355X: DeepSeek-V4-Pro, nominal 8192 input / 1024 output, random range ratio 0.8, concurrency 512, seed 0, 1024 warmups and 5120 measured requests, ignore EOS, no MTP. Both variants completed 5120/5120 with identical totals: 37,755,686 input and 4,718,313 output tokens.
- Mega startup logs confirm capacities 16384/128 with EP8/EPR48; 64/128-row graphs select 128 and 256/512-row graphs retain 16384. No server/client errors were found.

| Serving metric | DPA + TBO | DPA + EP8 + EPLB r0 + Mega | Change |
|---|---:|---:|---:|
| Output throughput (token/s) | 4914.75 | 5024.06 | +2.22% |
| Duration (s) | 960.03 | 939.14 | -2.18% |
| Mean TTFT (s) | 7.41 | 7.36 | -0.65% |
| Mean TPOT (ms) | 92.20 | 91.00 | -1.31% |
| Median ITL (ms) | 37.02 | 38.87 | +5.00% |
| P99 ITL (ms) | 1557.09 | 1662.72 | +6.78% |

This is one sequential comparison of complete serving configurations; repeat-run variance, an isolated capacity-toggle ablation, and full-model MTP accuracy remain unmeasured. EPLB migration costs are included. The workload and EPLB interval/window of 200 follow the performance catalog; the linked accuracy case uses 10, and GSM8K was not evaluated.

<details>
<summary>Reproduction and version details</summary>

CPU regression command:

```bash
python -m pytest \
  tests/test_mega_decode_capacity.py tests/test_mega_mxfp4_method.py \
  tests/test_forward_mode.py tests/test_dp_sync_layout.py \
  tests/test_dp_metadata.py tests/test_draft_graph.py \
  tests/test_scheduler_mtp_max_tokens.py tests/test_cudagraph_capture_bounds.py \
  tests/model_ops/test_moe_dp_token_capacity.py tests/test_envs.py -q
```

Serving was measured on ATOM `13a2fc427d02cf8778d9f0542e7988ee52669eff` plus the identical three-file patch, before rebasing onto current main. AITER: `b103cf92b07e26f1a1b7013fe90229408d3795c3`; image: `rocm/atom-dev@sha256:e67a284197327e113e8c0844b77dbaf1964057c74d7ec49713e82a929a8d4cd1`; Torch 2.10.0 / ROCm 7.2.4.

Common server settings: TP8, DPA, FP8 KV cache, FP4 index cache, prefix caching off, `max-num-batched-tokens=16384`, `max-num-seqs=512`, memory utilization 0.9, FULL graphs with sizes `[1,2,4,8,16,32,48,64,128,256,512]`. TBO uses `--enable-tbo prefill`. Mega uses `--enable-expert-parallel --eplb-enable --moe-backend mega` with redundant experts 0, naive placement, interval/window 200 and rebalance threshold 2.0.

Common environment: `AITER_BF16_FP8_MOE_BOUND=0`, `ATOM_MOE_GU_ITLV=1`, `GPU_MAX_HW_QUEUES=5`, `ATOM_NUMA_BIND=1`, `AITER_LOG_LEVEL=WARNING`, `MORI_SHMEM_HEAP_SIZE=16G`, `ATOM_MEGA_DECODE_FAST_PATH=1`.

</details>
