### PR TITLE
fix(mla): route the kv_b_proj gather by capability, not by import success

### DIFF
--- a/atom/model_ops/attention_mla.py
+++ b/atom/model_ops/attention_mla.py
@@ -473,7 +473,10 @@ if is_rocm_aiter_fp4bmm_enabled():
 # Optional flydsl backend for `_kv_b_proj_gather`, gated by
 # ATOM_USE_FLYDSL_GATHER_KV_B_PROJ.
 try:
-    from aiter.ops.flydsl import gather_kv_b_proj_flydsl
+    from aiter.ops.flydsl import (
+        gather_kv_b_proj_flydsl,
+        gather_kv_b_proj_flydsl_supported,
+    )
 
     _FLYDSL_GATHER_AVAILABLE = True
 except Exception:  # noqa: BLE001 -- optional kernel; absence is the whole answer
@@ -672,6 +675,9 @@ class MLAAttention(nn.Module):
         # kernels with an unpadded 576-wide q_out. The triton path never uses seg.
         self.use_seg_mla = (not self.use_triton_mla) and envs.ATOM_MLA_PAGE_SIZE > 1
         self.use_flydsl_gather_kv_b_proj = bool(envs.ATOM_USE_FLYDSL_GATHER_KV_B_PROJ)
+        # Resolved on the first gather, when the weights and cache exist; see
+        # `_kv_b_proj_gather`. None = not asked yet.
+        self._flydsl_gather_ok: bool | None = None
         if self.use_seg_mla:
             if envs.ATOM_MLA_PAGE_SIZE != _MLA_SEG_PAGE_SIZE:
                 raise RuntimeError(
@@ -1391,20 +1397,32 @@ class MLAAttention(nn.Module):
         weight_scale = getattr(self.kv_b_proj, "weight_scale", None)
         preshuffled = getattr(weight, "is_shuffled", False)
 
+        # `_FLYDSL_GATHER_AVAILABLE` says the import worked, which is a different
+        # question from whether that backend serves THESE tensors: it is gfx950,
+        # page_size 1, fp8 cache and fp8 weight only. A bf16 cache (GLM-5.2), an
+        # unquantized weight (Kimi-K3) or an MXFP4 one make it raise, and that
+        # used to take the engine down rather than reach the Triton op below,
+        # which covers all of them. Every term is fixed by the weights and the
+        # cache, so ask once and keep the answer.
         if self.use_flydsl_gather_kv_b_proj and _FLYDSL_GATHER_AVAILABLE:
-            gather_kv_b_proj_flydsl(
-                kv_buffer,
-                self._k_scale,
-                kv_indptr,
-                kv_indices,
-                cu_seqlens_k,
-                gather_weight,
-                weight_scale,
-                k_out,
-                v_out,
-                weight_preshuffle=preshuffled,
-            )
-            return
+            if self._flydsl_gather_ok is None:
+                self._flydsl_gather_ok = gather_kv_b_proj_flydsl_supported(
+                    kv_buffer, gather_weight, weight_scale, k_out, v_out
+                )
+            if self._flydsl_gather_ok:
+                gather_kv_b_proj_flydsl(
+                    kv_buffer,
+                    self._k_scale,
+                    kv_indptr,
+                    kv_indices,
+                    cu_seqlens_k,
+                    gather_weight,
+                    weight_scale,
+                    k_out,
+                    v_out,
+                    weight_preshuffle=preshuffled,
+                )
+                return
 
         gather_kv_b_proj(
             kv_buffer,

--- a/scripts/start_atom_server.sh
+++ b/scripts/start_atom_server.sh
@@ -13,7 +13,10 @@ MODEL_PATH="${1:-/data/DeepSeek-R1-0528}"
 TP_SIZE="${2:-8}"
 PORT="${3:-8000}"
 shift 3 2>/dev/null || true
-EXTRA_ARGS="$*"
+# An array, not "$*": a value carrying spaces -- an --online_quant_config
+# JSON, a chat-template kwargs blob -- reaches argv only if it is never
+# re-split. Flattening it here fed argparse the first word and nothing else.
+EXTRA_ARGS=("$@")
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-256}"
 GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.9}"
