### PR TITLE
(recipe) Kimi-K3 AgentX: C72 + C80 bands, drop the C14 CUDA-graph pin

### DIFF
--- a/recipes/Agentic-Kimi-K3.md
+++ b/recipes/Agentic-Kimi-K3.md
@@ -25,7 +25,7 @@ Related guides: [`Kimi-K3.md`](Kimi-K3.md) (generic serving / GSM8K),
 |---|---|---|
 | Interactive | 1, 2, 4 | TP8, **DCP=1**, DSpark **7**, synthetic AL **3.84**, GPU prefix cache only (no LMCache). CUDA-graph capture grows with `2 * CONC * 8`. |
 | Mid | 8, 12, 14, 16 | TP8, **DCP=8**, DSpark **3**, synthetic AL **3.00**, LMCache **128 GiB**, `max-num-batched-tokens 8192`. |
-| Throughput | 32, 40, 48, 56, 64, 72 | TP8, **DCP=8**, **no spec**, LMCache on. C32–C48 use 128 GiB; C56–C72 use **192 GiB** and a larger `max-num-seqs` so the in-flight window can track `2 * CONC`. |
+| Throughput | 32, 40, 48, 56, 64, 72, 80 | TP8, **DCP=8**, **no spec**, LMCache on. C32–C48 use 128 GiB; C56–C80 use **192 GiB** and a larger `max-num-seqs` so the in-flight window can track `2 * CONC`. |
 
 The AgentX **client** is the same at every concurrency. Only `--concurrency`
 changes.
@@ -66,12 +66,13 @@ changes.
 | 56 | 8 | 0 | — | **192 GiB** | 0 | **112** | 8192 | 0.90 | 112 |
 | 64 | 8 | 0 | — | **192 GiB** | 0 | **128** | 8192 | 0.90 | 128 |
 | 72 | 8 | 0 | — | **192 GiB** | 0 | **144** | 8192 | 0.90 | 144 |
+| 80 | 8 | 0 | — | **192 GiB** | 0 | **160** | 8192 | 0.90 | 160 |
 
-C8–C48 use 128 GiB LMCache; C56–C72 use **192 GiB**. LMCache CPU size is
+C8–C48 use 128 GiB LMCache; C56–C80 use **192 GiB**. LMCache CPU size is
 `LMCACHE_MAX_LOCAL_CPU_SIZE`; chunk size is 1024 tokens.
 
-`AITER_REUSE_IDENTICAL_COMM_GROUPS=1` on **C56/C64/C72**, and `0` on every other
-band (C1…C48).
+`AITER_REUSE_IDENTICAL_COMM_GROUPS=1` on **C56/C64/C72/C80**, and `0` on every
+other band (C1…C48).
 
 ## 0. Container prerequisites
 
@@ -167,17 +168,17 @@ case "${CONC}" in
       MAX_NUM_SEQS=24
     fi
     ;;
-  32|40|48|56|64|72)
+  32|40|48|56|64|72|80)
     # Throughput: no spec, and max-num-seqs tracks 2*CONC so the in-flight
     # window can keep up with the client.
     MAX_NUM_SEQS=$((2 * CONC))
-    # The three largest bands need a bigger CPU tier to stay off the HBM cliff.
+    # The four largest bands need a bigger CPU tier to stay off the HBM cliff.
     if [[ "${CONC}" -ge 56 ]]; then
       LMCACHE_MAX_LOCAL_CPU_SIZE=192
     fi
     ;;
   *)
-    echo "Unsupported CONC=${CONC}; AgentX Kimi-K3 covers 1,2,4,8,12,14,16,32,40,48,56,64,72." >&2
+    echo "Unsupported CONC=${CONC}; AgentX Kimi-K3 covers 1,2,4,8,12,14,16,32,40,48,56,64,72,80." >&2
     exit 2
     ;;
 esac

--- a/recipes/Agentic-Kimi-K3.md
+++ b/recipes/Agentic-Kimi-K3.md
@@ -58,7 +58,7 @@ changes.
 | 4 | 1 | 7 | 3.84 | off | 0 | 32 | 8192 | 0.90 | 64 |
 | 8 | 8 | 3 | 3.00 | 128 GiB | 1 | 32 | 8192 | 0.90 | 64 |
 | 12 | 8 | 3 | 3.00 | 128 GiB | 1 | 24 | 8192 | 0.90 | 96 |
