### PR TITLE
feat(atomesh): use HIP IPC/xGMI for single-node P/D transfers

### DIFF
--- a/.github/scripts/atomesh/hip_smoke.py
+++ b/.github/scripts/atomesh/hip_smoke.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Verify same-host Mooncake GPU transfer correctness without TCP payload fallback.
+
+Run in a HIP-enabled ATOM container on an otherwise idle pair of GPUs:
+    python3 .github/scripts/atomesh/hip_smoke.py --source-gpu 0 --target-gpu 4
+
+Control-plane RPC uses loopback. Payload-sized loopback traffic indicates a
+TCP fallback, which older Mooncake builds permit even with protocol="hip".
+"""
+
+import argparse
+import json
+import multiprocessing as mp
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+
+def loopback_received_bytes():
+    for line in Path("/proc/net/dev").read_text().splitlines():
+        if line.strip().startswith("lo:"):
+            return int(line.split(":", 1)[1].split()[0])
+    raise RuntimeError("Loopback traffic counters are required to detect TCP fallback")
+
+
+def worker(role, gpu, pipe):
+    try:
+        os.environ["HIP_VISIBLE_DEVICES"] = str(gpu)
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        import torch
+        from mooncake.engine import TransferEngine
+
+        from atom.kv_transfer.disaggregation.mooncake.mooncake_connector import (
+            _configure_mooncake_transport,
+            _engine_device_filter,
+            _select_ib_device,
+        )
+
+        assert torch.version.hip
+        torch.cuda.set_device(0)
+        size = 64 * 1024 * 1024
+        buffer = torch.full(
+            (size,), 37 if role == "producer" else 0, dtype=torch.uint8, device="cuda"
+        )
+        torch.cuda.synchronize()
+        _configure_mooncake_transport("hip")
+        device_filter = _engine_device_filter(
+            "hip", _select_ib_device("hip", "ionic_0", None)
+        )
+        engine = TransferEngine()
+        assert engine.initialize("127.0.0.1", "P2PHANDSHAKE", "hip", device_filter) == 0
+        assert engine.register_memory(buffer.data_ptr(), size) == 0
+        pipe.send(
+            {
+                "engine": f"127.0.0.1:{engine.get_rpc_port()}",
+                "ptr": buffer.data_ptr(),
+                "gpu": gpu,
+                "filter": device_filter,
+            }
+        )
+        if role == "producer":
+            peer = pipe.recv()
+            for _ in range(3):
+                assert (
+                    engine.batch_transfer_sync_write(
+                        peer["engine"], [buffer.data_ptr()], [peer["ptr"]], [size]
+                    )
+                    == 0
+                )
+            iterations = 100
+            loopback_before = loopback_received_bytes()
+            start = time.perf_counter()
+            for _ in range(iterations):
+                assert (
+                    engine.batch_transfer_sync_write(
+                        peer["engine"], [buffer.data_ptr()], [peer["ptr"]], [size]
+                    )
+                    == 0
+                )
+            elapsed = time.perf_counter() - start
+            pipe.send(
+                {
+                    "bytes": size * iterations,
+                    "seconds": elapsed,
+                    "GB_per_second": size * iterations / elapsed / 1e9,
+                    "loopback_received_bytes": loopback_received_bytes()
+                    - loopback_before,
+                }
+            )
+            pipe.recv()
+            buffer.fill_(83)
+            torch.cuda.synchronize()
+            assert (
+                engine.batch_transfer_sync_write(
+                    peer["engine"], [buffer.data_ptr()], [peer["ptr"]], [size]
+                )
+                == 0
+            )
+            pipe.send("second-pattern-written")
+            pipe.recv()
+        else:
+            for expected in (37, 83):
+                assert pipe.recv() == "verify"
+                torch.cuda.synchronize()
+                assert bool(
+                    torch.all(buffer == expected).item()
+                ), f"GPU {gpu} payload mismatch"
+                pipe.send({"verified_bytes": size, "pattern": expected})
+            pipe.recv()
+        assert engine.unregister_memory(buffer.data_ptr()) == 0
+    except BaseException:
+        pipe.send({"error": traceback.format_exc()})
+        raise
+
+
+def receive(pipe):
+    assert pipe.poll(180), "Worker timed out"
+    value = pipe.recv()
+    assert not (isinstance(value, dict) and "error" in value), value
+    return value
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-gpu", type=int, default=0)
+    parser.add_argument("--target-gpu", type=int, default=1)
+    args = parser.parse_args()
+    if args.source_gpu == args.target_gpu:
+        parser.error("Select two distinct GPUs")
+    ctx = mp.get_context("spawn")
+    processes = []
+    pipes = []
+    try:
+        for role, gpu in [("producer", args.source_gpu), ("consumer", args.target_gpu)]:
+            parent, child = ctx.Pipe()
+            process = ctx.Process(target=worker, args=(role, gpu, child))
+            process.start()
+            child.close()
+            processes.append(process)
+            pipes.append(parent)
+        source, target = pipes
+        source_meta, target_meta = receive(source), receive(target)
+        source.send(target_meta)
+        metrics = receive(source)
+        target.send("verify")
+        first = receive(target)
+        source.send("next-pattern")
+        receive(source)
+        target.send("verify")
+        second = receive(target)
+        source.send("done")
+        target.send("done")
+        for process in processes:
+            process.join(30)
+            assert process.exitcode == 0, process.exitcode
+        assert metrics["loopback_received_bytes"] < metrics["bytes"] // 10, (
+            (
+                "Payload-sized loopback traffic: HIP is falling back to TCP. "
+                "Use a Mooncake build that installs HIP transport."
+            ),
+            metrics,
+        )
+        print(
+            "HIP_TRANSFER_PASS="
+            + json.dumps(
+                {
+                    "source": source_meta,
+                    "target": target_meta,
+                    "benchmark": metrics,
+                    "verification": [first, second],
+                }
+            ),
+            flush=True,
+        )
+    finally:
+        for process in processes:
+            if process.is_alive():
+                process.terminate()
+                process.join(10)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/atomesh/pd_hip_config.py
+++ b/.github/scripts/atomesh/pd_hip_config.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Select HIP IPC for same-host Mooncake connectors at server launch time."""
+
+import argparse
+import json
+
+
+def use_hip(config: dict) -> None:
+    """Preserve connector composition while removing RDMA-only settings."""
+    if config.get("kv_connector") == "mooncake":
+        config["protocol"] = "hip"
+        for key in ("ib_device", "ib_enable_alternate_hca", "ib_rail_offset"):
+            config.pop(key, None)
+    for child in config.get("connectors", []):
+        if isinstance(child, dict):
+            use_hip(child)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("config", help="KV transfer JSON after runtime expansion")
+    args = parser.parse_args()
+    config = json.loads(args.config)
+    use_hip(config)
+    print(json.dumps(config, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/atomesh/pd_server_atom.sh
+++ b/.github/scripts/atomesh/pd_server_atom.sh
@@ -247,11 +247,12 @@ dump_launch_info() {
 apply_prefixed_env() {
   local prefix="$1"
   local role_ip="$2"
+  local role_handshake_port="${3:-${HANDSHAKE_PORT}}"
   local name raw value
   while IFS='=' read -r name raw; do
     [[ "${name}" == "${prefix}"* ]] || continue
     value="${raw//\$\{ROLE_IP\}/${role_ip}}"
-    value="${value//\$\{HANDSHAKE_PORT\}/${HANDSHAKE_PORT}}"
+    value="${value//\$\{HANDSHAKE_PORT\}/${role_handshake_port}}"
     export "${name#${prefix}}=${value}"
   done < <(env)
 }
@@ -268,6 +269,7 @@ ROLE_ENV_NAMES=()
 apply_role_env() {
   local prefix="$1"
   local role_ip="$2"
+  local role_handshake_port="${3:-${HANDSHAKE_PORT}}"
   local name
   for name in ${ROLE_ENV_NAMES[@]+"${ROLE_ENV_NAMES[@]}"}; do
     unset "${name}"
@@ -279,8 +281,8 @@ apply_role_env() {
   done < <(env)
   # A name the common block also sets was just unset with the previous role's,
   # so put the common value back before the role overrides it.
-  apply_prefixed_env "ATOMESH_ENV_" "${role_ip}"
-  apply_prefixed_env "${prefix}" "${role_ip}"
+  apply_prefixed_env "ATOMESH_ENV_" "${role_ip}" "${role_handshake_port}"
+  apply_prefixed_env "${prefix}" "${role_ip}" "${role_handshake_port}"
 }
 
 host_ip="$(echo "${IPADDRS}" | tr ',' '\n' | sed -n "$((NODE_RANK + 1))p")"
@@ -664,7 +666,7 @@ start_prefill() {
   local handshake_port="${3:-${HANDSHAKE_PORT}}"
   local dp_master_port="${4:-${PREFILL_DP_MASTER_PORT}}"
   local dp_base_port="${5:-${PREFILL_DP_BASE_PORT}}"
-  apply_role_env "ATOMESH_PREFILL_ENV_" "${host_ip}"
+  apply_role_env "ATOMESH_PREFILL_ENV_" "${host_ip}" "${handshake_port}"
   reset_lmcache_disk
   local -a prefill_cache_env=()
   build_server_cache_env "prefill" "${server_port}" prefill_cache_env
@@ -680,6 +682,9 @@ start_prefill() {
     prefill_kv_transfer_config="${PREFILL_KV_TRANSFER_CONFIG}"
   else
     prefill_kv_transfer_config="{\"kv_role\":\"kv_producer\",\"kv_connector\":\"mooncake\",\"proxy_ip\":\"${host_ip}\",\"handshake_port\":${handshake_port}}"
+  fi
+  if [[ "${SINGLE_NODE_PD}" == "1" ]]; then
+    prefill_kv_transfer_config="$(python3 "${ATOMESH_SCRIPT_DIR}/pd_hip_config.py" "${prefill_kv_transfer_config}")"
   fi
   echo "[prefill] rank=${NODE_RANK} host=${host_name} ip=${host_ip} gpu=${HIP_VISIBLE_DEVICES} port=${server_port} handshake=${handshake_port} dp_master=${dp_master_port} dp_base=${dp_base_port} cudagraph=${prefill_cudagraph_args[*]:-none}"
   local -a prefill_cmd=(
@@ -702,7 +707,7 @@ start_decode() {
   local handshake_port="${3:-${HANDSHAKE_PORT}}"
   local dp_master_port="${4:-${DECODE_DP_MASTER_PORT}}"
   local dp_base_port="${5:-${DECODE_DP_BASE_PORT}}"
-  apply_role_env "ATOMESH_DECODE_ENV_" "${host_ip}"
+  apply_role_env "ATOMESH_DECODE_ENV_" "${host_ip}" "${handshake_port}"
   local max_conc
   max_conc="$(echo "${BENCH_MAX_CONCURRENCY}" | tr 'x,' '\n' | sort -n | tail -1)"
   local decode_max_num_seqs="${MAX_NUM_SEQS}"
@@ -732,6 +737,9 @@ start_decode() {
     decode_kv_transfer_config="${DECODE_KV_TRANSFER_CONFIG}"
   else
     decode_kv_transfer_config="{\"kv_role\":\"kv_consumer\",\"kv_connector\":\"mooncake\",\"proxy_ip\":\"${host_ip}\",\"handshake_port\":${handshake_port}}"
+  fi
+  if [[ "${SINGLE_NODE_PD}" == "1" ]]; then
+    decode_kv_transfer_config="$(python3 "${ATOMESH_SCRIPT_DIR}/pd_hip_config.py" "${decode_kv_transfer_config}")"
   fi
   echo "[decode] rank=${NODE_RANK} host=${host_name} ip=${host_ip} gpu=${HIP_VISIBLE_DEVICES} port=${server_port} handshake=${handshake_port} dp_master=${dp_master_port} dp_base=${dp_base_port} cudagraph=${decode_cudagraph_args[*]:-none}"
   local -a decode_cmd=(

--- a/.github/scripts/atomesh/pd_slurm_job.sh
+++ b/.github/scripts/atomesh/pd_slurm_job.sh
@@ -275,7 +275,6 @@ EOF
   [[ -e /usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so ]] && docker_args+=(-v /usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so:/usr/lib/x86_64-linux-gnu/libibverbs/libionic-rdmav34.so:ro)
   [[ -e /etc/libibverbs.d/ionic.driver ]] && docker_args+=(-v /etc/libibverbs.d/ionic.driver:/etc/libibverbs.d/ionic.driver:ro)
   [[ -d /it-share ]] && docker_args+=(-v /it-share:/it-share)
-  [[ -d /shared_nfs ]] && docker_args+=(-v /shared_nfs:/shared_nfs)
 
   docker_args+=(
     "${DOCKER_IMAGE}"

--- a/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
+++ b/atom/kv_transfer/disaggregation/mooncake/mooncake_connector.py
@@ -4,8 +4,8 @@
 """
 Worker-side and scheduler-side KV cache connectors for disaggregated P/D.
 
-Uses Mooncake TransferEngine for TCP- or RDMA-based push (WRITE) transfers of
-KV cache data from producer (prefill) to consumer (decode) nodes.
+Uses Mooncake TransferEngine for HIP-, TCP-, or RDMA-based push (WRITE)
+transfers of KV cache data from producer (prefill) to consumer (decode).
 """
 
 from __future__ import annotations
@@ -83,6 +83,9 @@ except ImportError:
 # ---------------------------------------------------------------------------
 
 MOONCAKE_DEFAULT_PROTOCOL = "rdma"
+# An empty filter enables HCA auto-discovery even for protocol="hip" in
+# Mooncake's Python API. Exclude every HCA to avoid RDMA GPU registration.
+MOONCAKE_HIP_ONLY_DEVICE_FILTER = "__atom_hip_only_no_hca__"
 PREFILL_LOOKUP_TIMEOUT = 60
 PREFILL_LOOKUP_POLL_INTERVAL = 0.01
 
@@ -125,7 +128,7 @@ def _auto_select_ib_device(phys_idx: int) -> str:
 def _select_ib_device(
     protocol: str, configured_device: str, phys_idx: int | None
 ) -> str:
-    """Resolve the Mooncake device filter without enabling RDMA for TCP.
+    """Resolve the Mooncake device filter without enabling RDMA for TCP/HIP.
 
     Mooncake's TCP transport requires an empty device list. Passing a usable
     HCA alongside ``protocol=tcp`` allows the transfer engine to activate RDMA
@@ -133,13 +136,20 @@ def _select_ib_device(
     choice. RDMA-family transports retain the existing configured/automatic
     device selection.
     """
-    if protocol.strip().lower() == "tcp":
+    if protocol.strip().lower() in {"tcp", "hip"}:
         return ""
     if configured_device:
         return configured_device
     if phys_idx is None:
         raise ValueError("physical GPU index is required for RDMA device selection")
     return _auto_select_ib_device(phys_idx)
+
+
+def _engine_device_filter(protocol: str, ib_device: str) -> str:
+    """Exclude RDMA HCAs from HIP-only engine initialization."""
+    if protocol.strip().lower() == "hip":
+        return MOONCAKE_HIP_ONLY_DEVICE_FILTER
+    return ib_device
 
 
 def _configure_mooncake_transport(protocol: str) -> None:
@@ -151,6 +161,9 @@ def _configure_mooncake_transport(protocol: str) -> None:
     """
     if protocol.strip().lower() == "tcp":
         os.environ["MC_FORCE_TCP"] = "true"
+    elif protocol.strip().lower() == "hip":
+        os.environ.pop("MC_FORCE_TCP", None)
+        os.environ.pop("MC_DISABLE_HIP", None)
 
 
 # ZMQ side-channel message types
@@ -512,11 +525,12 @@ class MooncakeConnectorScheduler(KVConnectorSchedulerBase):
 
 
 class MooncakeConnector(KVConnectorBase):
-    """Worker-side KV cache connector using Mooncake push-mode RDMA.
+    """Worker-side KV cache connector using Mooncake push-mode transfers.
 
     Mooncake uses a push/WRITE model: the prefill (producer) node writes
     KV cache data directly into the decode (consumer) node's registered
-    GPU memory via ``batch_transfer_sync_write``.
+    GPU memory via ``batch_transfer_sync_write``. HIP mode uses same-host
+    GPU IPC/xGMI; RDMA mode uses a registered NIC memory region.
     """
 
     def __init__(self, config: Config) -> None:
@@ -551,7 +565,11 @@ class MooncakeConnector(KVConnectorBase):
         # Networking config
         self.http_port = kv_transfer_config.get("http_port", 8000)
         self.request_address = f"{self.local_ip}:{self.http_port}"
-        self.protocol = kv_transfer_config.get("protocol", MOONCAKE_DEFAULT_PROTOCOL)
+        self.protocol = (
+            kv_transfer_config.get("protocol", MOONCAKE_DEFAULT_PROTOCOL)
+            .strip()
+            .lower()
+        )
 
         # Side channel port (ZMQ) — deterministic from config for proxy relay
         self.base_handshake_port = kv_transfer_config.get("handshake_port", 6301)
@@ -571,9 +589,8 @@ class MooncakeConnector(KVConnectorBase):
                 "Install the mooncake package to use push-mode transfers."
             )
 
-        # Determine which RDMA device this TP rank should use. TCP is
-        # intentionally initialized with an empty device filter so Mooncake
-        # cannot activate an available HCA as an alternate path.
+        # TCP and HIP do not select a rank-local HCA. HIP additionally needs
+        # a nonempty filter at engine initialization to disable HCA discovery.
         # AMD GPU nodes pair GPU N with NIC N, but the HCA name is cluster
         # dependent: Spur MI350 exposes ionic_N while older setups used rdmaN.
         # Registering GPU memory with a non-local RDMA NIC fails with
@@ -584,7 +601,7 @@ class MooncakeConnector(KVConnectorBase):
             "ib_device", ""
         ) or os.environ.get("ATOM_MOONCAKE_IB_DEVICE", "")
         phys_idx: int | None = None
-        if self.protocol.strip().lower() != "tcp" and not configured_ib_device:
+        if self.protocol not in {"tcp", "hip"} and not configured_ib_device:
             visible_idx = torch.cuda.current_device()
             visible_env = os.environ.get("HIP_VISIBLE_DEVICES") or os.environ.get(
                 "CUDA_VISIBLE_DEVICES"
@@ -595,8 +612,14 @@ class MooncakeConnector(KVConnectorBase):
             else:
                 phys_idx = visible_idx
         ib_device = _select_ib_device(self.protocol, configured_ib_device, phys_idx)
+        engine_device_filter = _engine_device_filter(self.protocol, ib_device)
         if self.protocol.strip().lower() == "tcp":
             logger.info("Mooncake TCP selected; RDMA device selection is disabled")
+        elif self.protocol == "hip":
+            logger.info(
+                "Mooncake HIP-only selected: same-host GPU IPC/xGMI; "
+                "RDMA HCAs are excluded from GPU memory registration"
+            )
         elif not configured_ib_device:
             logger.info(
                 "Auto-selecting RDMA device %s for physical GPU %d "
@@ -627,22 +650,22 @@ class MooncakeConnector(KVConnectorBase):
             self.local_ip,
             "P2PHANDSHAKE",
             self.protocol,
-            ib_device,
+            engine_device_filter,
         )
         if ret != 0:
             raise RuntimeError(
                 f"Mooncake TransferEngine.initialize() failed (ret={ret}) "
                 f"on ip={self.local_ip}, protocol={self.protocol}, "
-                f"ib_device={ib_device}"
+                f"ib_device={engine_device_filter}"
             )
         self.rpc_port = self.transfer_engine.get_rpc_port()
         self.engine_id = f"{self.local_ip}:{self.rpc_port}"
         logger.info(
             "Mooncake TransferEngine initialized: ip=%s, protocol=%s, "
-            "ib_device=%s, rpc_port=%d",
+            "device_filter=%s, rpc_port=%d",
             self.local_ip,
             self.protocol,
-            ib_device,
+            engine_device_filter,
             self.rpc_port,
         )
 
@@ -905,7 +928,7 @@ class MooncakeConnector(KVConnectorBase):
                 offset += chunk
 
         logger.info(
-            "Registering %d RDMA chunks (%d block regions, %d slot regions, "
+            "Registering %d Mooncake chunks (%d block regions, %d slot regions, "
             "max_chunk=%.2f GiB)",
             len(reg_ptrs),
             len(tt.block_regions),
@@ -1751,7 +1774,7 @@ class MooncakeConnector(KVConnectorBase):
             return False
         if debug_block_transfer and block_descriptor_count:
             logger.debug(
-                "[PRODUCER] block RDMA write: req=%s, regions=%d, "
+                "[PRODUCER] block Mooncake write: req=%s, regions=%d, "
                 "source_blocks=%d, descriptors=%d, total_bytes=%d",
                 req_id,
                 num_regions - len(staged_regions),
@@ -1835,7 +1858,7 @@ class MooncakeConnector(KVConnectorBase):
             )
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
-                    "[PRODUCER] staged index RDMA write: req=%s, region=%d, "
+                    "[PRODUCER] staged index Mooncake write: req=%s, region=%d, "
                     "pages=%d, descriptors=%d, total_bytes=%d",
                     req_id,
                     region_idx,
@@ -1926,7 +1949,7 @@ class MooncakeConnector(KVConnectorBase):
                 block_sizes.append(src_region.unit_bytes)
 
         logger.debug(
-            "[PRODUCER] block RDMA: req=%s, %d regions × %d blocks, " "total_bytes=%d",
+            "[PRODUCER] block Mooncake: req=%s, %d regions × %d blocks, total_bytes=%d",
             req_id,
             len(self._block_regions),
             len(src_block_ids),
@@ -1980,7 +2003,7 @@ class MooncakeConnector(KVConnectorBase):
             slot_sizes.append(self._staging_slot_bytes)
 
         logger.debug(
-            "[PRODUCER] slot RDMA: req=%s, %d entries, "
+            "[PRODUCER] slot Mooncake: req=%s, %d entries, "
             "src_slot=%d → dst_slot=%d, total_bytes=%d",
             req_id,
             len(slot_src),

--- a/docs/ATOMesh_HIP_IPC.md
+++ b/docs/ATOMesh_HIP_IPC.md
@@ -1,0 +1,57 @@
+# Single-node ATOMesh transfers over HIP IPC/xGMI
+
+ATOMesh's `single_node` P/D layout selects `protocol: hip` for Mooncake when
+launching prefill and decode. This also updates Mooncake inside a `multi`
+connector while preserving LMCache/offload settings. Other layouts retain
+their configured transport (RDMA by default).
+
+Transport selection happens after runtime environment expansion, so the
+prefill/decode handshake ports include the execution phase's service-port
+offset. `${HANDSHAKE_PORT}` in a role's connector configuration resolves to
+that worker's port, including decode's offset from prefill.
+
+For a manually launched server, add `"protocol":"hip"` to its Mooncake KV
+transfer configuration on **both** sides. The two processes must run on the
+same host. The connector excludes RDMA HCAs using a nonempty device filter;
+an empty filter would let Mooncake auto-select HCAs. HIP mode also clears
+inherited `MC_FORCE_TCP` and `MC_DISABLE_HIP` overrides.
+
+## Runtime requirements
+
+- A Mooncake build with HIP support that installs the HIP transport for
+  intra-node transfers. Initialization must report
+  `HIP transport installed for intra-node GPU P2P` (or equivalent evidence
+  for the installed version).
+- ROCm peer access between the selected GPUs. Check the node's topology to
+  distinguish xGMI from PCIe links.
+- GPU devices exposed to the container, with IPC access between the workers.
+  The ATOMesh container launcher uses host IPC. Each worker may have its own
+  `HIP_VISIBLE_DEVICES` subset.
+
+Setting `protocol: hip` alone is not proof of the data path: older Mooncake
+builds can accept it and silently use TCP. A stale cached `rocm/atom-dev:latest`
+was observed doing this during validation. Rebuild the ATOM image with the
+HIP-capable Mooncake dependency or select a verified image, then run the
+smoke check below before benchmarking.
+
+## GPU smoke check
+
+Run inside the ATOM runtime container on an idle node, with two distinct GPUs:
+
+```bash
+python3 .github/scripts/atomesh/hip_smoke.py --source-gpu 0 --target-gpu 4
+```
+
+The check uses the connector's transport-selection functions and two separate
+processes, each seeing one GPU. It transfers a 64 MiB buffer, verifies every
+byte for two different patterns, and reports bandwidth over 100 writes.
+It fails if loopback traffic is large enough to indicate TCP payload fallback.
+The check uses loopback for control messages; unrelated heavy loopback traffic
+on the node can also make it fail. Success prints `HIP_TRANSFER_PASS` with
+the measured bytes, duration, bandwidth and loopback counter delta.
+
+For a full P/D run, use the existing ATOMesh benchmark with
+`pd_worker_layout: single_node` and verify both workers initialize Mooncake
+with `protocol=hip`, register their KV buffers, and complete benchmark requests.
+Model throughput also depends on compute, topology and concurrency; the smoke
+check's transfer bandwidth is not an inference-throughput speedup claim.

--- a/tests/test_atomesh_hip.py
+++ b/tests/test_atomesh_hip.py
@@ -1,0 +1,137 @@
+"""Exercise the real server launch functions without starting model servers."""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / ".github/scripts/atomesh"
+
+
+@pytest.mark.parametrize("single_node", [False, True])
+@pytest.mark.parametrize("port_offset", [0, 10000])
+@pytest.mark.parametrize("nested", [False, True])
+def test_launch_transport_and_role_ports(single_node, port_offset, nested):
+    source = (SCRIPT_DIR / "pd_server_atom.sh").read_text()
+    functions = "\n".join(
+        re.search(rf"^{name}\(\) \{{.*?^\}}", source, re.MULTILINE | re.DOTALL).group()
+        for name in (
+            "apply_prefixed_env",
+            "apply_role_env",
+            "start_prefill",
+            "start_decode",
+        )
+    )
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("ATOMESH_")
+    }
+    env.update(
+        PATH=f"{Path(sys.executable).parent}:{env['PATH']}",
+        ATOMESH_SCRIPT_DIR=str(SCRIPT_DIR),
+        SINGLE_NODE_PD=str(int(single_node)),
+        HANDSHAKE_PORT=str(6301 + port_offset),
+        PREFILL_PORT=str(8010 + port_offset),
+        DECODE_PORT=str(8020 + port_offset),
+        PREFILL_DP_MASTER_PORT="29500",
+        PREFILL_DP_BASE_PORT="29600",
+        DECODE_DP_MASTER_PORT="29700",
+        DECODE_DP_BASE_PORT="29800",
+        USE_EXPLICIT_DP_PORTS="1",
+        NODE_RANK="0",
+        host_ip="127.0.0.1",
+        host_name="test-node",
+        HIP_VISIBLE_DEVICES="0,1,2,3",
+        MAX_NUM_SEQS="16",
+        BENCH_MAX_CONCURRENCY="16",
+        DECODE_MAX_NUM_SEQS="",
+        DECODE_MAX_NUM_BATCHED_TOKENS="",
+        ISL_LIST="128",
+        OSL="32",
+        PREFILL_SERVER_ARGS="",
+        DECODE_SERVER_ARGS="",
+        RUNTIME_LOG_DIR="/unused",
+        PREFILL_KV_TRANSFER_CONFIG="",
+        DECODE_KV_TRANSFER_CONFIG="",
+    )
+    if nested:
+        prefill = {
+            "kv_connector": "multi",
+            "connectors": [
+                {
+                    "kv_connector": "mooncake",
+                    "kv_role": "kv_producer",
+                    "protocol": "rdma",
+                    "proxy_ip": "${ROLE_IP}",
+                    "handshake_port": "${HANDSHAKE_PORT}",
+                    "ib_device": "ionic_0",
+                    "ib_enable_alternate_hca": True,
+                    "ib_rail_offset": 4,
+                },
+                {"kv_connector": "lmcache_offload", "kv_role": "offload"},
+            ],
+        }
+        decode = dict(prefill["connectors"][0], kv_role="kv_consumer")
+        # Match the unquoted integer template used by models_atomesh.yaml.
+        for role, config in (("PREFILL", prefill), ("DECODE", decode)):
+            env[f"ATOMESH_{role}_ENV_{role}_KV_TRANSFER_CONFIG"] = json.dumps(
+                config
+            ).replace('"${HANDSHAKE_PORT}"', "${HANDSHAKE_PORT}")
+
+    harness = r"""
+set -euo pipefail
+ROLE_ENV_NAMES=()
+server_common=(); prefill_parallel=(); decode_parallel=()
+prefill_cudagraph_args=(); decode_cudagraph_args=()
+reset_lmcache_disk() { :; }
+build_server_cache_env() { :; }
+dump_launch_info() { :; }
+start_logged_process() {
+  shift 3
+  python3 -c 'import sys; print("LAUNCH_JSON=" + sys.argv[sys.argv.index("--kv-transfer-config") + 1])' "$@"
+}
+"""
+    harness += functions + "\nstart_prefill prefill\n"
+    harness += 'start_decode decode "$DECODE_PORT" "$((HANDSHAKE_PORT + 4))"\n'
+    result = subprocess.run(
+        ["bash", "-c", harness], env=env, check=True, text=True, capture_output=True
+    )
+    configs = [
+        json.loads(line.removeprefix("LAUNCH_JSON="))
+        for line in result.stdout.splitlines()
+        if line.startswith("LAUNCH_JSON=")
+    ]
+    assert len(configs) == 2
+    if nested:
+        assert configs[0]["connectors"][1] == {
+            "kv_connector": "lmcache_offload",
+            "kv_role": "offload",
+        }
+        configs[0] = configs[0]["connectors"][0]
+    for index, config in enumerate(configs):
+        assert config.get("protocol", "rdma") == ("hip" if single_node else "rdma")
+        assert config["handshake_port"] == 6301 + port_offset + 4 * index
+        assert config["proxy_ip"] == "127.0.0.1"
+        if single_node:
+            assert (
+                not {"ib_device", "ib_enable_alternate_hca", "ib_rail_offset"}
+                & config.keys()
+            )
+        elif nested:
+            assert config["ib_device"] == "ionic_0"
+
+
+def test_non_mooncake_config_is_preserved():
+    config = {"kv_connector": "moriio", "protocol": "rdma", "handshake_port": 7000}
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_DIR / "pd_hip_config.py"), json.dumps(config)],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert json.loads(result.stdout) == config

--- a/tests/test_pd_pp.py
+++ b/tests/test_pd_pp.py
@@ -300,6 +300,64 @@ def test_mooncake_tcp_forces_transfer_engine_transport(monkeypatch):
     assert os.environ["MC_FORCE_TCP"] == "true"
 
 
+@pytest.mark.parametrize("device", ["", "ionic_0"])
+def test_mooncake_hip_initializes_without_hca_discovery(monkeypatch, device):
+    from conftest import atom_config_double
+
+    import atom.kv_transfer.disaggregation.mooncake.mooncake_connector as mc
+
+    group = SimpleNamespace(rank_in_group=0, world_size=1)
+    monkeypatch.setattr(mc, "get_tp_group", lambda: group)
+    monkeypatch.setattr(mc, "get_dp_group", lambda: group)
+    monkeypatch.setattr(mc, "get_ip", lambda: "127.0.0.1")
+    monkeypatch.setattr(mc, "_MOONCAKE_AVAILABLE", True)
+    engine = MagicMock()
+    engine.initialize.return_value = 0
+    engine.get_rpc_port.return_value = 12345
+    monkeypatch.setattr(mc, "TransferEngine", lambda: engine, raising=False)
+    monkeypatch.setattr(mc.torch.cuda, "current_device", lambda: 0)
+
+    def unexpected_hca_lookup(*args):
+        pytest.fail("HIP must not discover HCAs or resolve an RDMA-local IP")
+
+    monkeypatch.setattr(mc, "_auto_select_ib_device", unexpected_hca_lookup)
+    monkeypatch.setattr(mc, "_ip_for_ib_device", unexpected_hca_lookup)
+    # UUID visibility must never be parsed as a physical HCA index in HIP mode.
+    monkeypatch.setenv("HIP_VISIBLE_DEVICES", "GPU-uuid-for-local-device")
+    monkeypatch.setenv("ATOM_MOONCAKE_IB_DEVICE", device)
+    monkeypatch.setenv("MC_FORCE_TCP", "true")
+    monkeypatch.setenv("MC_DISABLE_HIP", "1")
+    config = atom_config_double(
+        parallel_config=SimpleNamespace(pipeline_parallel_rank=0),
+        hf_config=SimpleNamespace(num_hidden_layers=1),
+        dcp_config=SimpleNamespace(interleave_size=1),
+        kv_transfer_config={
+            "kv_connector": "mooncake",
+            "kv_role": "kv_consumer",
+            "protocol": " HIP ",
+            "ib_device": device,
+        },
+    )
+    connector = mc.MooncakeConnector(config)
+    try:
+        engine.initialize.assert_called_once_with(
+            "127.0.0.1", "P2PHANDSHAKE", "hip", mc.MOONCAKE_HIP_ONLY_DEVICE_FILTER
+        )
+        assert connector.protocol == "hip"
+        assert "MC_FORCE_TCP" not in os.environ
+        assert "MC_DISABLE_HIP" not in os.environ
+    finally:
+        connector.zmq_context.term()
+
+
+@pytest.mark.parametrize("protocol", ["rdma", "tcp"])
+def test_mooncake_non_hip_engine_filter_is_unchanged(protocol):
+    import atom.kv_transfer.disaggregation.mooncake.mooncake_connector as mc
+
+    ib_device = "ionic_4" if protocol == "rdma" else ""
+    assert mc._engine_device_filter(protocol, ib_device) == ib_device
+
+
 def test_mooncake_rdma_preserves_explicit_device():
     mc = pytest.importorskip(
         "atom.kv_transfer.disaggregation.mooncake.mooncake_connector"


### PR DESCRIPTION
## Summary

Single-node ATOMesh prefill/decode launches now select Mooncake HIP IPC for same-host GPU KV transfers, enabling xGMI where supported by the GPU topology. Multi-node layouts retain their configured transport.

- Apply HIP selection after runtime configuration expansion, including nested Mooncake connectors while preserving LMCache/offload settings, and resolve each worker's handshake port with its role and execution-phase offsets.
- Initialize HIP transport without RDMA HCA discovery or registration, normalize protocol values, and clear inherited `MC_FORCE_TCP` / `MC_DISABLE_HIP` overrides.
- Add launch/configuration and connector regression tests, a two-process GPU transfer smoke check that verifies payload correctness and detects TCP fallback, and runtime documentation.
- Remove the duplicate shared NFS mount from the Slurm container launch.

## Validation

Checked the committed branch at `cf516ba87` in a separate worktree:

- `git diff --check origin/main...origin/junyyang/pr_v2_xgmi` — passed.
- `bash -n .github/scripts/atomesh/pd_server_atom.sh .github/scripts/atomesh/pd_slurm_job.sh` — passed.
- Python compilation of `pd_hip_config.py`, `hip_smoke.py`, and `mooncake_connector.py` — passed.
- `python3 -m pytest -q tests/test_atomesh_hip.py tests/test_pd_pp.py` — could not run because the current Python environment has no `pytest` installed.
- GPU smoke and end-to-end P/D benchmarks were not run during PR preparation. HIP transfers require a HIP-capable Mooncake build and GPU peer access; see `docs/ATOMesh_HIP_IPC.md` for verification instructions.