@@ -141,7 +144,7 @@ echo " Port:           $PORT"
 echo " KV Cache dtype: $KV_CACHE_DTYPE"
 echo " Max num seqs:   $MAX_NUM_SEQS"
 echo " GPU mem util:   $GPU_MEM_UTIL"
-echo " Extra args:     ${EXTRA_ARGS:-none}"
+echo " Extra args:     ${EXTRA_ARGS[*]:-none}"
 echo " Date:           $(date)"
 echo "----------------------------------------"
 echo " Inherited env vars (ATOM_*, V4_*, AITER_*, HSA_*, AMD_*, HIP_*):"
@@ -157,7 +160,7 @@ python -m atom.entrypoints.openai_server \
     --max-num-seqs "$MAX_NUM_SEQS" \
     --gpu-memory-utilization "$GPU_MEM_UTIL" \
     --server-port "$PORT" \
-    $EXTRA_ARGS \
+    "${EXTRA_ARGS[@]}" \
     >> "$LOG_FILE" 2>&1 &
 
 SERVER_PID=$!

--- a/tests/test_mla_flydsl_gather_dispatch.py
+++ b/tests/test_mla_flydsl_gather_dispatch.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+"""Which backend `_kv_b_proj_gather` picks, and when it asks.
+
+Dispatch policy only -- no device. The FlyDSL gather serves one corner (gfx950,
+page_size 1, fp8 cache and fp8 weight); a bf16 cache, an unquantized weight or
+an MXFP4 one belong to the Triton op, which takes the same arguments. Getting
+that wrong is not a slow path, it is a `ValueError` out of aiter mid-forward
+that kills the engine, which is how three CI accuracy jobs died.
+
+Both aiter functions are stubbed: what is under test is that ATOM consults the
+predicate rather than the import, and consults it once.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("triton", reason="attention_mla defines @triton.jit kernels")
+pytest.importorskip("aiter", reason="attention_mla imports the AITER runtime")
+
+from atom.model_ops import attention_mla as mla
+
+
+def _impl(**over):
+    """The slice of MLAAttention that `_kv_b_proj_gather` touches."""
+    fields = {
+        "kv_b_proj": SimpleNamespace(weight=SimpleNamespace(is_shuffled=True)),
+        "_k_scale": None,
+        "use_flydsl_gather_kv_b_proj": True,
+        "_flydsl_gather_ok": None,
+    }
+    return SimpleNamespace(**{**fields, **over})
+
+
+@pytest.fixture
+def spies(monkeypatch):
+    calls = SimpleNamespace(flydsl=0, triton=0, asked=0)
+
+    def supported(*_a, **_k):
+        calls.asked += 1
+        return calls.answer
+
+    monkeypatch.setattr(mla, "_FLYDSL_GATHER_AVAILABLE", True)
+    monkeypatch.setattr(mla, "gather_kv_b_proj_flydsl_supported", supported)
+    monkeypatch.setattr(
+        mla,
+        "gather_kv_b_proj_flydsl",
+        lambda *a, **k: setattr(calls, "flydsl", calls.flydsl + 1),
+    )
+    monkeypatch.setattr(
+        mla,
+        "gather_kv_b_proj",
+        lambda *a, **k: setattr(calls, "triton", calls.triton + 1),
+    )
+    monkeypatch.setattr(mla, "_maybe_view_mxfp4_weight_for_gather", lambda _proj, w: w)
+    return calls
+
+
+def _gather(impl):
+    mla.MLAAttention._kv_b_proj_gather(impl, None, None, None, None, None, None)
+
+
+@pytest.mark.parametrize("answer, flydsl, triton", [(True, 1, 0), (False, 0, 1)])
+def test_backend_follows_the_predicate_not_the_import(spies, answer, flydsl, triton):
+    """A shape the kernel declines must reach the Triton op, not raise."""
+    spies.answer = answer
+    _gather(_impl())
+    assert (spies.flydsl, spies.triton) == (flydsl, triton)
+
+
+def test_the_predicate_is_asked_once(spies):
+    """Its terms are fixed by the weights and the cache, so caching is sound;
+    asking per gather would put a Python-level shape walk on every layer."""
+    spies.answer = True
+    impl = _impl()
+    for _ in range(5):
+        _gather(impl)
+    assert spies.asked == 1
+    assert spies.flydsl == 5
+
+
+def test_env_off_never_asks(spies):
+    """ATOM_USE_FLYDSL_GATHER_KV_B_PROJ=0 is a decision, not a question."""
+    spies.answer = True
+    impl = _impl(use_flydsl_gather_kv_b_proj=False)
+    _gather(impl)
+    assert (spies.flydsl, spies.triton) == (0, 1)
+    assert spies.asked == 0


### PR DESCRIPTION
Consumes `gather_kv_b_proj_flydsl_supported`, added by ROCm/aiter#5475 (merged
2026-09-13). Without that aiter change nothing here behaves differently -- the
import falls into the existing `except` and the FlyDSL gather stays off.

## The bug

`_kv_b_proj_gather` picked the FlyDSL backend on `_FLYDSL_GATHER_AVAILABLE`,
which only says the import worked. That backend serves one corner -- gfx950,
page_size 1, fp8 cache and fp8 weight -- and refuses everything else by
*raising*, so the refusal killed the model runner instead of reaching the
Triton op three lines below, which takes the same arguments and covers all of
them:

```
ValueError: [FlyDSL gather_kv_b_proj] an unquantized weight (kv_proj_scale=None) is not supported
ValueError: [FlyDSL gather_kv_b_proj] k_buffer must be torch.float8_e4m3fn (OCP e4m3), got torch.bfloat16
```

Three accuracy jobs in one CI run died this way. Note the env gate
(`ATOM_USE_FLYDSL_GATHER_KV_B_PROJ`) **defaults to 1**, so this is the default
path, not an opt-in.

Asking the predicate instead. Its terms are fixed by the weights and the cache,
so the answer is resolved on the first gather and kept; with the env off it is
never asked at all.

## Verification

**Unit (in this PR)** -- `tests/test_mla_flydsl_gather_dispatch.py`, 4 passed:
the backend follows the predicate rather than the import (both answers), the
predicate is asked exactly once, and with the env off it is not asked.

**The predicate itself, both directions** -- on real MLA geometry
(`k_buffer [num_blocks, 1, 576]`), against a locally built aiter that contains
#5475:

| case | predicate | op raises |
|---|---|---|
| fp8 cache + fp8 weight (the served corner) | True | - |
| bf16 cache (GLM-5.2-MXFP4) | False | yes |
| unquantized weight (Kimi-K3 DSpark) | False | yes |
| mxfp4 weight | False | yes |

Both directions matter: a predicate that always answered False would "agree"
with every refusal while silently costing the fast path everywhere, so the
served corner is checked too.

**Full unit suite** -- 9 failed / 6148 passed; the 9 are the pre-existing
baseline set (`test_deepseek_v4_wo_a_dequant` x3, `test_heavy_ci_gate` x6),
unchanged, and the +4 over the previous run are the tests added here. `ruff`
per-file equal to base, `black` clean.

**End to end -- not obtained.** Every model that reaches this code path
(`deepseek_v2`, `kimi_k3`, `glm5_next`) has a tp8 CI recipe and only 4 cards
were available; the one tp4 recipe, GLM-5.2-MXFP4, faults on this machine
before serving a request, on the unmodified CI arguments as well as with this
change applied. The fault lands right after the `fused_moe` tuned-config load
and never mentions `gather_kv_b_proj`, so it is unrelated to this PR, but it
does mean the fallback has not been exercised against a live model here.

## Second commit

`start_atom_server.sh` built `EXTRA_ARGS` with `"$*"` and expanded it unquoted,
so the shell re-split it and any argument containing a space arrived as its
first word:

```
error: argument --online_quant_config: invalid loads value: '{"global_quant_config":'
```

That silently rules out every model whose recipe carries a JSON blob or a
`--default-chat-template-kwargs`. Found while trying to run the GLM recipe
above. An array preserves the boundaries the caller set; verified the JSON
reaches `argv` as one entry.

## Test plan

- [x] `tests/test_mla_flydsl_gather_dispatch.py` -- 4 passed
- [x] predicate agrees with the op in both directions, four shapes
- [x] full unit suite -- failures identical to baseline
- [x] ruff / black
- [x] launcher: JSON argument survives to argv
- [ ] end-to-end against a model that takes the fallback (blocked, see above)