-| 14 | 8 | 3 | 3.00 | 128 GiB | 1 | 32 | 8192 | 0.90 | 128 |
+| 14 | 8 | 3 | 3.00 | 128 GiB | 1 | 32 | 8192 | 0.90 | 112 |
 | 16 | 8 | 3 | 3.00 | 128 GiB | 1 | 32 | 8192 | 0.90 | 128 |
 | 32 | 8 | 0 | — | 128 GiB | 0 | 64 | 8192 | 0.90 | 64 |
 | 40 | 8 | 0 | — | 128 GiB | 0 | 80 | 8192 | 0.90 | 80 |
@@ -165,12 +165,6 @@ case "${CONC}" in
     # C12 is the one band whose in-flight window is not the default 32.
     if [[ "${CONC}" == "12" ]]; then
       MAX_NUM_SEQS=24
-    fi
-    # C14 runs the C16 server verbatim, including the pinned CUDA-graph width.
-    # Only the client concurrency is 14. Deriving graph_max from 2*CONC here
-    # would give 28 and the server fails during CUDA-graph warmup.
-    if [[ "${CONC}" == "14" ]]; then
-      CUDAGRAPH_MAX_NUM_SEQS=32
     fi
     ;;
   32|40|48|56|64|72)

--- a/recipes/Agentic-Kimi-K3.md
+++ b/recipes/Agentic-Kimi-K3.md
@@ -25,7 +25,7 @@ Related guides: [`Kimi-K3.md`](Kimi-K3.md) (generic serving / GSM8K),
 |---|---|---|
 | Interactive | 1, 2, 4 | TP8, **DCP=1**, DSpark **7**, synthetic AL **3.84**, GPU prefix cache only (no LMCache). CUDA-graph capture grows with `2 * CONC * 8`. |
 | Mid | 8, 12, 14, 16 | TP8, **DCP=8**, DSpark **3**, synthetic AL **3.00**, LMCache **128 GiB**, `max-num-batched-tokens 8192`. |
-| Throughput | 32, 40, 48, 56, 64 | TP8, **DCP=8**, **no spec**, LMCache on. C32–C48 use 128 GiB; C56/C64 use **192 GiB** and a larger `max-num-seqs` so the in-flight window can track `2 * CONC`. |
+| Throughput | 32, 40, 48, 56, 64, 72 | TP8, **DCP=8**, **no spec**, LMCache on. C32–C48 use 128 GiB; C56–C72 use **192 GiB** and a larger `max-num-seqs` so the in-flight window can track `2 * CONC`. |
 
 The AgentX **client** is the same at every concurrency. Only `--concurrency`
 changes.
@@ -65,11 +65,12 @@ changes.
 | 48 | 8 | 0 | — | 128 GiB | 0 | 96 | 8192 | 0.90 | 96 |
 | 56 | 8 | 0 | — | **192 GiB** | 0 | **112** | 8192 | 0.90 | 112 |
 | 64 | 8 | 0 | — | **192 GiB** | 0 | **128** | 8192 | 0.90 | 128 |
+| 72 | 8 | 0 | — | **192 GiB** | 0 | **144** | 8192 | 0.90 | 144 |
 
-C8–C48 use 128 GiB LMCache; C56/C64 use **192 GiB**. LMCache CPU size is
+C8–C48 use 128 GiB LMCache; C56–C72 use **192 GiB**. LMCache CPU size is
 `LMCACHE_MAX_LOCAL_CPU_SIZE`; chunk size is 1024 tokens.
 
-`AITER_REUSE_IDENTICAL_COMM_GROUPS=1` on **C56/C64**, and `0` on every other
+`AITER_REUSE_IDENTICAL_COMM_GROUPS=1` on **C56/C64/C72**, and `0` on every other
 band (C1…C48).
 
 ## 0. Container prerequisites
@@ -172,17 +173,17 @@ case "${CONC}" in
       CUDAGRAPH_MAX_NUM_SEQS=32
     fi
     ;;
-  32|40|48|56|64)
+  32|40|48|56|64|72)
     # Throughput: no spec, and max-num-seqs tracks 2*CONC so the in-flight
     # window can keep up with the client.
     MAX_NUM_SEQS=$((2 * CONC))
-    # The two largest bands need a bigger CPU tier to stay off the HBM cliff.
+    # The three largest bands need a bigger CPU tier to stay off the HBM cliff.
     if [[ "${CONC}" -ge 56 ]]; then
       LMCACHE_MAX_LOCAL_CPU_SIZE=192
     fi
     ;;
   *)
