### PR TITLE
fix(minimax-m3): the maskless fp8 kernel returns NaN at gqa=16, 16 pages, partial tail

### DIFF
--- a/atom/model_ops/base_attention.py
+++ b/atom/model_ops/base_attention.py
@@ -77,8 +77,13 @@ def run_pa_fwd_asm(
     qo_indptr: torch.Tensor | None = None,
     max_qlen: int = 1,
     high_precision: int = 0,
+    kernel_name: str | None = None,
 ):
-    """Run the AITER paged-attention ASM kernel with explicit metadata."""
+    """Run the AITER paged-attention ASM kernel with explicit metadata.
+
+    ``kernel_name`` bypasses aiter's kernel heuristic; a name absent from
+    pa_asm.csv aborts the process rather than raising.
+    """
 
     import aiter
 
@@ -95,6 +100,7 @@ def run_pa_fwd_asm(
         out_=out,
         qo_indptr=qo_indptr,
         high_precision=high_precision,
+        kernelName=kernel_name,
     )
 
 

--- a/atom/model_ops/embed_head.py
+++ b/atom/model_ops/embed_head.py
@@ -45,8 +45,10 @@ def _masked_embedding_kernel(
     cols = col_start + tl.arange(0, BLOCK_D)
     col_mask = cols < D
 
+    # int64, not `local_idx`'s own int32: the row address wraps at
+    # vocab * hidden >= 2^31, silently -- `in_range` tests the id, not the address.
     emb = tl.load(
-        weight_ptr + local_idx * stride_w_row + cols,
+        weight_ptr + local_idx.to(tl.int64) * stride_w_row + cols,
         mask=in_range & col_mask,
         other=0.0,
     )
@@ -222,6 +224,15 @@ class ReplicatedEmbedding(nn.Module):
         return replicated_embedding(x, self.weight)
 
 
+def empty_token_ids(hidden: torch.Tensor) -> torch.Tensor:
+    """Storage ``compute_argmax_token`` answers into, for a caller holding none.
+
+    Sized off the row axis, so a V4 draft's ``[N, hc, dim]`` works as well as a
+    plain ``[N, dim]``.
+    """
+    return torch.empty(hidden.shape[0], dtype=torch.int32, device=hidden.device)
+
+
 class ParallelLMHead(VocabParallelEmbedding):
 
     def __init__(
@@ -265,10 +276,18 @@ class ParallelLMHead(VocabParallelEmbedding):
         return logits
 
     def compute_argmax_token(
-        self, x: torch.Tensor, *, out: torch.Tensor | None = None
+        self, x: torch.Tensor, *, out: torch.Tensor
     ) -> torch.Tensor:
-        """Greedy argmax token over the (TP-sharded) vocab — returns ``[N]`` token
-        ids WITHOUT all-gathering the full ``[N, vocab]`` logits.
+        """Greedy argmax token over the (TP-sharded) vocab — fills ``out`` with
+        ``[N]`` token ids WITHOUT all-gathering the full ``[N, vocab]`` logits.
+
+        ``out`` is required: the storage belongs to whoever knows its lifetime,
+        and the draft loop's is a CUDA-graph buffer whose address a capture
+        baked. ``empty_token_ids`` makes one for a caller with none.
+
+        int32, the engine's token dtype everywhere else -- ``argmax``'s int64 is
+        torch's convention, not a consumer's, so the vLLM/SGLang bridges widen
+        at their own boundary.
 
         For greedy speculative drafting only the argmax is needed, so each rank
         reduces its own vocab shard to ``(max_val, global_idx)`` and we all-gather
@@ -285,14 +304,12 @@ class ParallelLMHead(VocabParallelEmbedding):
         itself is still exact over whatever logits it is given; only the GEMM's
         rounding differs.
         """
-        if out is not None:
-            assert out.shape == x.shape[:-1], (
-                f"argmax out has shape {tuple(out.shape)}, expected "
-                f"{tuple(x.shape[:-1])}"
-            )
-            assert (
-                out.dtype == torch.long and out.device == x.device
-            ), "argmax out must be an int64 tensor on the input device"
+        assert (
+            out.shape == x.shape[:-1]
+        ), f"argmax out has shape {tuple(out.shape)}, expected {tuple(x.shape[:-1])}"
+        assert (
+            out.dtype == torch.int32 and out.device == x.device
+        ), "argmax out must be an int32 tensor on the input device"
         # Pure-DP draft: shard the vocab across the DP group instead of a
         # replicated full-vocab GEMM. Skip plugin mode -- its caller decides the
         # collective count per chunk (a mismatch would deadlock DP) -- and skip
@@ -302,11 +319,10 @@ class ParallelLMHead(VocabParallelEmbedding):
             and not is_plugin_mode()
             and self._can_use_dp_sharded_argmax(get_forward_context().context)
         ):
-            return self._dp_sharded_logits(x, "argmax", out)
+            return out.copy_(self._dp_sharded_logits(x, "argmax"))
         logits = tgemm.mm(x, self.weight, self.bias)  # [N, vocab/tp]
         if self.tp_size <= 1:
-            token = logits.argmax(dim=-1)
-            return token if out is None else out.copy_(token)
+            return out.copy_(logits.argmax(dim=-1))
         # Pack (val, idx) as fp32 — idx < 2^24 is exact — and all-gather only the
         # per-rank reductions ([N, 2]) instead of the full logits.
         packed = lm_head_argmax_pack(logits, self.vocab_start_idx)
@@ -318,7 +334,7 @@ class ParallelLMHead(VocabParallelEmbedding):
         gathered = gathered.view(self.tp_size, -1, 2)
         winner = gathered[:, :, 0].argmax(dim=0)  # [N] winning rank (ties -> lowest)
         token = gathered[:, :, 1].gather(0, winner.unsqueeze(0)).squeeze(0)  # [N] fp32
-        return token.to(torch.long) if out is None else out.copy_(token)
+        return out.copy_(token)
 
     # ------------------------------------------------------------------
     # Pure-DP sharded LM head (config ② all-gather / ③ all-to-all).
@@ -364,9 +380,7 @@ class ParallelLMHead(VocabParallelEmbedding):
             return False
         return get_forward_context().dp_metadata is not None
 
-    def _dp_sharded_logits(
-        self, x: torch.Tensor, mode: str, out: torch.Tensor | None = None
-    ) -> torch.Tensor:
+    def _dp_sharded_logits(self, x: torch.Tensor, mode: str) -> torch.Tensor:
         """This rank's own rows out of a DP-vocab-sharded lm_head.
 
         Shared front half: pad x to the DP-agreed ``running_tokens``, all-gather
@@ -375,7 +389,7 @@ class ParallelLMHead(VocabParallelEmbedding):
 
         - ``"argmax"``: reduce each shard to a packed ``(max, global_id)`` and
           all-gather only ``[Σrows, 2]``, then pick the winner -> ``[local_rows]``
-          int64 ids (drafting; ``out``, if given, receives them).
+          ids, still packed as fp32 (drafting; the caller narrows into its own).
         - ``"all2all"`` / ``"allgather"``: exchange full-vocab logits ->
           ``[local_rows, vocab]`` (the decode head).
         """
@@ -414,15 +428,8 @@ class ParallelLMHead(VocabParallelEmbedding):
                 packed, dim=0, use_custom=use_custom
             ).view(dp_size, dp_size * max_rows, 2)
             winner = gathered_packed[:, :, 0].argmax(dim=0)  # [Σrows] winning shard
-            token = (
-                gathered_packed[:, :, 1]
-                .gather(0, winner.unsqueeze(0))
-                .squeeze(0)
-                .to(torch.long)
-            )[
-                start : start + local_rows
-            ]  # keep own rows
-            return token if out is None else out.copy_(token)
+            token = gathered_packed[:, :, 1].gather(0, winner.unsqueeze(0)).squeeze(0)
+            return token[start : start + local_rows]  # keep own rows
 
         if mode == "all2all":
             # Send each destination rank only the rows it owns; receive this

--- a/atom/model_ops/minimax_m3/sparse_attn.py
+++ b/atom/model_ops/minimax_m3/sparse_attn.py
@@ -141,6 +141,40 @@ def _gluon_one_pass_max_rows(device_index: int | None) -> int:
     return max(1, cus // get_recommended_splits(1, 1))
 
 
+# The maskless fp8 kernel returns NaN for gqa=16 when the context needs exactly
+# 16 pages with a partial tail (241..255 tokens); gqa=8 is correct there, and
+# two 8-head queries of one request are the same arithmetic over the same KV.
+# Unconditional: the trigger is a sparse_ctx value, and reading it costs a sync.
+_ASM_NAN_GROUP = 16
+_ASM_SPLIT = 2
+
+# A maskless mtp>0 kernel is unreachable through the heuristic (a null qo_indptr
+# forces mtp=0, a non-null one forces msk=1), so name the row. An unlisted dtype
+# keeps the unsplit path rather than aborting inside aiter.
+_ASM_SPLIT_KERNELS = {
+    torch.bfloat16: "_ZN5aiter40pa_bf16_pertokenFp8_gqa8_1tg_4w_mtp_msk0E",
+    torch.float16: "_ZN5aiter40pa_fp16_pertokenFp8_gqa8_1tg_4w_mtp_msk0E",
+}
+
+
+# Every request contributes two queries, so the indptr is 2 * arange. Allocated
+# once past any batch (1 MiB) and narrowed per call: narrow raises where a slice
+# would hand the kernel a short tensor, and a pool that grew on demand would
+# allocate inside a graph capture.
+_SPLIT_INDPTR_ROWS = 1 << 18
+
+
+@functools.cache
+def _split_indptr(device: torch.device) -> torch.Tensor:
+    return torch.arange(
+        0,
+        (_SPLIT_INDPTR_ROWS + 1) * _ASM_SPLIT,
+        _ASM_SPLIT,
+        dtype=torch.int32,
+        device=device,
+    )
+
+
 def _sparse_pa_ran_on_asm(
     q: torch.Tensor,  # [rows, query_group_size, head_dim]
     k_cache: torch.Tensor,  # page-16 SHUFFLE, kv-head already collapsed
@@ -164,13 +198,24 @@ def _sparse_pa_ran_on_asm(
         run_pa_fwd_asm,
     )
 
+    rows, group, head_dim = q.shape
     if (
         k_scale is None
         or not _is_fp8_kv_cache_tensor(k_cache)
-        or q.shape[1] > PA_ASM_MAX_QUERY_GROUP_SIZE
-        or q.shape[0] <= _gluon_one_pass_max_rows(q.device.index)
+        or group > PA_ASM_MAX_QUERY_GROUP_SIZE
+        or rows <= _gluon_one_pass_max_rows(q.device.index)
     ):
         return False
+
+    kernel_name = _ASM_SPLIT_KERNELS.get(q.dtype) if group == _ASM_NAN_GROUP else None
+    qo_indptr, max_qlen = None, 1
+    if kernel_name:
+        # Rows 2b/2b+1 are request b's head halves -- the kernel's own
+        # q[b*qlen + i] layout, so one block-table row still serves both.
+        qo_indptr = _split_indptr(q.device).narrow(0, 0, rows + 1)
+        q = q.view(rows * _ASM_SPLIT, group // _ASM_SPLIT, head_dim)
+        out = out.view(q.shape)
+        max_qlen = _ASM_SPLIT
 
     pages, pbs = k_cache.shape[0], k_scale.shape[-1]
     run_pa_fwd_asm(
@@ -182,7 +227,9 @@ def _sparse_pa_ran_on_asm(
         k_scale=k_scale.view(pages, 1, pbs),
         v_scale=v_scale.view(pages, 1, pbs),
         out=out,
-        max_qlen=1,
+        qo_indptr=qo_indptr,
+        max_qlen=max_qlen,
+        kernel_name=kernel_name,
     )
     return True
 

--- a/atom/models/deepseek_mtp.py
+++ b/atom/models/deepseek_mtp.py
@@ -280,7 +280,7 @@ class DeepSeekMultiTokenPredictor(nn.Module):
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
         *,
-        out: torch.Tensor | None = None,
+        out: torch.Tensor,
     ) -> torch.Tensor:
         """Greedy draft token ids via distributed argmax over the TP-sharded vocab —
         avoids all-gathering the full [N, vocab] logits every draft step.
@@ -424,7 +424,7 @@ class DeepSeekMTP(nn.Module):
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
         *,
-        out: torch.Tensor | None = None,
+        out: torch.Tensor,
     ) -> torch.Tensor:
         """Distributed greedy argmax for the MTP draft rollout (GLM-5.2).
 

--- a/atom/models/deepseek_v4_mtp.py
+++ b/atom/models/deepseek_v4_mtp.py
@@ -201,11 +201,13 @@ class DeepseekV4MTPModel(nn.Module):
         self,
         hidden_states: torch.Tensor,  # [num_tokens, hc, dim]  pre-hc_head residual
         spec_step_idx: int = 0,
-    ) -> torch.Tensor:  # [num_tokens] int64
+        *,
+        out: torch.Tensor,  # [num_tokens] int32
+    ) -> torch.Tensor:
         """Same reduce + norm as compute_logits, but the argmax runs per vocab
         shard so only [N, 2] crosses TP instead of the full [N, vocab]."""
         blk, x = self._head_input(hidden_states, spec_step_idx)
-        return blk.head.compute_argmax_token(x)
+        return blk.head.compute_argmax_token(x, out=out)
 
 
 class DeepseekV4MTP(nn.Module):
@@ -319,13 +321,15 @@ class DeepseekV4MTP(nn.Module):
         self,
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
+        *,
+        out: torch.Tensor,
     ) -> torch.Tensor:
         """Greedy draft token ids via distributed argmax — only [N, 2] crosses
         TP instead of the full [N, vocab]. Token-identical to
         compute_logits(...).argmax(-1): the draft path never hits the LM head's
         prefill last-token slice (is_draft is set for the whole propose loop),
         so both see the same rows."""
-        return self.model.compute_draft_ids(hidden_states, spec_step_idx)
+        return self.model.compute_draft_ids(hidden_states, spec_step_idx, out=out)
 
     def share_with_target(self, target_base: nn.Module, loaded: set[str]) -> None:
         """Bind embed/head on each MTPBlock to the already-loaded target's

--- a/atom/models/eagle3_deepseek_mla.py
+++ b/atom/models/eagle3_deepseek_mla.py
@@ -382,11 +382,13 @@ class Eagle3DeepseekMLAModel(nn.Module):
             hidden_states = self.norm(hidden_states)
         return self.lm_head(hidden_states)
 
-    def compute_draft_ids(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def compute_draft_ids(
+        self, hidden_states: torch.Tensor, *, out: torch.Tensor
+    ) -> torch.Tensor:
         """Greedy draft token ids via distributed argmax — avoids all-gathering
         the full [N, vocab] logits every draft step. Token-identical to
         compute_logits(...).argmax(-1); norm handling mirrors compute_logits.
         """
         if not self.norm_output:
             hidden_states = self.norm(hidden_states)
-        return self.lm_head.compute_argmax_token(hidden_states)
+        return self.lm_head.compute_argmax_token(hidden_states, out=out)

--- a/atom/models/eagle3_llama.py
+++ b/atom/models/eagle3_llama.py
@@ -483,11 +483,13 @@ class Eagle3LlamaModel(nn.Module):
             hidden_states = self.norm(hidden_states)
         return self.lm_head(hidden_states)
 
-    def compute_draft_ids(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def compute_draft_ids(
+        self, hidden_states: torch.Tensor, *, out: torch.Tensor
+    ) -> torch.Tensor:
         """Greedy draft token ids via distributed argmax — avoids all-gathering
         the full [N, vocab] logits every draft step. Token-identical to
         compute_logits(...).argmax(-1); norm handling mirrors compute_logits.
         """
         if not self.norm_output:
             hidden_states = self.norm(hidden_states)
-        return self.lm_head.compute_argmax_token(hidden_states)
+        return self.lm_head.compute_argmax_token(hidden_states, out=out)

--- a/atom/models/glm4_moe_mtp.py
+++ b/atom/models/glm4_moe_mtp.py
@@ -168,11 +168,13 @@ class Glm4MoeMultiTokenPredictor(nn.Module):
         self,
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
+        *,
+        out: torch.Tensor,
     ) -> torch.Tensor:
         # Same bare-LM-head input as compute_logits, but reduced per vocab shard
         # so only [N, 2] crosses TP instead of the full [N, vocab].
         head = self._mtp_layer(spec_step_idx).shared_head.head
-        return head.compute_argmax_token(hidden_states)
+        return head.compute_argmax_token(hidden_states, out=out)
 
 
 @support_torch_compile
@@ -229,6 +231,8 @@ class Glm4MoeMTP(nn.Module):
         self,
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
+        *,
+        out: torch.Tensor,
     ) -> torch.Tensor:
         """Greedy draft token ids via distributed argmax — only [N, 2] is
         all-gathered instead of the full [N, vocab] logits. Token-identical to
@@ -241,7 +245,7 @@ class Glm4MoeMTP(nn.Module):
         this class. The plugin calls it unconditionally, though, so the method
         has to exist.
         """
-        return self.model.compute_draft_ids(hidden_states, spec_step_idx)
+        return self.model.compute_draft_ids(hidden_states, spec_step_idx, out=out)
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales

--- a/atom/models/mimo_v2_mtp.py
+++ b/atom/models/mimo_v2_mtp.py
@@ -307,6 +307,8 @@ class MiMoV2MTP(nn.Module):
         self,
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
+        *,
+        out: torch.Tensor,
     ) -> torch.Tensor:
         """Greedy draft token ids via distributed argmax — each rank reduces its
         own vocab shard and only [N, 2] is all-gathered, instead of the full
@@ -315,7 +317,7 @@ class MiMoV2MTP(nn.Module):
         prefill last-token slice (is_draft is set for the whole propose loop),
         so both see the same rows.
         """
-        return self.lm_head.compute_argmax_token(hidden_states)
+        return self.lm_head.compute_argmax_token(hidden_states, out=out)
 
     _MTP_PATTERN = re.compile(r"model\.mtp\.layers\.(\d+)\.")
     _PREDICTOR_KEYS: ClassVar[set[str]] = {

--- a/atom/models/qwen3_5_mtp.py
+++ b/atom/models/qwen3_5_mtp.py
@@ -201,6 +201,8 @@ class Qwen3_5MTP(nn.Module):
         self,
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
+        *,
+        out: torch.Tensor,
     ) -> torch.Tensor:
         """Greedy draft token ids via distributed argmax — each rank reduces its
         own vocab shard and only [N, 2] is all-gathered, instead of the full
@@ -209,7 +211,7 @@ class Qwen3_5MTP(nn.Module):
         prefill last-token slice (is_draft is set for the whole propose loop),
         so both see the same rows.
         """
-        return self.lm_head.compute_argmax_token(hidden_states)
+        return self.lm_head.compute_argmax_token(hidden_states, out=out)
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales

--- a/atom/models/qwen3_next_mtp.py
+++ b/atom/models/qwen3_next_mtp.py
@@ -206,6 +206,8 @@ class Qwen3NextMTP(nn.Module):
         self,
         hidden_states: torch.Tensor,
         spec_step_idx: int = 0,