-    echo "Unsupported CONC=${CONC}; AgentX Kimi-K3 covers 1,2,4,8,12,14,16,32,40,48,56,64." >&2
+    echo "Unsupported CONC=${CONC}; AgentX Kimi-K3 covers 1,2,4,8,12,14,16,32,40,48,56,64,72." >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
Three changes to `recipes/Agentic-Kimi-K3.md`, all measured on 8×MI355X with
AgentX 3600 s, ATOM `97c15a73` / aiter `6b3f14b5f` / triton `3.7.0`.

### 1. Add the C72 band

Same shape as C64, `max-num-seqs=144` per the `2 * CONC` rule. C64 was not the
throughput plateau: tokens/chip goes 12221 → 12794, **+4.7%**.

### 2. Drop the C14 `CUDAGRAPH_MAX_NUM_SEQS=32` pin

The pin's stated justification — that `2 * CONC` "would give 28 and the server
fails during CUDA-graph warmup" — is false, and the pin has no effect.

Capture sizes are **sequences, not tokens**. `ModelRunner` truncates the declared
ladder to `max_schedulable_decode_bs() = min(max_num_seqs, max_num_batched_tokens
// full_q_len)` (`atom/model_engine/model_runner.py:142`), which *divides* the
speculative width out while the launcher *multiplies* it in. For C14 that bound
is `min(32, 8192//4) = 32`, independent of `CUDAGRAPH_MAX_NUM_SEQS`. Oversized
sizes are dropped with a warning, not asserted on.

Both settings therefore capture exactly `bs=2..32`:

| | declared | truncation | captured |
|---|---|---|---|
| pinned, CGMS=32 | `[2..128]` | `= 2048) = 32; dropping` ×8 ranks | `2..32` |
| default, CGMS=28 | `[2..112]` | `= 2048) = 32; dropping` ×8 ranks | `2..32` |

Measured (both legs `AITER_REUSE_IDENTICAL_COMM_GROUPS=0`):

| | TTFT p50 | TTFT p90 | ITL p50 | ITL p90 | Inter p90 | tot tok/s |
|---|---|---|---|---|---|---|
| CGMS=32 | 804.3 | 2140.0 | 12.42 | 19.18 | 52.1 | 57148 |
| CGMS=28 | 775.8 | 2028.4 | 12.36 | 19.18 | 52.1 | 57060 |

ITL p90 and Inter p90 are equal to the digit; throughput differs by −0.15%.
Ten-minute buckets have identical n per bucket and ITL deltas of
−5.4/+1.2/+0.2/−0.9/−1.0/+3.6 %, three each way, all inside the ~7% run-to-run
noise floor. Server reached READY in ~330 s unpinned.

C14's `graph_max` in the table becomes `2*14*(1+3) = 112`. With the pin gone,
**every row satisfies the stated rule** `graph_max = 2 * CONC * (1 + spec)` —
C14 was the only exception.

### 3. Add the C80 band, and note that C72 is the knee

| CONC | TTFT p50 | TTFT p90 | ITL p50 | ITL p90 | Inter p90 | tot tok/chip | out tok/chip |
|---|---|---|---|---|---|---|---|
| 64 | 1356.1 | 3802.3 | 77.11 | 100.66 | 9.9 | 12221 | 88.56 |
| 72 | 1489.8 | 3963.2 | 88.60 | 119.50 | 8.4 | 12794 | 89.42 |
| 80 | 1549.8 | 4405.3 | 103.07 | 130.43 | 7.7 | 12839 | 95.75 |

C72 → C80 is **+0.35%** on tokens/chip — inside noise — while ITL p90 rises 9%
and Inter p90 falls 8.4 → 7.7.

`tot` needs care at the top of the ladder: C80's ISL drops to 107777 (vs C72's
116894) because the trace serves more, shorter requests (3443 vs 3165), so
**output** throughput still climbs +7.1% (715 → 766 tok/s) while total flattens.
The two metrics agree at every band C8–C72 and diverge for the first time here.

Saturation is unambiguous across three independent signals:

| | KV samples ≥95% | KV max | `maxRunning` |
|---|---|---|---|
| C64 | 2/528 | 96.5% | 84 |
| C72 | 17/545 | 96.2% | 119 |
| C80 | **48/556** | **99.7%** | **114** |

`maxRunning` stops rising while KV hits 99.7% — the scheduler is bounded by the
KV pool, not the concurrency parameter. Same ordering variable that decides the
`AITER_REUSE_IDENTICAL_COMM_GROUPS` crossover at C56 (#2208).

C80 is in the table for completeness. **C72 is the knee.**

C80 needs no new branch in the launcher: the existing `CONC -ge 56` guards
already select the 192 GiB CPU tier and `AITER_REUSE_IDENTICAL_COMM_GROUPS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)