+        *,
+        out: torch.Tensor,
     ) -> torch.Tensor:
         """Greedy draft token ids via distributed argmax — each rank reduces its
         own vocab shard and only [N, 2] is all-gathered, instead of the full
@@ -214,7 +216,7 @@ class Qwen3NextMTP(nn.Module):
         prefill last-token slice (is_draft is set for the whole propose loop),
         so both see the same rows.
         """
-        return self.lm_head.compute_argmax_token(hidden_states)
+        return self.lm_head.compute_argmax_token(hidden_states, out=out)
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales

--- a/atom/plugin/sglang/dflash_lm_head_bridge.py
+++ b/atom/plugin/sglang/dflash_lm_head_bridge.py
@@ -147,23 +147,25 @@ def install_dflash_lm_head_patch() -> None:
             return torch.empty((0,), dtype=torch.long, device=hidden_states.device)
 
         weight_dtype = lm_head.weight.dtype
-        out_tokens = torch.empty(
-            (num_tokens,), dtype=torch.long, device=hidden_states.device
-        )
+        # Each chunk's slice IS the head's output, so the per-chunk copy this
+        # loop used to make is gone; SGLang's caller wants int64, widened once.
+        ids = torch.empty((num_tokens,), dtype=torch.int32, device=hidden_states.device)
         step = max(int(chunk_size), 1)
         for start in range(0, num_tokens, step):
             end = min(num_tokens, start + step)
             hs = hidden_states[start:end]
             if hs.dtype != weight_dtype:
                 hs = hs.to(weight_dtype)
-            token_ids = compute_argmax_token(hs)
-            if token_ids.shape != (end - start,):
+            dst = ids[start:end]
+            answered = compute_argmax_token(hs, out=dst)
+            # The head is duck-typed; a shape check would no longer catch one
+            # that ignores `out`, which leaves this chunk unwritten.
+            if answered.data_ptr() != dst.data_ptr():
                 raise ValueError(
-                    "ATOM lm_head.compute_argmax_token returned an invalid shape: "
-                    f"expected {(end - start,)}, got {tuple(token_ids.shape)}."
+                    "ATOM lm_head.compute_argmax_token did not answer into the "
+                    "storage it was given."
                 )
-            out_tokens[start:end].copy_(token_ids.to(torch.long))
-        return out_tokens
+        return ids.to(torch.long)
 
     patched.__name__ = original.__name__
     patched.__qualname__ = original.__qualname__

--- a/atom/plugin/vllm/model_wrapper.py
+++ b/atom/plugin/vllm/model_wrapper.py
@@ -32,6 +32,7 @@ from vllm.model_executor.models.interfaces_base import (
 from vllm.sequence import IntermediateTensors
 
 import atom  # noqa: F401
+from atom.model_ops.embed_head import empty_token_ids
 from atom.plugin.config import (
     _generate_atom_config_from_vllm_config,
     generate_atom_config_for_plugin_mode,
@@ -1099,8 +1100,10 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
         vLLM's ``LLMBaseProposer._greedy_sample`` calls this (when
         ``use_local_argmax_reduction`` is enabled) in place of
         ``compute_logits(...).argmax(-1)``. Bridge it to the draft model's
-        ``compute_draft_ids``, which returns ``[N]`` int64 token ids and is
-        token-identical to ``compute_logits(...).argmax(-1)``.
+        ``compute_draft_ids``, which is token-identical to
+        ``compute_logits(...).argmax(-1)`` but answers into int32 storage the
+        caller owns -- so supply it here and widen, because vLLM's caller was
+        written against that op's int64 return.
 
         Every arch delivers the ``O(2*tp)`` behaviour vLLM enables this flag
         for: each rank reduces its own logit shard to ``(max_val, global_idx)``
@@ -1112,7 +1115,8 @@ class ATOMModelBase(nn.Module, VllmModel, SupportsQuant, SupportsPP):
             hidden_states = _deepseek_v4_mtp_unflatten_hidden_states(
                 hidden_states, self.model
             )
-        return self.model.compute_draft_ids(hidden_states)
+        ids = empty_token_ids(hidden_states)
+        return self.model.compute_draft_ids(hidden_states, out=ids).to(torch.long)
 
 
 class ATOMForCausalLM(ATOMModelBase, VllmModelForTextGeneration): ...

--- a/atom/spec_decode/eagle_proposer.py
+++ b/atom/spec_decode/eagle_proposer.py
@@ -14,6 +14,7 @@ from atom.distributed.pcp_utils import (
     pcp_pad_len,
     pcp_round_robin_split,
 )
+from atom.model_ops.embed_head import empty_token_ids
 from atom.spec_decode.draft_graph import DraftGraph, StagedInput
 from atom.spec_decode.draft_kv import draft_kv_builder
 from atom.spec_decode.drafter import Drafter
@@ -142,11 +143,10 @@ class EagleProposer(Drafter):
         # does not, which is exactly the two-dimensional case.
         hc = getattr(draft_hf, "hc_mult", None)
         inputs = {
-            # int64, not the int32 of the token buffer step 0 reads: a mid-step's
-            # ids come from `compute_draft_ids`, which is an argmax. The loop
-            # rebinds `input_ids` from one to the other, so the two halves
-            # genuinely differ.
-            "input_ids": StagedInput(dtype=torch.int64),
+            # The same int32 the token buffer step 0 reads: the loop rebinds
+            # `input_ids` from that buffer to this one, and `stage` asserts the
+            # two agree.
+            "input_ids": StagedInput(dtype=torch.int32),
             "positions": StagedInput(dtype=torch.int64),
             "hidden_states": StagedInput(
                 shape=(
@@ -186,7 +186,7 @@ class EagleProposer(Drafter):
             input_ids=input_ids, positions=positions, hidden_states=hidden_states
         )
 
-    def _step_head(self, out, running_bs, *, input_ids, hidden_states, **_):
+    def _step_head(self, fwd_out, running_bs, *, input_ids, hidden_states, **_):
         """The mid-step's draft ids, recorded with the backbone that made them.
 
         Both come back because the next mid-step reads the hidden states and
@@ -195,10 +195,13 @@ class EagleProposer(Drafter):
         is the caller's, on the way out.
         """
         if self._reuse_step_buffers:
-            hidden_states.copy_(out[:running_bs])
+            hidden_states.copy_(fwd_out[:running_bs])
             self.model.compute_draft_ids(hidden_states, out=input_ids)
             return hidden_states, input_ids
-        return out, self.model.compute_draft_ids(out)
+        # No fixed storage on this flavor, so the ids land in the graph's own
+        # pool -- where `argmax`'s result landed before.
+        ids = empty_token_ids(fwd_out)
+        return fwd_out, self.model.compute_draft_ids(fwd_out, out=ids)
 
     def _build_draft_model(self, model_class) -> nn.Module:
         draft_model_hf_config = self.speculative_config.draft_model_hf_config
@@ -544,9 +547,12 @@ class EagleProposer(Drafter):
         else:
             hidden_states = target_hidden_states
 
+        # Step-major while the loop fills it: `draft_token_ids[i]` is then a
+        # contiguous row, and the id-consuming Triton kernels (masked embedding,
+        # the fp8 MTP prologue) index at unit stride. Transposed on the way out.
         draft_token_ids = torch.empty(
-            scheduled_bs,
             self.mtp_k,
+            scheduled_bs,
             dtype=next_token_ids.dtype,
             device=next_token_ids.device,
         )
@@ -668,55 +674,26 @@ class EagleProposer(Drafter):
                         if self._reuse_step_buffers
                         else None
                     )
-                    sample_hidden_states = (
-                        torch.index_select(
-                            ret_hidden_states,
-                            0,
-                            last_token_indices,
-                            out=hidden_out,
-                        )
-                        if hidden_out is not None
-                        else torch.index_select(
-                            ret_hidden_states, 0, last_token_indices
-                        )
+                    # out=None is index_select's own default: it allocates.
+                    sample_hidden_states = torch.index_select(
+                        ret_hidden_states, 0, last_token_indices, out=hidden_out
                     )
                 else:
                     sample_hidden_states = ret_hidden_states[:scheduled_bs]
-                # Only step 0 and a flavor with no declared pass land here; a
-                # recorded mid-step produced its ids inside the graph.
-                # Every draft model EagleProposer can build implements this --
-                # the DSpark archs in support_draft_model_arch_dict do not, but
-                # they are DSparkProposer's and never reach this loop. All of
-                # them reduce per vocab shard and all-gather only [N, 2] rather
-                # than the full [N, vocab] logits, which is token-identical to
-                # compute_logits().argmax(-1) here because is_draft suppresses
-                # the LM head's prefill last-token slice. How the ids are
-                # produced stays the model's business, not this loop's.
-                ids_out = (
-                    self.step.buffer("input_ids", scheduled_bs)
-                    if self._reuse_step_buffers
-                    and graphed_ids is None
-                    and i + 1 < self.mtp_k
-                    else None
-                )
+                # This step's row is owned storage -- the assembled matrix's
+                # async D2H reads it while later replays run.
+                exported = draft_token_ids[i]
                 if graphed_ids is not None:
                     next_input_ids = graphed_ids[:scheduled_bs]
-                    # The fixed ids feed the next replay, but exported draft ids
-                    # need owned storage that a later replay cannot overwrite
-                    # while their assembled matrix is copied to the host.
-                    new_draft_ids = (
-                        next_input_ids.clone()
-                        if self._reuse_step_buffers
-                        else next_input_ids
-                    )
+                    exported.copy_(next_input_ids)
                 else:
-                    new_draft_ids = (
-                        self.model.compute_draft_ids(sample_hidden_states, out=ids_out)
-                        if ids_out is not None
-                        else self.model.compute_draft_ids(sample_hidden_states)
+                    # Every draft model EagleProposer can build implements this
+                    # (DSpark's do not, but they never reach here), and it is
+                    # token-identical to compute_logits().argmax(-1) because
+                    # is_draft suppresses the LM head's prefill last-token slice.
+                    next_input_ids = self.model.compute_draft_ids(
+                        sample_hidden_states, out=exported
                     )
-                    next_input_ids = new_draft_ids
-                draft_token_ids[:, i] = new_draft_ids
 
                 if i < self.mtp_k - 1:
                     do_attn_metadata_update = (
@@ -820,5 +797,5 @@ class EagleProposer(Drafter):
                     hidden_states = sample_hidden_states
 
         # self.runner.debug(f"final {draft_token_ids=}")
-        # [batch_size, mtp_k]
-        return draft_token_ids
+        # [batch_size, mtp_k], contiguous: every consumer indexes by sequence.
+        return draft_token_ids.t().contiguous()

--- a/scripts/start_atom_server.sh
+++ b/scripts/start_atom_server.sh
@@ -60,16 +60,37 @@ owned_in_use() {
         END { print n + 0 }'
 }
 
+# Ownership is decidable only on the server process: its EngineCore child
+# clears HIP_VISIBLE_DEVICES. Empty means this run claims the whole box.
+owns_our_cards() {
+    [ -n "${HIP_VISIBLE_DEVICES:-}" ] || return 0
+    [ "$(tr '\0' '\n' <"/proc/$1/environ" 2>/dev/null |
+        sed -n 's/^HIP_VISIBLE_DEVICES=//p')" = "$HIP_VISIBLE_DEVICES" ]
+}
+
+# Children are reached through the tree, not by name: the worker calls itself
+# ATOM::EngineCore and matches none of the patterns a pkill would use. An
+# EngineCore already orphaned by a dead server is unreachable either way -- it
+# carries neither the card set nor a parent -- and shows up as owned_in_use.
+kill_tree() {
+    local child
+    for child in $(pgrep -P "$1" 2>/dev/null); do
+        kill_tree "$child"
+    done
+    kill -9 "$1" 2>/dev/null || true
+}
+
 # === Pre-flight: ensure GPU is clean ===
 echo "Pre-flight: cleaning up processes and GPU memory..."
 
-# 1. Kill atom server processes
-pkill -f 'atom.entrypoints' 2>/dev/null || true
-sleep 2
-
-# 2. Kill orphaned multiprocessing spawn/tracker (these hold GPU memory after server dies)
-pkill -9 -f 'multiprocessing.spawn' 2>/dev/null || true
-pkill -9 -f 'multiprocessing.resource_tracker' 2>/dev/null || true
+# 1. Kill this run's servers and everything under them. A bare `pkill -f` hits
+#    every ATOM process on the box, which on a shared one is someone else's.
+for pid in $(pgrep -f 'atom\.entrypoints' 2>/dev/null || true); do
+    if owns_our_cards "$pid"; then
+        echo "  killing server $pid and its children"
+        kill_tree "$pid"
+    fi
+done
 sleep 3
 
 # 3. Verify GPU memory is actually free

--- a/scripts/start_atom_server.sh
+++ b/scripts/start_atom_server.sh
@@ -22,6 +22,44 @@ LOG_FILE="/app/logs_claude/atom_server.log"
 export AITER_LOG_LEVEL="${AITER_LOG_LEVEL:-INFO}"
 export KINETO_CONFIG="/home/ljin1/dk/libkineto.conf"
 
+# === Which cards this run owns ===
+# HIP_VISIBLE_DEVICES numbering is not rocm-smi's (measured here: HIP 0 is
+# GPU[3]) and the map does not survive a reboot, so resolve it through the PCI
+# bus now. Unset means the whole box, which is all this script used to assume.
+OWNED_GPUS=""
+if [ -n "${HIP_VISIBLE_DEVICES:-}" ]; then
+    OWNED_GPUS="$(python - <<'PY' || true
+import re, subprocess, torch
+
+mine = {
+    f"{torch.cuda.get_device_properties(i).pci_bus_id:02X}"
+    for i in range(torch.cuda.device_count())
+}
+smi = subprocess.run(["rocm-smi", "--showbus"], capture_output=True, text=True).stdout
+print(" ".join(
+    idx for idx, bus in re.findall(r"GPU\[(\d+)\].*?PCI Bus: \w+:(\w\w):", smi)
+    if bus.upper() in mine
+))
+PY
+)"
+    [ -n "$OWNED_GPUS" ] || {
+        echo "ERROR: cannot map HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES to rocm-smi indices"
+        exit 1
+    }
+    echo "Owned GPUs: rocm-smi [$OWNED_GPUS] <- HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES"
+fi
+
+# How many OWNED cards hold memory. Empty OWNED_GPUS counts every card.
+owned_in_use() {
+    rocm-smi --showmemuse 2>/dev/null | awk -v owned="$OWNED_GPUS" '
+        /VRAM%/ {
+            idx = $0; sub(/^GPU\[/, "", idx); sub(/\].*/, "", idx)
+            if (owned != "" && index(" " owned " ", " " idx " ") == 0) next
+            if ($NF + 0 > 0) n++
+        }
+        END { print n + 0 }'
+}
+
 # === Pre-flight: ensure GPU is clean ===
 echo "Pre-flight: cleaning up processes and GPU memory..."
 
@@ -37,16 +75,21 @@ sleep 3
 # 3. Verify GPU memory is actually free
 MAX_WAIT=30
 for i in $(seq 1 $MAX_WAIT); do
-    USED_GPUS=$(rocm-smi --showmemuse 2>/dev/null | grep "VRAM%" | awk '{print $NF}' | awk '$1 > 0' | wc -l)
+    USED_GPUS=$(owned_in_use)
     if [ "$USED_GPUS" -eq 0 ]; then
         echo "GPU memory clear after ${i}s"
         break
     fi
     if [ "$i" -eq "$MAX_WAIT" ]; then
-        echo "WARNING: GPU memory still in use after ${MAX_WAIT}s. Dumping GPU process info:"
+        echo "WARNING: owned GPU memory still in use after ${MAX_WAIT}s:"
         rocm-smi --showpidgpus 2>&1 | grep "PID.*is using" | grep -v "0 DRM" || true
-        echo "Attempting force kill of GPU-holding processes..."
-        rocm-smi --showpidgpus 2>&1 | grep -oP 'PID \K\d+' | while read pid; do
+        # Only what we can BOTH attribute and reach. The pids rocm-smi prints
+        # are the host's and mean something else in this container, so the
+        # blanket `kill -9` this used to do could hit an unrelated local pid --
+        # and on a shared box that memory may not be ours to reclaim at all.
+        # Our own leftovers are the ones we can name.
+        for pid in $(pgrep -f 'atom\.entrypoints|multiprocessing\.spawn' || true); do
+            echo "  force-killing our own leftover pid $pid"
             kill -9 "$pid" 2>/dev/null || true
         done
         sleep 5
@@ -103,7 +146,7 @@ echo "Server started in background (PID: $SERVER_PID)"
 echo "Waiting for server to be ready..."
 for i in $(seq 1 120); do
     if curl -sf "http://localhost:${PORT}/v1/models" > /dev/null 2>&1; then
-        VRAM_COUNT=$(rocm-smi --showmemuse 2>/dev/null | grep "VRAM%" | awk '{print $NF}' | awk '$1 > 0' | wc -l)
+        VRAM_COUNT=$(owned_in_use)
         if [ "$VRAM_COUNT" -gt 0 ]; then
             echo "Server is ready! (PID: $SERVER_PID, GPU VRAM loaded)"
             exit 0

--- a/tests/plugin/test_dflash_lm_head_bridge.py
+++ b/tests/plugin/test_dflash_lm_head_bridge.py
@@ -51,10 +51,10 @@ class _AtomHead:
         self._full_weight = full_weight
         self.calls = 0
 
-    def compute_argmax_token(self, x: torch.Tensor) -> torch.Tensor:
+    def compute_argmax_token(self, x: torch.Tensor, *, out: torch.Tensor):
         # Emulate the all-gathered global reduction ATOM performs across ranks.
         self.calls += 1
-        return torch.argmax(torch.matmul(x, self._full_weight.T), dim=-1).to(torch.long)
+        return out.copy_(torch.argmax(torch.matmul(x, self._full_weight.T), dim=-1))
 
 
 class _PlainHead:
@@ -178,18 +178,18 @@ def test_patch_handles_empty_input(dflash_module):
     assert out.dtype == torch.long
 
 
-def test_patch_rejects_bad_shape_from_head(dflash_module):
-    """A head returning the wrong shape must fail loudly, not silently corrupt
-    the draft block."""
+def test_patch_rejects_a_head_that_ignores_the_output_storage(dflash_module):
+    """A head answering somewhere other than ``out`` must fail loudly, not hand
+    the draft block a buffer nobody wrote."""
     weight, hidden = _inputs(seed=11)
 
     class _BadHead(_AtomHead):
-        def compute_argmax_token(self, x):
-            return torch.zeros(x.shape[0] + 1, dtype=torch.long)
+        def compute_argmax_token(self, x, *, out):
+            return torch.zeros(x.shape[0], dtype=torch.int32)
 
     install_dflash_lm_head_patch()
     worker = dflash_module.DFlashWorkerV2()
-    with pytest.raises(ValueError, match="invalid shape"):
+    with pytest.raises(ValueError, match="did not answer into"):
         worker._greedy_sample_from_vocab_parallel_head(
             hidden_states=hidden, lm_head=_BadHead(weight, tp_rank=0)
         )

--- a/tests/test_lm_head_argmax_out.py
+++ b/tests/test_lm_head_argmax_out.py
@@ -22,7 +22,7 @@ def test_argmax_can_write_directly_to_caller_storage(monkeypatch):
     logits = torch.tensor([[1.0, 4.0, 2.0], [9.0, 3.0, 5.0]])
     head = _tp1_head(logits, monkeypatch)
     hidden = torch.empty(2, 4)
-    out = torch.empty(2, dtype=torch.long)
+    out = torch.empty(2, dtype=torch.int32)
 
     token_ids = head.compute_argmax_token(hidden, out=out)
 
@@ -30,11 +30,34 @@ def test_argmax_can_write_directly_to_caller_storage(monkeypatch):
     assert token_ids.tolist() == [1, 0]
 
 
+def test_argmax_refuses_to_allocate_for_the_caller(monkeypatch):
+    """No ``out``, no answer: the storage belongs to whoever knows its lifetime.
+
+    A returned tensor would let a caller holding a CUDA-graph buffer read a
+    fresh one and leave the buffer -- whose address the capture baked -- stale.
+    """
+    head = _tp1_head(torch.empty(2, 3), monkeypatch)
+    with pytest.raises(TypeError, match="out"):
+        head.compute_argmax_token(torch.empty(2, 4))
+
+
+def test_empty_token_ids_is_the_engines_token_dtype():
+    """int32, like every `Sampler` path and the target's own id buffer.
+
+    This is what a caller without storage hands the head, and what the draft
+    loop stages into a graph buffer -- `DraftGraph._stage_one` asserts the two
+    dtypes agree, so an int64 here is a startup crash, not a silent widening.
+    Sized off the row axis, so a V4 draft's ``[N, hc, dim]`` gives ``[N]`` too.
+    """
+    assert embed_head.empty_token_ids(torch.empty(5, 4)).dtype == torch.int32
+    assert embed_head.empty_token_ids(torch.empty(5, 2, 4)).shape == (5,)
+
+
 @pytest.mark.parametrize(
     "out",
     [
-        torch.empty(3, dtype=torch.long),
-        torch.empty(2, dtype=torch.int32),
+        torch.empty(3, dtype=torch.int32),
+        torch.empty(2, dtype=torch.long),
     ],
 )
 def test_argmax_rejects_invalid_output_storage(monkeypatch, out):


### PR DESCRIPTION
`pa_fwd_asm`'s maskless fp8 kernel returns `0/0` -- every output element NaN --
for a gqa=16 selection whose context needs exactly 16 pages with a partial
tail, i.e. `sparse_ctx` in `[241, 255]`. On MiniMax-M3 tp4 this zeroes
speculative acceptance and turns the model's output into NUL bytes.

## Scope of the kernel bug

Each axis was swept rather than assumed:

| axis | finding |
|---|---|
| page count | swept 1..128; **only 16** fails. 33 and 65 pages with a partial tail are fine |
| tail | `ctx=240` and `ctx=256` (tail exactly full) are clean; 241..255 all fail |
| gqa | **gqa=16 only**; gqa=8 is correct at the same contexts -- this is why tp8 never showed it |
| msk | `msk=0` gives NaN, `msk=1` gives a silent 0.92..0.997 error. Both ASM paths are wrong; only gluon is right |
| qlen | irrelevant; 1 and 2 both fail at gqa=16 |

Inputs are clean (no NaN in k/v/scales/q), gluon on the same inputs is clean,
and a sentinel-filled output rules out unwritten rows -- so the kernel
manufactures it, consistent with a softmax whose denominator is zero.

aiter's own test reproduces it:

```
$ python op_tests/test_pa.py -c 255 -n 16,1 -d bf16
[aiter] golden vs aiter_asm: (quant:KV_8BIT_PER_TOKEN, kvcache:float8_e4m3fn) failed!
[aiter] -->max abs delta:nan, delta details: 100.0% (262144 of 262144) elements
```

It stays green because the default `ctx_len` list is
`[7, 26, 57, 66, 109, 128, 257, 282, 4097]` -- 128 and 257 step over the whole
window -- and no default `num_heads` has gqa 16. A third hazard: at gqa=16/fp8
the test aborts (exit 134) at `high_precision=2` with "cannot get heuristic
kernel", so even correct parameters lose every ctx after the first.

## Why it is catastrophic rather than occasional

`sparse_ctx` is a token's causal length, so a sequence sweeps the window as it
grows, and there are two independent ways in:

* **prefill** -- each query token is its own row, so any prompt of 241 tokens
  or more puts 15 rows inside the window. Those positions' hidden go NaN and
  propagate into later layers' KV.
* **decode** -- a shorter prompt crosses the window while generating.

End to end the cliff is one token wide:

```
prompt_tok  finish   content
       240    stop   '72'
       241  length   '\x00\x00\x00...'     <- NUL = token id 0 = argmax(NaN)
```

Acceptance was `40/2073000` = 1.9e-5, which is chance agreement for a ~200k
vocabulary, and the accepted-token distribution was `{0: 100%}`.

## Fix

With `msk=0` there is no causal mask between queries, so one query of 16 heads
and two queries of 8 heads **of the same request** are the same arithmetic over
the same KV set. `q` is contiguous `[rows, 16, 128]`, so `view(rows*2, 8, 128)`
puts request `b`'s two head-halves at rows `2b`/`2b+1` -- exactly the kernel's
`q[b*qlen + i]` layout. The block table and context lens are **not** duplicated.

aiter's heuristic cannot select such a kernel -- a null `qo_indptr` forces
`mtp=0`, a non-null one forces `msk=1`, so `(Mtp=1, Msk=0)` is unreachable --
but `pa_asm.csv` ships that row, so it is named directly. Hence the new
`kernel_name` passthrough on `run_pa_fwd_asm`.

## Results

Full GSM8K 1319, MiniMax-M3-MXFP4 tp4 + EAGLE3 draft, CI recipe:

| | before | after | baseline / threshold |
|---|---|---|---|
| GSM8K flexible / strict | 0 (NUL) | **0.9439 / 0.9447** | 0.9469 / 0.93 |
| acceptance | 0.00% | **72.44%** | 72.64% (historical tp4) / 0.715 |
| accepted distribution | `{0: 100%}` | `{0: 14.8, 1: 12.6, 2: 13.3, 3: 59.4}` | |
| 241-token cliff | NUL | gone | |

Correctness against gluon: normal shapes (256 / 512 / 1024) are **bit-identical
to before**; 241..255 moves from NaN to cos 0.987..0.997.

Throughput at ctx=2048:

| rows | before | after | gluon |
|---|---|---|---|
| 32 | 15.75 us | 16.51 us | 60.07 us |
| 512 | 41.56 us | 43.00 us | 57.70 us |
| 8192 | 610.62 us | **575.89 us** | 834.45 us |

Within 5% below 512 rows, 3-6% *faster* at 2048+. Routing the affected batches
to gluon instead would have cost 1.34x-3.73x. **tp8 is untouched** -- its query
group is 8, so the split never fires and the code path is byte-for-byte today's.

Alternatives measured and rejected: clamping ctx to 240 costs cos 0.953..0.990
(dropping the most recent tokens is far worse than the count suggests); forcing
the masked kernel costs cos 0.9168 at ctx=241 while being verified faithful at
ctx=256, i.e. that kernel is wrong too.

This is mitigation, not a cure: at 241..255 the split still lands at 0.987
rather than the usual 0.9985, so the 16-page boundary perturbs gqa=8 as well,
just not to NaN. The aiter kernel should still be fixed, and `test_pa.py` needs
ctx values that cross page-count boundaries, `(16,1)` in num_heads, and a skip
rather than an abort when `hp=2` has no kernel.

## Other commits

* **launcher GPU scoping** -- the pre-flight waited for every card on the box
  and force-killed every pid rocm-smi attributed to a GPU. On a shared box that
  blocks on someone else's job and then tries to kill it. Now resolves
  `HIP_VISIBLE_DEVICES` to rocm-smi indices through the PCI bus (they do not
  agree: HIP 0 is GPU[3] here) and only names its own leftovers.
* **launcher process-tree kill** -- the three blanket pkills reached at most
  the server process. The processes that actually hold GPU memory call
  themselves `ATOM::TP0..TP3` and `ATOM::EngineCore`, so `multiprocessing.spawn`
  had not matched a worker in some time and cleanup relied on children noticing
  a dead parent. Ownership is now tested on the server -- the only process
  carrying `HIP_VISIBLE_DEVICES` -- and the rest reached through the process
  tree. Measured on a live tp4 server: all seven processes reached, "GPU memory
  clear after 1s" against 5s of fixed sleeps before.
* **argmax into caller storage, int32** -- `compute_argmax_token` could
  allocate its own result, leaving a CUDA-graph capture pointing at a buffer
  the graph did not know about. `out` is now required, and ids are int32, the
  width the engine already uses everywhere else. Includes an int64 widening in
  the masked-embedding kernel, whose row address wrapped silently once
  `vocab * hidden` reached 2^31.

## Test plan

- [x] unit tests: 9 failed / 6144 passed, failures identical to the pre-existing baseline set
- [x] ruff / black: per-file counts equal to HEAD, no new violations
- [x] full GSM8K 1319 (above)
- [x] A/B with and without the int32 commit, full 1319 each: 0.33 sigma apart, indistinguishable
- [x] offline ctx sweep 1..2048 through the real code path: zero NaN
- [x] prompt-length cliff probe: 190..317 tokens all answer correctly
- [ ] tp8 regression (unaffected by inspection -- the split is gated on gqa=16 -- but not run)
